### PR TITLE
Removed Data Structure expansion from APIB Refract

### DIFF
--- a/features/fixtures/ast.json
+++ b/features/fixtures/ast.json
@@ -243,37 +243,7 @@
                           "element": "dataStructure",
                           "content": [
                             {
-                              "element": "extend",
-                              "content": [
-                                {
-                                  "element": "object",
-                                  "meta": {
-                                    "description": "<data structure description>\n\n",
-                                    "ref": "<data structure name>"
-                                  },
-                                  "content": [
-                                    {
-                                      "element": "member",
-                                      "meta": {
-                                        "description": "<data structure property description>"
-                                      },
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "<data structure property name>"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "content": "<data structure property value>"
-                                        }
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "element": "object"
-                                }
-                              ]
+                              "element": "<data structure name>"
                             }
                           ]
                         }
@@ -559,37 +529,7 @@
                           "element": "dataStructure",
                           "content": [
                             {
-                              "element": "extend",
-                              "content": [
-                                {
-                                  "element": "object",
-                                  "meta": {
-                                    "description": "<data structure description>\n\n",
-                                    "ref": "<data structure name>"
-                                  },
-                                  "content": [
-                                    {
-                                      "element": "member",
-                                      "meta": {
-                                        "description": "<data structure property description>"
-                                      },
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "<data structure property name>"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "content": "<data structure property value>"
-                                        }
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "element": "object"
-                                }
-                              ]
+                              "element": "<data structure name>"
                             }
                           ]
                         }

--- a/features/fixtures/ast.yaml
+++ b/features/fixtures/ast.yaml
@@ -183,27 +183,7 @@ resourceGroups:
                         element: "dataStructure"
                         content:
                           -
-                            element: "extend"
-                            content:
-                              -
-                                element: "object"
-                                meta:
-                                  description: "<data structure description>\n\n"
-                                  ref: "<data structure name>"
-                                content:
-                                  -
-                                    element: "member"
-                                    meta:
-                                      description: "<data structure property description>"
-                                    content:
-                                      key:
-                                        element: "string"
-                                        content: "<data structure property name>"
-                                      value:
-                                        element: "string"
-                                        content: "<data structure property value>"
-                              -
-                                element: "object"
+                            element: "<data structure name>"
         content:
           -
             element: "dataStructure"
@@ -405,27 +385,7 @@ content:
                         element: "dataStructure"
                         content:
                           -
-                            element: "extend"
-                            content:
-                              -
-                                element: "object"
-                                meta:
-                                  description: "<data structure description>\n\n"
-                                  ref: "<data structure name>"
-                                content:
-                                  -
-                                    element: "member"
-                                    meta:
-                                      description: "<data structure property description>"
-                                    content:
-                                      key:
-                                        element: "string"
-                                        content: "<data structure property name>"
-                                      value:
-                                        element: "string"
-                                        content: "<data structure property value>"
-                              -
-                                element: "object"
+                            element: "<data structure name>"
         content:
           -
             element: "dataStructure"

--- a/features/fixtures/refract.json
+++ b/features/fixtures/refract.json
@@ -679,37 +679,7 @@
                           "element": "dataStructure",
                           "content": [
                             {
-                              "element": "extend",
-                              "content": [
-                                {
-                                  "element": "object",
-                                  "meta": {
-                                    "description": "<data structure description>\n\n",
-                                    "ref": "<data structure name>"
-                                  },
-                                  "content": [
-                                    {
-                                      "element": "member",
-                                      "meta": {
-                                        "description": "<data structure property description>"
-                                      },
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "<data structure property name>"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "content": "<data structure property value>"
-                                        }
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "element": "object"
-                                }
-                              ]
+                              "element": "<data structure name>"
                             }
                           ]
                         },

--- a/features/fixtures/refract.yaml
+++ b/features/fixtures/refract.yaml
@@ -467,27 +467,7 @@ content:
                         element: "dataStructure"
                         content:
                           -
