### PR TITLE
Update AST and Parse Result versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ cat << 'EOF' > blueprint.apib
 EOF
 
 $ drafter blueprint.apib 
-_version: 2.1
+_version: 3.0
 metadata:
 name: "My API"
  ...

--- a/features/fixtures/ast.json
+++ b/features/fixtures/ast.json
@@ -1,5 +1,5 @@
 {
-  "_version": "2.1",
+  "_version": "3.0",
   "metadata": [
     {
       "name": "Format",

--- a/features/fixtures/ast.yaml
+++ b/features/fixtures/ast.yaml
@@ -1,4 +1,4 @@
-_version: "2.1"
+_version: "3.0"
 metadata:
   -
     name: "Format"

--- a/src/Serialize.cc
+++ b/src/Serialize.cc
@@ -11,7 +11,6 @@
 
 using namespace drafter;
 
-const std::string SerializeKey::ASTVersion = "_version";
 const std::string SerializeKey::Metadata = "metadata";
 const std::string SerializeKey::Reference = "reference";
 const std::string SerializeKey::Id = "id";
@@ -58,7 +57,7 @@ const std::string SerializeKey::ValueDefinition = "valueDefinition";
 const std::string SerializeKey::Element = "element";
 const std::string SerializeKey::Role = "role";
 
-const std::string SerializeKey::AnnotationsVersion = "_version";
+const std::string SerializeKey::Version = "_version";
 const std::string SerializeKey::Ast = "ast";
 const std::string SerializeKey::SourceMap= "sourcemap";
 const std::string SerializeKey::Error = "error";

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -14,7 +14,7 @@
 #include "sos.h"
 
 /** Version of API Blueprint serialization */
-#define AST_SERIALIZATION_VERSION "2.1"
+#define AST_SERIALIZATION_VERSION "3.0"
 #define PARSE_RESULT_SERIALIZATION_VERSION "2.1"
 
 namespace drafter {

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -13,9 +13,9 @@
 #include "BlueprintSourcemap.h"
 #include "sos.h"
 
-/** Version of API Blueprint AST serialization */
+/** Version of API Blueprint serialization */
 #define AST_SERIALIZATION_VERSION "2.1"
-#define AST_ANNOTATION_SERIALIZATION_VERSION "2.1"
+#define PARSE_RESULT_SERIALIZATION_VERSION "2.1"
 
 namespace drafter {
 
@@ -23,7 +23,6 @@ namespace drafter {
      *  AST entities serialization keys
      */
     struct SerializeKey {
-        static const std::string ASTVersion;
         static const std::string Metadata;
         static const std::string Reference;
         static const std::string Id;
@@ -71,7 +70,7 @@ namespace drafter {
         static const std::string Element;
         static const std::string Role;
 
-        static const std::string AnnotationsVersion;
+        static const std::string Version;
         static const std::string Ast;
         static const std::string SourceMap;
         static const std::string Error;

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -748,7 +748,7 @@ sos::Object drafter::WrapBlueprint(const Blueprint& blueprint)
     sos::Object blueprintObject;
 
     // Version
-    blueprintObject.set(SerializeKey::ASTVersion, sos::String(AST_SERIALIZATION_VERSION));
+    blueprintObject.set(SerializeKey::Version, sos::String(AST_SERIALIZATION_VERSION));
 
     // Metadata
     blueprintObject.set(SerializeKey::Metadata, 

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -48,7 +48,7 @@ sos::Object drafter::WrapResult(const snowcrash::ParseResult<snowcrash::Blueprin
 
     const Report& report = blueprint.report;
 
-    object.set(SerializeKey::AnnotationsVersion, sos::String(AST_ANNOTATION_SERIALIZATION_VERSION));
+    object.set(SerializeKey::Version, sos::String(PARSE_RESULT_SERIALIZATION_VERSION));
     
     object.set(SerializeKey::Ast, WrapBlueprint(blueprint.node));
 

--- a/test/fixtures/annotations-with-warning.ast.json
+++ b/test/fixtures/annotations-with-warning.ast.json
@@ -1,5 +1,5 @@
 {
-  "_version": "2.1",
+  "_version": "3.0",
   "metadata": [
     {
       "name": "FORMAT",

--- a/test/fixtures/annotations-with-warning.result-with-sourcemap.json
+++ b/test/fixtures/annotations-with-warning.result-with-sourcemap.json
@@ -1,7 +1,7 @@
 {
   "_version": "2.1",
   "ast": {
-    "_version": "2.1",
+    "_version": "3.0",
     "metadata": [
       {
         "name": "FORMAT",

--- a/test/fixtures/annotations-with-warning.result.json
+++ b/test/fixtures/annotations-with-warning.result.json
@@ -1,7 +1,7 @@
 {
   "_version": "2.1",
   "ast": {
-    "_version": "2.1",
+    "_version": "3.0",
     "metadata": [
       {
         "name": "FORMAT",


### PR DESCRIPTION
Since the serialisation has moved to drafter, I am updating them here. Sorry, I forgot about making this PR earlier.

AST version = 3.0
Parse Result version = 2.1