### PR TITLE
Refract - implement Ref Element expansion

### DIFF
--- a/src/RefractAST.cc
+++ b/src/RefractAST.cc
@@ -631,7 +631,7 @@ namespace drafter
     {
         refract::ObjectElement* ref = new refract::ObjectElement;
         ref->element(key::Ref);
-        ref->renderCompactContent(true);
+        ref->renderType(refract::IElement::rCompact);
 
         refract::MemberElement* href = new refract::MemberElement;
         href->set(key::Href, refract::IElement::Create(mixin.typeSpecification.name.symbol.literal));

--- a/src/refract/Element.h
+++ b/src/refract/Element.h
@@ -76,7 +76,7 @@ namespace refract
     struct IElement
     {
         bool hasContent; ///< was content of element already set? \see empty()
-        bool useCompactContent;  ///< should be content serialized in compact form? \see compactContent()
+
 
         /**
          * define __visitors__ which can visit element
@@ -93,7 +93,7 @@ namespace refract
         >::type Visitors;
 
 
-        IElement() : hasContent(false), useCompactContent(false)
+        IElement() : hasContent(false), renderStrategy(rDefault)
         {
         }
 
@@ -154,6 +154,7 @@ namespace refract
             cNoMetaId   = 0x10,
         } cloneFlags;
 
+
         virtual IElement* clone(const int flag = cAll) const = 0;
 
         virtual bool empty() const
@@ -161,14 +162,31 @@ namespace refract
             return !hasContent;
         }
 
-        virtual bool compactContent() const
+        /**
+         * select seriaization/rendering type of element
+         * by default are elements serialized in expanded form,
+         * with compact form of meta and attributes
+         *
+         * `renderType()` allows to change default behavior of selected element
+         * (behavioration must be implemented in serialization visitors - it is partially done)
+         */
+
+        typedef enum { 
+            rDefault = 0,
+            rFull,
+            rCompact,
+        } renderFlags;
+
+        renderFlags renderStrategy;
+
+        virtual renderFlags renderType() const
         {
-            return useCompactContent;
+            return renderStrategy;
         }
 
-        virtual void renderCompactContent(bool compact)
+        virtual void renderType(const renderFlags render)
         {
-            useCompactContent = compact;
+            renderStrategy = render;
         }
 
         virtual ~IElement()
@@ -226,7 +244,7 @@ namespace refract
             Type* element =  new Type;
 
             element->hasContent = self->hasContent;
-            element->useCompactContent = self->useCompactContent;
+            element->renderStrategy = self->renderStrategy;
 
             if (flags & cElement) {
                 element->element_ = self->element_;

--- a/src/refract/ExpandVisitor.cc
+++ b/src/refract/ExpandVisitor.cc
@@ -10,8 +10,6 @@
 #include "Visitors.h"
 #include "Registry.h"
 
-#include <iostream>
-
 namespace refract
 {
 
@@ -179,7 +177,6 @@ namespace refract
 
             return ref;
         }
-
 
         template <typename T>
         IElement* ExpandReference(const T& e, const Registry& registry)

--- a/src/refract/ExpandVisitor.cc
+++ b/src/refract/ExpandVisitor.cc
@@ -10,6 +10,8 @@
 #include "Visitors.h"
 #include "Registry.h"
 
+#include <iostream>
+
 namespace refract
 {
 
@@ -66,11 +68,19 @@ namespace refract
             return NULL;
         }
 
+        typedef enum {
+            Inherited,
+            Referenced,
+        } NamedTypeExpansion;
+
         template<typename T>
-        T* FindNamedType(const Registry& registry, const std::string& name)
+        T* ExpandNamedType(const Registry& registry, const std::string& name, NamedTypeExpansion expansion)
         {
             std::string en = name;
-            T* e = new T;
+            T* e = NULL;
+            if (expansion == Inherited) {
+                e = new T;
+            }
 
             // FIXME: add check against recursive inheritance
 
@@ -81,7 +91,12 @@ namespace refract
 
                 IElement* clone = parent->clone((IElement::cAll ^ IElement::cElement) | IElement::cNoMetaId);
                 clone->meta["ref"] = IElement::Create(en);
-                e->push_back(clone);
+                if (e) {
+                    e->push_back(clone);
+                }
+                else {
+                    e = static_cast<T*>(clone);
+                }
             }
 
             // FIXME: posible solution while referenced type is not found in regisry
@@ -98,17 +113,8 @@ namespace refract
         T* ExpandMembers(const T& e, const Registry& registry, const bool cloneId = true)
         {
             std::vector<IElement*> members;
-#if _MIXIN_EXPANSION_
-            bool hasRef = false;
-#endif
 
             for (typename T::ValueType::const_iterator it = e.value.begin() ; it != e.value.end() ; ++it) {
-#if _MIXIN_EXPANSION_
-                if ((*it)->element() == "ref") {
-                   hasRef = true; 
-                }
-#endif
-
                 members.push_back(ExpandOrClone(*it, registry));
             }
 
@@ -123,15 +129,6 @@ namespace refract
                 o->set(members);
             }
 
-#if _MIXIN_EXPANSION_
-            if (hasRef) { // create addition object envelope over parent object
-                T* extend = new T;
-                extend->element("extend");
-                extend->push_back(o);
-                o = extend;
-            }
-#endif
-
             return o;
         }
 
@@ -139,19 +136,18 @@ namespace refract
         T* CreateExtend(const IElement& e, const Registry& registry) {
             typedef T ElementType;
 
-            ElementType* extend = FindNamedType<T>(registry, e.element());
+            ElementType* extend = ExpandNamedType<T>(registry, e.element(), Inherited);
             extend->element("extend");
 
             CopyMetaId(*extend, e);
 
             ElementType* origin = ExpandMembers(static_cast<const ElementType&>(e), registry, false);
-
             extend->push_back(origin);
 
             return extend;
         }
 
-        IElement* ExpandNamedType(const ObjectElement& e, const Registry& registry) 
+        IElement* ExpandInheritance(const ObjectElement& e, const Registry& registry) 
         {
             IElement* base = registry.find(e.element());
             TypeQueryVisitor t;
@@ -168,35 +164,53 @@ namespace refract
 
         }
 
-#if _MIXIN_EXPANSION_
-        IElement* ExpandReference(const ObjectElement& e, const Registry& registry)
+        template<typename T>
+        T* CreateReference(const IElement& e, const std::string& href, const Registry& registry) {
+
+            typedef T ElementType;
+            ElementType* ref = ExpandMembers(static_cast<const ElementType&>(e), registry, true);
+            ref->element("ref");
+            ref->renderType(e.renderType());
+
+            ElementType* resolved = ExpandNamedType<T>(registry, href, Referenced);
+
+            resolved->renderType(IElement::rFull);
+            ref->attributes["resolved"] = resolved;
+
+            return ref;
+        }
+
+
+        template <typename T>
+        IElement* ExpandReference(const T& e, const Registry& registry)
         {
-            TypeQueryVisitor tq;
-            StringElement* href = tq.as<StringElement>(FindMemberByKey(e, "href"));
+            StringElement* href = TypeQueryVisitor::as<StringElement>(FindMemberByKey(e, "href"));
 
-            if (href) {
-                IElement* expanded = FindNamedType(registry, href->value);
-
-                if (expanded->empty()) { // if referenced element not found return clone of reference
-                    delete expanded;
-                    expanded = e.clone(); 
-                }
-
-                return expanded;
+            if (!href || href->value.empty()) {
+                return e.clone();
             }
 
-            // FIXME: report error
-            // - Ref Element does not contain "href" key, 
-            // - value of `href` is not `StringElement`
-            
-            // can no be implemeted until error reporting system
-            // for now - ignore silently
-            return NULL;
+            IElement* referenced = registry.find(href->value);
+            if (!referenced) {
+                return e.clone();
+            }
+
+            IElement* base = registry.find(e.element());
+            TypeQueryVisitor t;
+            if (base) {
+                base->content(t);
+            }
+
+            if (t.get() == TypeQueryVisitor::Array) {
+                return CreateReference<ArrayElement>(e, href->value, registry);
+            }
+            else {
+                return CreateReference<ObjectElement>(e, href->value, registry);
+            }
+
         }
-#endif
 
-
-    } // end of anonymous namespac
+    } // end of anonymous namespace
 
     ExpandVisitor::ExpandVisitor(const Registry& registry) : result(NULL), registry(registry) {};
 
@@ -232,13 +246,11 @@ namespace refract
         std::string en = e.element();
 
         if (!isReserved(en)) { // expand named type
-            result = ExpandNamedType(e, registry);
+            result = ExpandInheritance(e, registry);
         }
-#if _MIXIN_EXPANSION_
         else if (en == "ref") { // expand reference
             result = ExpandReference(e, registry);
         } 
-#endif
         else { // walk throught members and expand them
             result = ExpandMembers(e, registry);
         } 
@@ -252,6 +264,7 @@ namespace refract
     void ExpandVisitor::visit(const BooleanElement& e) {}
     
     void ExpandVisitor::visit(const ArrayElement& e) {
+
         if (!Expandable(e)) {  // do we have some expandable members?
             return;
         }

--- a/src/refract/IsExpandableVisitor.cc
+++ b/src/refract/IsExpandableVisitor.cc
@@ -19,11 +19,7 @@ namespace refract
                 if (e) {
                     type = e->element();
                 }
-                return !isReserved(type) 
-#if _MIXIN_EXPANSION_
-                    || type == "ref"
-#endif
-                ;
+                return !isReserved(type) || type == "ref" ;
             }
         };
 
