### PR TITLE
Don't exact match for content-type in rendering

### DIFF
--- a/src/Render.cc
+++ b/src/Render.cc
@@ -9,14 +9,18 @@
 #include "Render.h"
 #include "RefractDataStructure.h"
 #include "BlueprintUtility.h"
+#include "RegexMatch.h"
 
 using namespace snowcrash;
 
 namespace drafter {
 
+    // JSON content-type regex
+    const char* const JSONRegex = "^[[:blank:]]*application/(.*\\+)?json";
+
     RenderFormat findRenderFormat(const std::string& contentType) {
 
-        if (contentType.find("application/json") != std::string::npos) {
+        if (RegexMatch(contentType, JSONRegex)) {
             return JSONRenderFormat;
         }
 

--- a/src/Render.cc
+++ b/src/Render.cc
@@ -14,9 +14,9 @@ using namespace snowcrash;
 
 namespace drafter {
 
-    RenderFormat findRenderFormat(std::string contentType) {
+    RenderFormat findRenderFormat(const std::string& contentType) {
 
-        if (contentType == "application/json") {
+        if (contentType.find("application/json") != std::string::npos) {
             return JSONRenderFormat;
         }
 

--- a/src/Render.h
+++ b/src/Render.h
@@ -19,7 +19,7 @@ namespace drafter {
         JSONSchemaRenderFormat = 2   // JSON Schema format (not used yet)
     };
 
-    RenderFormat findRenderFormat(std::string contentType);
+    RenderFormat findRenderFormat(const std::string& contentType);
     std::string getContentTypeFromHeaders(const snowcrash::Headers& headers);
 
     snowcrash::Asset renderPayloadBody(const snowcrash::Payload& payload, const refract::Registry& registry);

--- a/test/fixtures/render/content-type.apib
+++ b/test/fixtures/render/content-type.apib
@@ -2,3 +2,13 @@
 + Response 200 (application/json; charset=utf-8)
     + Attributes
         + user: pksunkara
+
+# GET /hal
++ Response 200 (application/hal+json)
+    + Attributes
+        + user: pksunkara
+
+# GET /typo
++ Response 200 (application/haljson)
+    + Attributes
+        + user: pksunkara

--- a/test/fixtures/render/content-type.apib
+++ b/test/fixtures/render/content-type.apib
@@ -1,0 +1,4 @@
+# GET /
++ Response 200 (application/json; charset=utf-8)
+    + Attributes
+        + user: pksunkara

--- a/test/fixtures/render/content-type.json
+++ b/test/fixtures/render/content-type.json
@@ -1,0 +1,158 @@
+{
+  "_version": "3.0",
+  "metadata": [],
+  "name": "",
+  "description": "",
+  "element": "category",
+  "resourceGroups": [
+    {
+      "name": "",
+      "description": "",
+      "resources": [
+        {
+          "element": "resource",
+          "name": "",
+          "description": "",
+          "uriTemplate": "/",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json; charset=utf-8"
+                        }
+                      ],
+                      "body": "{\n  \"user\": \"pksunkara\"\n}",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": [
+                            {
+                              "element": "object",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "user"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "pksunkara"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        }
+      ]
+    }
+  ],
+  "content": [
+    {
+      "element": "category",
+      "content": [
+        {
+          "element": "resource",
+          "name": "",
+          "description": "",
+          "uriTemplate": "/",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json; charset=utf-8"
+                        }
+                      ],
+                      "body": "{\n  \"user\": \"pksunkara\"\n}",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": [
+                            {
+                              "element": "object",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "user"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "pksunkara"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/render/content-type.json
+++ b/test/fixtures/render/content-type.json
@@ -76,6 +76,142 @@
             }
           ],
           "content": []
+        },
+        {
+          "element": "resource",
+          "name": "",
+          "description": "",
+          "uriTemplate": "/hal",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/hal+json"
+                        }
+                      ],
+                      "body": "{\n  \"user\": \"pksunkara\"\n}",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": [
+                            {
+                              "element": "object",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "user"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "pksunkara"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        },
+        {
+          "element": "resource",
+          "name": "",
+          "description": "",
+          "uriTemplate": "/typo",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/haljson"
+                        }
+                      ],
+                      "body": "",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": [
+                            {
+                              "element": "object",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "user"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "pksunkara"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
         }
       ]
     }
@@ -118,6 +254,142 @@
                         }
                       ],
                       "body": "{\n  \"user\": \"pksunkara\"\n}",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": [
+                            {
+                              "element": "object",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "user"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "pksunkara"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        },
+        {
+          "element": "resource",
+          "name": "",
+          "description": "",
+          "uriTemplate": "/hal",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/hal+json"
+                        }
+                      ],
+                      "body": "{\n  \"user\": \"pksunkara\"\n}",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": [
+                            {
+                              "element": "object",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "user"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "pksunkara"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        },
+        {
+          "element": "resource",
+          "name": "",
+          "description": "",
+          "uriTemplate": "/typo",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/haljson"
+                        }
+                      ],
+                      "body": "",
                       "schema": "",
                       "content": [
                         {

--- a/test/test-RenderTest.cc
+++ b/test/test-RenderTest.cc
@@ -15,6 +15,11 @@ TEST_CASE("Testing render of a simple object", "[render]")
     REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/render/simple-object"));
 }
 
+TEST_CASE("Testing render of a simple object where content-type value has extra qualifiers", "[render]")
+{
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/render/content-type"));
+}
+
 TEST_CASE("Testing render of a nested object", "[render]")
 {
     REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/render/nested-object"));


### PR DESCRIPTION
This PR makes sure that when rendering we don't try to match the content-types exactly. This PR also fixes a small case where a value is not passed by reference.