### PR TITLE
[configure] Support Python 2.6

### DIFF
--- a/configure
+++ b/configure
@@ -8,7 +8,12 @@
 import sys
 
 
-if sys.version_info.major != 2:
+def get_major_version():
+    if isinstance(sys.version_info, tuple):
+        return sys.version_info[0]
+    return sys.version_info.major
+
+if get_major_version() != 2:
     # Since various Linux distros and OS X doesn't properly follow PEP 394,
     # We've set the shebang line to `python` and erroring when it isn't
     # Python 2.


### PR DESCRIPTION
Ref apiaryio/redsnow#51

Python 2.6 uses a tuple instead of a named tuple  ¯\_(ツ)_/¯.

```
$ python2.7 ./configure
creating ./config.gypi
creating ./config.mk
creating makefiles
All OK.
$ python2.6 ./configure
creating ./config.gypi
creating ./config.mk
creating makefiles
All OK.
$ python3 ./configure
./configure requires Python 2, please install Python 2 and re-run this script.
You may be able to do this with `python2 configure`.
```