### PR TITLE
Refract - fix array expansion

### DIFF
--- a/src/refract/TypeQueryVisitor.h
+++ b/src/refract/TypeQueryVisitor.h
@@ -76,6 +76,27 @@ namespace refract
             return static_cast<E*>(e);
         }
 
+        template<typename E>
+        static const E* as(const IElement* e)
+        {
+            if (!e) {
+                return static_cast<const E*>(e);
+            }
+
+            TypeQueryVisitor tq;
+            tq.visit(*e);
+
+            E type;
+            TypeQueryVisitor eq;
+            type.content(eq);
+
+            if (eq.typeInfo != tq.typeInfo) {
+                return 0;
+            }
+
+            return static_cast<const E*>(e);
+        }
+
     };
 
 }; // namespace refract

--- a/test/fixtures/mson-inheritance.json
+++ b/test/fixtures/mson-inheritance.json
@@ -196,7 +196,10 @@
               ]
             },
             {
-              "element": "object"
+              "element": "object",
+              "meta": {
+                "description": "This object has no own members\n"
+              }
             }
           ]
         }


### PR DESCRIPTION
- "Expand" envolope Element is now same type (in C++ meaning) as referenced object
- Original Element is cloned with meta && attributes

replace PR #57