### PR TITLE
Add iterator header wherever it's missing

### DIFF
--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Apiary Inc. All rights reserved.
 //
 
+#include <iterator>
+
 #include "RefractDataStructure.h"
 #include "RefractAPI.h"
 #include "Render.h"

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 Apiary Inc. All rights reserved.
 //
 
-#include <iterator>
-
 #include "RefractDataStructure.h"
 #include "refract/AppendDecorator.h"
 

--- a/src/refract/Element.h
+++ b/src/refract/Element.h
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <functional>
 #include <stdexcept>
+#include <iterator>
 
 #include "Typelist.h"
 #include "VisitableBy.h"


### PR DESCRIPTION
This PR adds the `iterator` C++ header to the files wherever it was required to fix the compilation errors on windows for protagonist.