### PR TITLE
Fix build on Windows

### DIFF
--- a/src/RefractAST.cc
+++ b/src/RefractAST.cc
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Apiary Inc. All rights reserved.
 //
 
+#include <iterator>
+
 #include "RefractAST.h"
 #include "refract/Element.h"
 #include "refract/Visitors.h"

--- a/src/refract/AppendDecorator.h
+++ b/src/refract/AppendDecorator.h
@@ -8,6 +8,8 @@
 #ifndef REFRACT_APPENDDECORATOR_H
 #define REFRACT_APPENDDECORATOR_H
 
+#include <iterator>
+
 namespace refract
 {
 


### PR DESCRIPTION
This change explicitly includes the `iterator` header in the
files using `std::back_iterator`. In some versions of Microsoft
Visual Studio, this header is not automatically included and
it leads to compile errors. See:

http://stackoverflow.com/questions/2959234/vs2008-vs2010-leads-to-cryptic-stl-errors

https://ci.appveyor.com/project/Apiary/protagonist/build/1.0.107