### PR TITLE
Make version check work in Python <2.7

### DIFF
--- a/configure
+++ b/configure
@@ -8,7 +8,7 @@
 import sys
 
 
-if sys.version_info.major != 2:
+if sys.version_info[0] != 2:
     # Since various Linux distros and OS X doesn't properly follow PEP 394,
     # We've set the shebang line to `python` and erroring when it isn't
     # Python 2.


### PR DESCRIPTION
In Python 2.6 `sys.version_info` is a tuple, so doesn't have a `.major` attribute.
Using the index access method works in both 2.6, 2.7 and 3