@@ -40,7 +36,6 @@ namespace refract
         template <typename T>
         struct IsExpandable<T, MemberElement::ValueType> : public CheckElement {
             bool operator()(const T* e) const {
-                //std::cout << __PRETTY_FUNCTION__ << e->element() << std::endl;
 
                 if (checkElement(e)) {
                     return true;
@@ -70,7 +65,6 @@ namespace refract
         template <typename T>
         struct IsExpandable<T, std::vector<IElement*> > : public CheckElement {
             bool operator()(const T* e) const {
-                //std::cout << __PRETTY_FUNCTION__ << e->element() << std::endl;
 
                 if (checkElement(e)) {
                     return true;

--- a/src/refract/SerializeCompactVisitor.cc
+++ b/src/refract/SerializeCompactVisitor.cc
@@ -59,7 +59,14 @@ namespace refract
         }
 
         if (e.value.second) {
-            e.value.second->content(*this);
+            if (e.value.second->renderType() != IElement::rFull) {
+                e.value.second->content(*this);
+            }
+            else { // value has request to be serialized in Expanded form
+                SerializeVisitor s;
+                s.visit(*e.value.second);
+                value_ = s.get();
+            }
         }
     }
 

--- a/src/refract/SerializeVisitor.cc
+++ b/src/refract/SerializeVisitor.cc
@@ -8,6 +8,8 @@
 #include "Element.h"
 #include "Visitors.h"
 
+#include <iostream>
+
 namespace refract
 {
 
@@ -54,7 +56,7 @@ namespace refract
         if (e.empty())
             return;
 
-        if (e.compactContent()) {
+        if (e.renderType() == IElement::rCompact) {
             SerializeCompactVisitor s;
             e.content(s);
             result.set("content", s.value());

--- a/src/refract/SerializeVisitor.cc
+++ b/src/refract/SerializeVisitor.cc
@@ -8,8 +8,6 @@
 #include "Element.h"
 #include "Visitors.h"
 
-#include <iostream>
-
 namespace refract
 {
 

--- a/test/fixtures/mson-mixin.apib
+++ b/test/fixtures/mson-mixin.apib
@@ -10,3 +10,4 @@
 ## User (object)
 - id
 - Include Address
+- nick

--- a/test/fixtures/mson-mixin.apib
+++ b/test/fixtures/mson-mixin.apib
@@ -4,6 +4,9 @@
 # Data Structures
 
 ## Address (object)
+mixin w/ description
+
+### Properties
 - city
 - street
 

--- a/test/fixtures/mson-mixin.json
+++ b/test/fixtures/mson-mixin.json
@@ -12,7 +12,8 @@
         {
           "element": "object",
           "meta": {
-            "id": "Address"
+            "id": "Address",
+            "description": "mixin w/ description\n\n"
           },
           "content": [
             {
@@ -61,9 +62,56 @@
             },
             {
               "element": "ref",
+              "attributes": {
+                "resolved": {
+                  "element": "object",
+                  "meta": {
+                    "description": "mixin w/ description\n\n",
+                    "ref": "Address"
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "city"
+                        },
+                        "value": {
+                          "element": "string"
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "street"
+                        },
+                        "value": {
+                          "element": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
               "content": {
                 "href": "Address",
                 "path": "content"
+              }
+            },
+            {
+              "element": "member",
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "nick"
+                },
+                "value": {
+                  "element": "string"
+                }
               }
             }
           ]

--- a/test/fixtures/mson-resource-nested-mixin.json
+++ b/test/fixtures/mson-resource-nested-mixin.json
@@ -70,6 +70,29 @@
                                           "content": [
                                             {
                                               "element": "ref",
+                                              "attributes": {
+                                                "resolved": {
+                                                  "element": "object",
+                                                  "meta": {
+                                                    "ref": "X"
+                                                  },
+                                                  "content": [
+                                                    {
+                                                      "element": "member",
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "id"
+                                                        },
+                                                        "value": {
+                                                          "element": "string",
+                                                          "content": "pavan"
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              },
                                               "content": {
                                                 "href": "X",
                                                 "path": "content"
@@ -162,6 +185,29 @@
                                           "content": [
                                             {
                                               "element": "ref",
+                                              "attributes": {
+                                                "resolved": {
+                                                  "element": "object",
+                                                  "meta": {
+                                                    "ref": "X"
+                                                  },
+                                                  "content": [
+                                                    {
+                                                      "element": "member",
+                                                      "content": {
+                                                        "key": {
+                                                          "element": "string",
+                                                          "content": "id"
+                                                        },
+                                                        "value": {
+                                                          "element": "string",
+                                                          "content": "pavan"
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              },
                                               "content": {
                                                 "href": "X",
                                                 "path": "content"

--- a/test/fixtures/render-object-mixin.json
+++ b/test/fixtures/render-object-mixin.json
@@ -92,7 +92,7 @@
                                         },
                                         "value": {
                                           "element": "number",
-                                          "content": "34567"
+                                          "content": 34567
                                         }
                                       }
                                     }
@@ -205,7 +205,7 @@
                                         },
                                         "value": {
                                           "element": "number",
-                                          "content": "34567"
+                                          "content": 34567
                                         }
                                       }
                                     }


### PR DESCRIPTION
Expansion via `attributes.resolved` as defined in https://github.com/refractproject/refract-spec/blob/master/namespaces/mson-namespace.md#type-reference-ref-element