-                            element: "extend"
-                            content:
-                              -
-                                element: "object"
-                                meta:
-                                  description: "<data structure description>\n\n"
-                                  ref: "<data structure name>"
-                                content:
-                                  -
-                                    element: "member"
-                                    meta:
-                                      description: "<data structure property description>"
-                                    content:
-                                      key:
-                                        element: "string"
-                                        content: "<data structure property name>"
-                                      value:
-                                        element: "string"
-                                        content: "<data structure property value>"
-                              -
-                                element: "object"
+                            element: "<data structure name>"
                       -
                         element: "asset"
                         meta:

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -39,10 +39,14 @@ namespace drafter {
         }
     }
 
-    refract::IElement* DataStructureToRefract(const snowcrash::DataStructure& dataStructure)
+    refract::IElement* DataStructureToRefract(const snowcrash::DataStructure& dataStructure, bool expand)
     {
         refract::IElement* msonElement = MSONToRefract(dataStructure);
-        // refract::IElement* msonExpanded = ExpandRefract(msonElement, GetNamedTypesRegistry());
+
+        if (expand) {
+            refract::IElement* msonExpanded = ExpandRefract(msonElement, GetNamedTypesRegistry());
+            msonElement = msonExpanded;
+        }
 
         if (!msonElement) {
             return NULL;

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -42,15 +42,15 @@ namespace drafter {
     refract::IElement* DataStructureToRefract(const snowcrash::DataStructure& dataStructure)
     {
         refract::IElement* msonElement = MSONToRefract(dataStructure);
-        refract::IElement* msonExpanded = ExpandRefract(msonElement, GetNamedTypesRegistry());
+        // refract::IElement* msonExpanded = ExpandRefract(msonElement, GetNamedTypesRegistry());
 
-        if (!msonExpanded) {
+        if (!msonElement) {
             return NULL;
         }
 
         refract::ObjectElement* element = new refract::ObjectElement;
         element->element(SerializeKey::DataStructure);
-        element->push_back(msonExpanded);
+        element->push_back(msonElement);
 
         return element;
     }

--- a/src/RefractAPI.h
+++ b/src/RefractAPI.h
@@ -13,7 +13,7 @@
 
 namespace drafter {
 
-    refract::IElement* DataStructureToRefract(const snowcrash::DataStructure& dataStructure);
+    refract::IElement* DataStructureToRefract(const snowcrash::DataStructure& dataStructure, bool expand = false);
     refract::IElement* BlueprintToRefract(const snowcrash::Blueprint& blueprint);
 }
 

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -57,6 +57,8 @@ enum {
 static int DrafterErrorCode = NoError;
 static std::string DrafterErrorMessage;
 
+static bool ExpandMSON = false;
+
 #endif
 
 sos::Object WrapValue(const mson::Value& value)
@@ -459,7 +461,7 @@ sos::Object WrapDataStructure(const DataStructure& dataStructure)
     sos::Object dataStructureObject;
 
 #if _WITH_REFRACT_
-    refract::IElement *element = DataStructureToRefract(dataStructure);
+    refract::IElement *element = DataStructureToRefract(dataStructure, ExpandMSON);
     dataStructureObject = SerializeRefract(element);
 
     if (element) {
@@ -862,12 +864,13 @@ sos::Object WrapBlueprintAST(const Blueprint& blueprint)
     return blueprintObject;
 }
 
-sos::Object drafter::WrapBlueprint(const Blueprint& blueprint, const ASTType astType)
+sos::Object drafter::WrapBlueprint(const Blueprint& blueprint, const ASTType astType, bool expand)
 {
     sos::Object blueprintObject;
 
 #if _WITH_REFRACT_
     registerNamedTypes(blueprint.content.elements());
+    ExpandMSON = expand;
 #endif
 
     try {

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -821,18 +821,8 @@ void registerNamedTypes(const snowcrash::Elements& elements)
 
 sos::Object WrapBlueprintRefract(const Blueprint& blueprint)
 {
-    sos::Object blueprintObject;
-
-    refract::IElement *element = NULL;
-
-    try {
-        element = BlueprintToRefract(blueprint);
-        blueprintObject = SerializeRefract(element);
-    }
-    catch (std::exception& e) {
-        DrafterErrorCode = RuntimeError;
-        DrafterErrorMessage = e.what();
-    }
+    refract::IElement* element = BlueprintToRefract(blueprint);
+    sos::Object blueprintObject = SerializeRefract(element);
 
     if (element) {
         delete element;

--- a/src/SerializeAST.h
+++ b/src/SerializeAST.h
@@ -13,7 +13,7 @@
 
 namespace drafter {
 
-    sos::Object WrapBlueprint(const snowcrash::Blueprint& blueprint, const ASTType astType);
+    sos::Object WrapBlueprint(const snowcrash::Blueprint& blueprint, const ASTType astType, bool expand = false);
 }
 
 #endif

--- a/test/draftertest.h
+++ b/test/draftertest.h
@@ -55,7 +55,7 @@ namespace draftertest {
 
     struct FixtureHelper {
 
-        static bool handleBlueprintJSON(const std::string& basepath, drafter::ASTType astType = drafter::NormalASTType, bool mustBeOk = true) {
+        static bool handleBlueprintJSON(const std::string& basepath, drafter::ASTType astType = drafter::NormalASTType, bool expand = false, bool mustBeOk = true) {
             ITFixtureFiles fixture = ITFixtureFiles(basepath);
 
             snowcrash::ParseResult<snowcrash::Blueprint> blueprint;
@@ -68,7 +68,7 @@ namespace draftertest {
             std::stringstream outStream;
             sos::SerializeJSON serializer;
 
-            serializer.process(drafter::WrapBlueprint(blueprint.node, astType), outStream);
+            serializer.process(drafter::WrapBlueprint(blueprint.node, astType, expand), outStream);
             outStream << "\n";
 
             return (outStream.str() == fixture.get(".json"));

--- a/test/fixtures/api/attributes-references.json
+++ b/test/fixtures/api/attributes-references.json
@@ -79,33 +79,7 @@
                                       "content": "user"
                                     },
                                     "value": {
-                                      "element": "extend",
-                                      "content": [
-                                        {
-                                          "element": "object",
-                                          "meta": {
-                                            "ref": "User"
-                                          },
-                                          "content": [
-                                            {
-                                              "element": "member",
-                                              "content": {
-                                                "key": {
-                                                  "element": "string",
-                                                  "content": "name"
-                                                },
-                                                "value": {
-                                                  "element": "string",
-                                                  "content": "John"
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "element": "object"
-                                        }
-                                      ]
+                                      "element": "User"
                                     }
                                   }
                                 }

--- a/test/fixtures/render/array-mixin.json
+++ b/test/fixtures/render/array-mixin.json
@@ -57,20 +57,6 @@
                                 },
                                 {
                                   "element": "ref",
-                                  "attributes": {
-                                    "resolved": {
-                                      "element": "array",
-                                      "meta": {
-                                        "ref": "Address"
-                                      },
-                                      "content": [
-                                        {
-                                          "element": "string",
-                                          "content": "Prague"
-                                        }
-                                      ]
-                                    }
-                                  },
                                   "content": {
                                     "href": "Address",
                                     "path": "content"
@@ -144,20 +130,6 @@
                                 },
                                 {
                                   "element": "ref",
-                                  "attributes": {
-                                    "resolved": {
-                                      "element": "array",
-                                      "meta": {
-                                        "ref": "Address"
-                                      },
-                                      "content": [
-                                        {
-                                          "element": "string",
-                                          "content": "Prague"
-                                        }
-                                      ]
-                                    }
-                                  },
                                   "content": {
                                     "href": "Address",
                                     "path": "content"

--- a/test/fixtures/render/array-ref-array.json
+++ b/test/fixtures/render/array-ref-array.json
@@ -56,24 +56,7 @@
                                   "content": "Karlin"
                                 },
                                 {
-                                  "element": "extend",
-                                  "content": [
-                                    {
-                                      "element": "array",
-                                      "meta": {
-                                        "ref": "Address"
-                                      },
-                                      "content": [
-                                        {
-                                          "element": "string",
-                                          "content": "Prague"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "element": "array"
-                                    }
-                                  ]
+                                  "element": "Address"
                                 }
                               ]
                             }
@@ -142,24 +125,7 @@
                                   "content": "Karlin"
                                 },
                                 {
-                                  "element": "extend",
-                                  "content": [
-                                    {
-                                      "element": "array",
-                                      "meta": {
-                                        "ref": "Address"
-                                      },
-                                      "content": [
-                                        {
-                                          "element": "string",
-                                          "content": "Prague"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "element": "array"
-                                    }
-                                  ]
+                                  "element": "Address"
                                 }
                               ]
                             }

--- a/test/fixtures/render/array-ref-object.json
+++ b/test/fixtures/render/array-ref-object.json
@@ -56,33 +56,7 @@
                                   "content": "Karlin"
                                 },
                                 {
-                                  "element": "extend",
-                                  "content": [
-                                    {
-                                      "element": "object",
-                                      "meta": {
-                                        "ref": "Address"
-                                      },
-                                      "content": [
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "city"
-                                            },
-                                            "value": {
-                                              "element": "string",
-                                              "content": "Prague"
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "element": "object"
-                                    }
-                                  ]
+                                  "element": "Address"
                                 }
                               ]
                             }
@@ -151,33 +125,7 @@
                                   "content": "Karlin"
                                 },
                                 {
-                                  "element": "extend",
-                                  "content": [
-                                    {
-                                      "element": "object",
-                                      "meta": {
-                                        "ref": "Address"
-                                      },
-                                      "content": [
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "city"
-                                            },
-                                            "value": {
-                                              "element": "string",
-                                              "content": "Prague"
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "element": "object"
-                                    }
-                                  ]
+                                  "element": "Address"
                                 }
                               ]
                             }

--- a/test/fixtures/render/inheritance-array-sample.json
+++ b/test/fixtures/render/inheritance-array-sample.json
@@ -49,40 +49,7 @@
                           "element": "dataStructure",
                           "content": [
                             {
-                              "element": "extend",
-                              "content": [
-                                {
-                                  "element": "array",
-                                  "meta": {
-                                    "ref": "RefSample"
-                                  },
-                                  "attributes": {
-                                    "samples": [
-                                      [
-                                        "c",
-                                        "d"
-                                      ]
-                                    ],
-                                    "default": [
-                                      "e",
-                                      "f"
-                                    ]
-                                  },
-                                  "content": [
-                                    {
-                                      "element": "string",
-                                      "content": "a"
-                                    },
-                                    {
-                                      "element": "string",
-                                      "content": "b"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "element": "array"
-                                }
-                              ]
+                              "element": "RefSample"
                             }
                           ]
                         }
@@ -142,40 +109,7 @@
                           "element": "dataStructure",
                           "content": [
                             {
-                              "element": "extend",
-                              "content": [
-                                {
-                                  "element": "array",
-                                  "meta": {
-                                    "ref": "RefSample"
-                                  },
-                                  "attributes": {
-                                    "samples": [
-                                      [
-                                        "c",
-                                        "d"
-                                      ]
-                                    ],
-                                    "default": [
-                                      "e",
-                                      "f"
-                                    ]
-                                  },
-                                  "content": [
-                                    {
-                                      "element": "string",
-                                      "content": "a"
-                                    },
-                                    {
-                                      "element": "string",
-                                      "content": "b"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "element": "array"
-                                }
-                              ]
+                              "element": "RefSample"
                             }
                           ]
                         }

--- a/test/fixtures/render/inheritance-object-sample.json
+++ b/test/fixtures/render/inheritance-object-sample.json
@@ -49,69 +49,7 @@
                           "element": "dataStructure",
                           "content": [
                             {
-                              "element": "extend",
-                              "content": [
-                                {
-                                  "element": "object",
-                                  "meta": {
-                                    "ref": "RefObject"
-                                  },
-                                  "content": [
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "r1"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "attributes": {
-                                            "samples": [
-                                              "v1"
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "r2"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "attributes": {
-                                            "samples": [
-                                              "v2"
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "r3"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "attributes": {
-                                            "default": "v3"
-                                          }
-                                        }
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "element": "object"
-                                }
-                              ]
+                              "element": "RefObject"
                             }
                           ]
                         }
@@ -171,69 +109,7 @@
                           "element": "dataStructure",
                           "content": [
                             {
-                              "element": "extend",
-                              "content": [
-                                {
-                                  "element": "object",
-                                  "meta": {
-                                    "ref": "RefObject"
-                                  },
-                                  "content": [
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "r1"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "attributes": {
-                                            "samples": [
-                                              "v1"
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "r2"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "attributes": {
-                                            "samples": [
-                                              "v2"
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "r3"
-                                        },
-                                        "value": {
-                                          "element": "string",
-                                          "attributes": {
-                                            "default": "v3"
-                                          }
-                                        }
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "element": "object"
-                                }
-                              ]
+                              "element": "RefObject"
                             }
                           ]
                         }

--- a/test/fixtures/render/mixin-array-sample.json
+++ b/test/fixtures/render/mixin-array-sample.json
@@ -57,27 +57,6 @@
                                 },
                                 {
                                   "element": "ref",
-                                  "attributes": {
-                                    "resolved": {
-                                      "element": "array",
-                                      "meta": {
-                                        "description": "description\n\n",
-                                        "ref": "RefSample"
-                                      },
-                                      "attributes": {
-                                        "samples": [
-                                          [
-                                            "a",
-                                            "b"
-                                          ],
-                                          [
-                                            "d",
-                                            "e"
-                                          ]
-                                        ]
-                                      }
-                                    }
-                                  },
                                   "content": {
                                     "href": "RefSample",
                                     "path": "content"
@@ -155,27 +134,6 @@
                                 },
                                 {
                                   "element": "ref",
-                                  "attributes": {
-                                    "resolved": {
-                                      "element": "array",
-                                      "meta": {
-                                        "description": "description\n\n",
-                                        "ref": "RefSample"
-                                      },
-                                      "attributes": {
-                                        "samples": [
-                                          [
-                                            "a",
-                                            "b"
-                                          ],
-                                          [
-                                            "d",
-                                            "e"
-                                          ]
-                                        ]
-                                      }
-                                    }
-                                  },
                                   "content": {
                                     "href": "RefSample",
                                     "path": "content"

--- a/test/fixtures/render/mixin-object-sample.json
+++ b/test/fixtures/render/mixin-object-sample.json
@@ -70,65 +70,6 @@
                                 },
                                 {
                                   "element": "ref",
-                                  "attributes": {
-                                    "resolved": {
-                                      "element": "object",
-                                      "meta": {
-                                        "ref": "RefSample"
-                                      },
-                                      "content": [
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "r1"
-                                            },
-                                            "value": {
-                                              "element": "string",
-                                              "attributes": {
-                                                "samples": [
-                                                  "v1"
-                                                ]
-                                              }
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "r2"
-                                            },
-                                            "value": {
-                                              "element": "string",
-                                              "attributes": {
-                                                "samples": [
-                                                  "v2"
-                                                ]
-                                              }
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "r3"
-                                            },
-                                            "value": {
-                                              "element": "string",
-                                              "attributes": {
-                                                "default": "v3"
-                                              }
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
                                   "content": {
                                     "href": "RefSample",
                                     "path": "content"
@@ -227,65 +168,6 @@
                                 },
                                 {
                                   "element": "ref",
-                                  "attributes": {
-                                    "resolved": {
-                                      "element": "object",
-                                      "meta": {
-                                        "ref": "RefSample"
-                                      },
-                                      "content": [
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "r1"
-                                            },
-                                            "value": {
-                                              "element": "string",
-                                              "attributes": {
-                                                "samples": [
-                                                  "v1"
-                                                ]
-                                              }
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "r2"
-                                            },
-                                            "value": {
-                                              "element": "string",
-                                              "attributes": {
-                                                "samples": [
-                                                  "v2"
-                                                ]
-                                              }
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "r3"
-                                            },
-                                            "value": {
-                                              "element": "string",
-                                              "attributes": {
-                                                "default": "v3"
-                                              }
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
                                   "content": {
                                     "href": "RefSample",
                                     "path": "content"

--- a/test/fixtures/render/object-mixin.json
+++ b/test/fixtures/render/object-mixin.json
@@ -66,42 +66,6 @@
                                 },
                                 {
                                   "element": "ref",
-                                  "attributes": {
-                                    "resolved": {
-                                      "element": "object",
-                                      "meta": {
-                                        "ref": "Address"
-                                      },
-                                      "content": [
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "city"
-                                            },
-                                            "value": {
-                                              "element": "string",
-                                              "content": "Prague"
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "zip"
-                                            },
-                                            "value": {
-                                              "element": "number",
-                                              "content": 34567
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
                                   "content": {
                                     "href": "Address",
                                     "path": "content"
@@ -184,42 +148,6 @@
                                 },
                                 {
                                   "element": "ref",
-                                  "attributes": {
-                                    "resolved": {
-                                      "element": "object",
-                                      "meta": {
-                                        "ref": "Address"
-                                      },
-                                      "content": [
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "city"
-                                            },
-                                            "value": {
-                                              "element": "string",
-                                              "content": "Prague"
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "element": "member",
-                                          "content": {
-                                            "key": {
-                                              "element": "string",
-                                              "content": "zip"
-                                            },
-                                            "value": {
-                                              "element": "number",
-                                              "content": 34567
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
                                   "content": {
                                     "href": "Address",
                                     "path": "content"

--- a/test/fixtures/render/object-ref-object.json
+++ b/test/fixtures/render/object-ref-object.json
@@ -59,46 +59,7 @@
                                       "content": "p"
                                     },
                                     "value": {
-                                      "element": "extend",
-                                      "content": [
-                                        {
-                                          "element": "object",
-                                          "meta": {
-                                            "ref": "Address"
-                                          },
-                                          "content": [
-                                            {
-                                              "element": "member",
-                                              "content": {
-                                                "key": {
-                                                  "element": "string",
-                                                  "content": "city"
-                                                },
-                                                "value": {
-                                                  "element": "string",
-                                                  "content": "Prague"
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "element": "member",
-                                              "content": {
-                                                "key": {
-                                                  "element": "string",
-                                                  "content": "zip"
-                                                },
-                                                "value": {
-                                                  "element": "number",
-                                                  "content": 34567
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "element": "object"
-                                        }
-                                      ]
+                                      "element": "Address"
                                     }
                                   }
                                 }
@@ -172,46 +133,7 @@
                                       "content": "p"
                                     },
                                     "value": {
-                                      "element": "extend",
-                                      "content": [
-                                        {
-                                          "element": "object",
-                                          "meta": {
-                                            "ref": "Address"
-                                          },
-                                          "content": [
-                                            {
-                                              "element": "member",
-                                              "content": {
-                                                "key": {
-                                                  "element": "string",
-                                                  "content": "city"
-                                                },
-                                                "value": {
-                                                  "element": "string",
-                                                  "content": "Prague"
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "element": "member",
-                                              "content": {
-                                                "key": {
-                                                  "element": "string",
-                                                  "content": "zip"
-                                                },
-                                                "value": {
-                                                  "element": "number",
-                                                  "content": 34567
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "element": "object"
-                                        }
-                                      ]
+                                      "element": "Address"
                                     }
                                   }
                                 }

--- a/test/test-RefractDataStructureTest.cc
+++ b/test/test-RefractDataStructureTest.cc
@@ -4,165 +4,165 @@ using namespace draftertest;
 
 TEST_CASE("Testing refract serialization for primitive types", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/primitives"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/primitives", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for named types with inheritance", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/inheritance"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/inheritance", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for array[type]", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/typed-array"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/typed-array", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for typed object", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/typed-object"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/typed-object", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for nontypped object", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/nontyped-object"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/nontyped-object", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for enums", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/enum"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/enum", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for oneof", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/oneof"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/oneof", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for mixin", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/mixin"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/mixin", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for nonexistent mixin", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/mixin-nonexistent", drafter::NormalASTType, false));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/mixin-nonexistent", drafter::NormalASTType, true, false));
 }
 
 TEST_CASE("Testing refract serialization for primitive with samples", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/string-sample"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/string-sample", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for typed array samples", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/typed-array-sample"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/typed-array-sample", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for 'One Of' with grouped elements", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/group"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/group", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization array with empty sample", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/empty-sample"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/empty-sample", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization with inner inheritance", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/inner-inheritance"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/inner-inheritance", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization oneof w/ sample", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/oneof-sample"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/oneof-sample", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization with multiline comments", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/multiline-description"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/multiline-description", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for primitive variables", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/primitive-variables"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/primitive-variables", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for NamedTypes w/ type specification", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/named-with-types"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/named-with-types", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for nontypes array", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/nontyped-array"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/nontyped-array", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for wrong number value", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/number-wrong-value"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/number-wrong-value", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization for enum samples", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/enum-sample"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/enum-sample", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract serialization primitive elements w/ members", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/primitive-with-members", drafter::NormalASTType, false));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/primitive-with-members", drafter::NormalASTType, true, false));
 }
 
 TEST_CASE("Testing refract serialization of nontyped array w/ samples", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/nontyped-array-sample"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/nontyped-array-sample", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract with anonymous resource", "[refract][mson][drafter.js]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-anonymous"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-anonymous", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract resource w/ nested inheritance", "[refract][mson][drafter.js]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-nested-inheritance"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-nested-inheritance", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract resource w/ nested mixin", "[refract][mson][drafter.js]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-nested-mixin"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-nested-mixin", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract resource w/ unresolved reference", "[refract][mson][drafter.js]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-unresolved-reference"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-unresolved-reference", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract resource resolve basetype from other resource", "[refract][mson][drafter.js]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-resolve-basetype"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-resolve-basetype", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract resource - mixin from primitive type", "[refract][mson][drafter.js]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-primitive-mixin"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-primitive-mixin", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract - array typed content", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/array-typed-content"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/array-typed-content", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract resource - nested type in array", "[refract][mson][drafter.js]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-nested-member"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/resource-nested-member", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract named structure - array samples and default", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/array-sample"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/array-sample", drafter::NormalASTType, true));
 }
 
 TEST_CASE("Testing refract named structure - object samples and default", "[refract][mson]")
 {
-    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/object-sample"));
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/object-sample", drafter::NormalASTType, true));
 }


### PR DESCRIPTION
This PR does a few things:

1. Removes Data Structure expansion from APIB Refract
2. Adds an option for `drafter::WrapBlueprint` for data structure expansion so that the MSON refract tests can use it to check the intermediate step of expanding refract for rendering.
3. Change the above mentioned tests to use the above mentioned option.