### PR TITLE
Add simple Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM apiaryio/base-dev-cpp:1.0.0
+MAINTAINER Apiary "sre@apiary.io"
+
+
+RUN locale-gen en_US.UTF-8
+RUN echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale
+RUN dpkg-reconfigure locales
+
+ADD ./ /drafter
+
+WORKDIR /drafter
+
+# It's tempting to put ./configure into RUN, but then you have timestamp issues
+
+RUN ./configure && make all && make install
+
+CMD /usr/local/bin/drafter


### PR DESCRIPTION
```
arael-2:drafter almad$ docker run -t apiaryio/drafter drafter --help
usage: drafter [options] ... <input file>

API Blueprint Parser
If called without <input file>, 'drafter' will listen on stdin.

options:
  -o, --output          save output AST into file (string [=])
  -f, --format          output AST format (string [=yaml])
  -s, --sourcemap       export sourcemap AST into file (string [=])
  -h, --help            display this help message
  -v, --version         print Drafter version
  -l, --validate        validate input only, do not print AST
  -u, --use-line-num    use line and row number instead of character index when printing annotation
```