### PR TITLE
Add Drafter-php as binding for the PHP language

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Drafter bindings in other languages:
 
 - [Protagonist](https://github.com/apiaryio/protagonist) (Node.js)
 - [RedSnow](https://github.com/apiaryio/redsnow) (Ruby)
+- [Drafter-php](https://github.com/hendrikmaus/drafter-php) (PHP)
 
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Drafter bindings in other languages:
 
 - [Protagonist](https://github.com/apiaryio/protagonist) (Node.js)
 - [RedSnow](https://github.com/apiaryio/redsnow) (Ruby)
+
+### CLI Wrapper
 - [Drafter-php](https://github.com/hendrikmaus/drafter-php) (PHP)
 
 


### PR DESCRIPTION
I recently created [Drafter-php](https://github.com/hendrikmaus/drafter-php) as wrapper around the Drafter command line tool.

The package can be installed using composer.
Drafter command line tool has to be installed aside to it. The readme contains some basic instructions on how to do that with composer, but first of all references the Drafter repositories installation guides.

If you consider this a binding, this pull request would add it to the readme.

I am looking forward to your feedback.

Cheers,
Hendrik

