### PR TITLE
Added link to AUR package for Arch Linux installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ $ brew install --HEAD \
   https://raw.github.com/apiaryio/drafter/master/tools/homebrew/drafter.rb
 ```
 
+[AUR package](https://aur.archlinux.org/packages/drafter-git/) for Arch Linux.
+
 Other systems refer to [build notes](#build).
 
 ## Use


### PR DESCRIPTION
I made a package to install Drafter on Arch Linux, this adds a link to it in the README file.