### PR TITLE
Updates snowcrash and adds tests

### DIFF
--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -735,12 +735,6 @@ namespace drafter {
             e->meta[SerializeKey::Id] = IElement::Create(ds.name.symbol.literal);
         }
 
-        // FIXME: "title" is temporary commented, until clear refract spec 
-        // in few examples for named object is "title" attribute used
-        // sometime is not used.
-        
-        //e->meta[SerializeKey::Title] = IElement::Create(ds.name.symbol.literal);
-
         TypeSectionData<T> data;
 
         TransformTypeSectionData<T>(ds, e, data);

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -148,7 +148,8 @@ namespace drafter {
 
     static refract::IElement* MsonElementToRefract(const mson::Element& mse, mson::BaseTypeName defaultNestedType = mson::StringTypeName);
 
-    RefractElements MsonElementsToRefract(const mson::Elements& elements, mson::BaseTypeName defaultNestedType = mson::StringTypeName) {
+    RefractElements MsonElementsToRefract(const mson::Elements& elements, mson::BaseTypeName defaultNestedType = mson::StringTypeName)
+    {
         RefractElements result;
 
         // FIXME: should be used instead of "for loop" below, but there is some problem with
@@ -247,34 +248,32 @@ namespace drafter {
             defaultNestedType(SelectNestedTypeSpecification(FetchTypeDefinition<U>()(sectionHolder).typeSpecification.nestedTypes)) 
         {}
 
-
         void operator()(const mson::TypeSection& ts) {
             Fetch<typename T::ValueType> fetch;
             Store<typename T::ValueType> store;
 
             switch (ts.klass) {
 
-            case mson::TypeSection::MemberTypeClass:
-                data.values.push_back(fetch(ts, defaultNestedType));
-                break;
+                case mson::TypeSection::MemberTypeClass:
+                    data.values.push_back(fetch(ts, defaultNestedType));
+                    break;
 
-            case mson::TypeSection::SampleClass:
-                store(data.samples, fetch(ts, defaultNestedType));
-                break;
+                case mson::TypeSection::SampleClass:
+                    store(data.samples, fetch(ts, defaultNestedType));
+                    break;
 
-            case mson::TypeSection::DefaultClass:
-                store(data.defaults, fetch(ts, defaultNestedType));
-                break;
+                case mson::TypeSection::DefaultClass:
+                    store(data.defaults, fetch(ts, defaultNestedType));
+                    break;
 
-            case mson::TypeSection::BlockDescriptionClass:
-                data.descriptions.push_back(ts.content.description);
-                break;
+                case mson::TypeSection::BlockDescriptionClass:
+                    data.descriptions.push_back(ts.content.description);
+                    break;
 
-            default:
-                throw std::logic_error("Unexpected section type for property");
+                default:
+                    throw std::logic_error("Unexpected section type for property");
             }
         }
-
     };
 
 
@@ -557,7 +556,7 @@ namespace drafter {
         }
 
         for (mson::TypeSections::const_iterator it = property.sections.begin(); it != property.sections.end(); ++it) {
-            if (it->klass == mson::TypeSection::BlockDescriptionClass){ 
+            if (it->klass == mson::TypeSection::BlockDescriptionClass) {
                 if (addNewLine) {
                     descriptionRef.append("\n");
                     addNewLine = false;

--- a/test/fixtures/mson/array-reference.apib
+++ b/test/fixtures/mson/array-reference.apib
@@ -1,0 +1,12 @@
+# Tesla
+
+# Data Structures
+## User (object)
++ username: kyle
+
+# GET /sample
++ Response 200 (application/json)
+    + Attributes
+        + data (object, required)
+            + users (array, required)
+                + (User)

--- a/test/fixtures/mson/array-reference.json
+++ b/test/fixtures/mson/array-reference.json
@@ -1,0 +1,297 @@
+{
+  "_version": "3.0",
+  "metadata": [],
+  "name": "Tesla",
+  "description": "",
+  "element": "category",
+  "resourceGroups": [
+    {
+      "name": "",
+      "description": "",
+      "resources": [
+        {
+          "element": "resource",
+          "name": "",
+          "description": "",
+          "uriTemplate": "/sample",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "{\n  \"data\": {\n    \"users\": [\n      {\n        \"username\": \"kyle\"\n      }\n    ]\n  }\n}",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": [
+                            {
+                              "element": "object",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "attributes": {
+                                    "typeAttributes": [
+                                      "required"
+                                    ]
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "data"
+                                    },
+                                    "value": {
+                                      "element": "object",
+                                      "content": [
+                                        {
+                                          "element": "member",
+                                          "attributes": {
+                                            "typeAttributes": [
+                                              "required"
+                                            ]
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "users"
+                                            },
+                                            "value": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "extend",
+                                                  "content": [
+                                                    {
+                                                      "element": "object",
+                                                      "meta": {
+                                                        "ref": "User"
+                                                      },
+                                                      "content": [
+                                                        {
+                                                          "element": "member",
+                                                          "content": {
+                                                            "key": {
+                                                              "element": "string",
+                                                              "content": "username"
+                                                            },
+                                                            "value": {
+                                                              "element": "string",
+                                                              "content": "kyle"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "element": "object"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        }
+      ]
+    }
+  ],
+  "content": [
+    {
+      "element": "category",
+      "content": [
+        {
+          "element": "dataStructure",
+          "content": [
+            {
+              "element": "object",
+              "meta": {
+                "id": "User"
+              },
+              "content": [
+                {
+                  "element": "member",
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "username"
+                    },
+                    "value": {
+                      "element": "string",
+                      "content": "kyle"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "category",
+      "content": [
+        {
+          "element": "resource",
+          "name": "",
+          "description": "",
+          "uriTemplate": "/sample",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "{\n  \"data\": {\n    \"users\": [\n      {\n        \"username\": \"kyle\"\n      }\n    ]\n  }\n}",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": [
+                            {
+                              "element": "object",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "attributes": {
+                                    "typeAttributes": [
+                                      "required"
+                                    ]
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "data"
+                                    },
+                                    "value": {
+                                      "element": "object",
+                                      "content": [
+                                        {
+                                          "element": "member",
+                                          "attributes": {
+                                            "typeAttributes": [
+                                              "required"
+                                            ]
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "users"
+                                            },
+                                            "value": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "extend",
+                                                  "content": [
+                                                    {
+                                                      "element": "object",
+                                                      "meta": {
+                                                        "ref": "User"
+                                                      },
+                                                      "content": [
+                                                        {
+                                                          "element": "member",
+                                                          "content": {
+                                                            "key": {
+                                                              "element": "string",
+                                                              "content": "username"
+                                                            },
+                                                            "value": {
+                                                              "element": "string",
+                                                              "content": "kyle"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "element": "object"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/mson/reference-override.apib
+++ b/test/fixtures/mson/reference-override.apib
@@ -1,0 +1,13 @@
+# Tesla
+
+# Data Structures
+## User (object)
++ username: kyle
+
+# GET /sample
++ Response 200 (application/json)
+    + Attributes
+        + data (object, required)
+            + users (array, required)
+                + (User)
+                    + relation: family

--- a/test/fixtures/mson/reference-override.json
+++ b/test/fixtures/mson/reference-override.json
@@ -1,0 +1,327 @@
+{
+  "_version": "3.0",
+  "metadata": [],
+  "name": "Tesla",
+  "description": "",
+  "element": "category",
+  "resourceGroups": [
+    {
+      "name": "",
+      "description": "",
+      "resources": [
+        {
+          "element": "resource",
+          "name": "",
+          "description": "",
+          "uriTemplate": "/sample",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "{\n  \"data\": {\n    \"users\": [\n      {\n        \"username\": \"kyle\",\n        \"relation\": \"family\"\n      }\n    ]\n  }\n}",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": [
+                            {
+                              "element": "object",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "attributes": {
+                                    "typeAttributes": [
+                                      "required"
+                                    ]
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "data"
+                                    },
+                                    "value": {
+                                      "element": "object",
+                                      "content": [
+                                        {
+                                          "element": "member",
+                                          "attributes": {
+                                            "typeAttributes": [
+                                              "required"
+                                            ]
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "users"
+                                            },
+                                            "value": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "extend",
+                                                  "content": [
+                                                    {
+                                                      "element": "object",
+                                                      "meta": {
+                                                        "ref": "User"
+                                                      },
+                                                      "content": [
+                                                        {
+                                                          "element": "member",
+                                                          "content": {
+                                                            "key": {
+                                                              "element": "string",
+                                                              "content": "username"
+                                                            },
+                                                            "value": {
+                                                              "element": "string",
+                                                              "content": "kyle"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "element": "object",
+                                                      "content": [
+                                                        {
+                                                          "element": "member",
+                                                          "content": {
+                                                            "key": {
+                                                              "element": "string",
+                                                              "content": "relation"
+                                                            },
+                                                            "value": {
+                                                              "element": "string",
+                                                              "content": "family"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        }
+      ]
+    }
+  ],
+  "content": [
+    {
+      "element": "category",
+      "content": [
+        {
+          "element": "dataStructure",
+          "content": [
+            {
+              "element": "object",
+              "meta": {
+                "id": "User"
+              },
+              "content": [
+                {
+                  "element": "member",
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "username"
+                    },
+                    "value": {
+                      "element": "string",
+                      "content": "kyle"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "category",
+      "content": [
+        {
+          "element": "resource",
+          "name": "",
+          "description": "",
+          "uriTemplate": "/sample",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "{\n  \"data\": {\n    \"users\": [\n      {\n        \"username\": \"kyle\",\n        \"relation\": \"family\"\n      }\n    ]\n  }\n}",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": [
+                            {
+                              "element": "object",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "attributes": {
+                                    "typeAttributes": [
+                                      "required"
+                                    ]
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "data"
+                                    },
+                                    "value": {
+                                      "element": "object",
+                                      "content": [
+                                        {
+                                          "element": "member",
+                                          "attributes": {
+                                            "typeAttributes": [
+                                              "required"
+                                            ]
+                                          },
+                                          "content": {
+                                            "key": {
+                                              "element": "string",
+                                              "content": "users"
+                                            },
+                                            "value": {
+                                              "element": "array",
+                                              "content": [
+                                                {
+                                                  "element": "extend",
+                                                  "content": [
+                                                    {
+                                                      "element": "object",
+                                                      "meta": {
+                                                        "ref": "User"
+                                                      },
+                                                      "content": [
+                                                        {
+                                                          "element": "member",
+                                                          "content": {
+                                                            "key": {
+                                                              "element": "string",
+                                                              "content": "username"
+                                                            },
+                                                            "value": {
+                                                              "element": "string",
+                                                              "content": "kyle"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "element": "object",
+                                                      "content": [
+                                                        {
+                                                          "element": "member",
+                                                          "content": {
+                                                            "key": {
+                                                              "element": "string",
+                                                              "content": "relation"
+                                                            },
+                                                            "value": {
+                                                              "element": "string",
+                                                              "content": "family"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        }
+      ]
+    }
+  ]
+}

--- a/test/test-RefractDataStructureTest.cc
+++ b/test/test-RefractDataStructureTest.cc
@@ -171,3 +171,13 @@ TEST_CASE("Testing description on members of enum|array", "[refract][mson]")
 {
     REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/enum-members-description", drafter::NormalASTType, true));
 }
+
+TEST_CASE("Testing refract array containing reference", "[refract][mson]")
+{
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/array-reference", drafter::NormalASTType, true));
+}
+
+TEST_CASE("Testing refract reference getting overridden", "[refract][mson]")
+{
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/reference-override", drafter::NormalASTType, true));
+}


### PR DESCRIPTION
This PR updates the snowcrash submodule to the latest. This PR also adds tests to make sure:

1. Named type references in an array which is nested are getting expanded
2. Overriding named type references should be working

PS: After this PR is merged, #39 can no longer be directly merged and need to use CLI to merge it. Since, we can't rebase the `shared/refract` branch, this is okay.