### PR TITLE
Fix fstream behaviour on windows 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: http://github.com/cucumber/aruba.git
-  revision: fccb412d18d699b7ecacd0da6b2e5338987cf4eb
+  revision: 5ae1ba967deaa904b275197d7f1236e783d72b65
   specs:
-    aruba (0.5.4)
+    aruba (0.6.2)
       childprocess (>= 0.3.6)
       cucumber (>= 1.1.1)
       rspec-expectations (>= 2.7.0)
@@ -13,23 +13,25 @@ GEM
     builder (3.2.2)
     childprocess (0.5.3)
       ffi (~> 1.0, >= 1.0.11)
-    cucumber (1.3.10)
+    cucumber (1.3.19)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12)
       multi_json (>= 1.7.5, < 2.0)
-      multi_test (>= 0.0.2)
+      multi_test (>= 0.1.2)
     diff-lcs (1.2.5)
-    ffi (1.9.3)
-    ffi (1.9.3-x86-mingw32)
+    ffi (1.9.6)
+    ffi (1.9.6-x86-mingw32)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     gherkin (2.12.2-x86-mingw32)
       multi_json (~> 1.3)
-    multi_json (1.8.4)
-    multi_test (0.0.3)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
+    multi_json (1.11.0)
+    multi_test (0.1.2)
+    rspec-expectations (3.2.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
 
 PLATFORMS
   ruby

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,4 +6,5 @@ build_script:
   - vcbuild.bat MSVC2013
 
 test_script:
+  - vcbuild.bat MSVC2013 test
   - vcbuild.bat MSVC2013 inttest

--- a/features/sourcemap.feature
+++ b/features/sourcemap.feature
@@ -1,18 +1,17 @@
 Feature: Validate SourceMap output
 
   Scenario: Parse a blueprint file into YAML with sourcemap
-
     When I run `drafter -s sourcemap blueprint.apib`
     Then a file named "sourcemap" should exist
-    And the file "sourcemap" should be equal to file "sourcemap.yaml"
+    #And the file "sourcemap" should be equal to file "sourcemap.yaml"
     When I remove the file "sourcemap"
     Then a file named "sourcemap" should not exist
 
   Scenario: Parse a blueprint file into JSON with sourcemap
-
     When I run `drafter -s sourcemap --format json blueprint.apib`
     Then a file named "sourcemap" should exist
-    And the file "sourcemap" should be equal to file "sourcemap.json"
+    #And the file "sourcemap" should be equal to file "sourcemap.json"
+    And the file "sourcemap_" should be equal to file "sourcemap.json"
     When I remove the file "sourcemap"
     Then a file named "sourcemap" should not exist
 

--- a/features/sourcemap.feature
+++ b/features/sourcemap.feature
@@ -3,15 +3,14 @@ Feature: Validate SourceMap output
   Scenario: Parse a blueprint file into YAML with sourcemap
     When I run `drafter -s sourcemap blueprint.apib`
     Then a file named "sourcemap" should exist
-    #And the file "sourcemap" should be equal to file "sourcemap.yaml"
+    And the file "sourcemap" should be equal to file "sourcemap.yaml"
     When I remove the file "sourcemap"
     Then a file named "sourcemap" should not exist
 
   Scenario: Parse a blueprint file into JSON with sourcemap
     When I run `drafter -s sourcemap --format json blueprint.apib`
     Then a file named "sourcemap" should exist
-    #And the file "sourcemap" should be equal to file "sourcemap.json"
-    And the file "sourcemap_" should be equal to file "sourcemap.json"
+    And the file "sourcemap" should be equal to file "sourcemap.json"
     When I remove the file "sourcemap"
     Then a file named "sourcemap" should not exist
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -83,11 +83,13 @@ template <typename T> struct to_fstream;
 template<> 
 struct to_fstream<std::istream>{
   typedef std::ifstream stream_type;
+  static std::ios_base::openmode open_flags() { return std::ios_base::in | std::ios_base::binary; }
 };
 
 template<> 
 struct to_fstream<std::ostream>{
   typedef std::ofstream stream_type;
+  static std::ios_base::openmode open_flags() { return std::ios_base::out | std::ios_base::binary; }
 };
 
 /**
@@ -99,7 +101,7 @@ template<typename T> struct fstream_io_selector{
 
     return_type operator()(const char* name) const 
     { 
-        return return_type(new stream_type(name)); 
+        return return_type(new stream_type(name, to_fstream<T>::open_flags())); 
     }
 };
 


### PR DESCRIPTION
Add fstream open in `binary` mode.
In text mode on windows is char `\n` automatic transformed into `\r\n`
This fix avoid this behaviour
