### PR TITLE
Correctly serialize parameter refract for enum

### DIFF
--- a/features/fixtures/refract.json
+++ b/features/fixtures/refract.json
@@ -75,9 +75,19 @@
                       "element": "enum",
                       "attributes": {
                         "samples": [
-                          "<example value>"
+                          [
+                            {
+                              "element": "string",
+                              "content": "<example value>"
+                            }
+                          ]
                         ],
-                        "default": "<default value>"
+                        "default": [
+                          {
+                            "element": "string",
+                            "content": "<default value>"
+                          }
+                        ]
                       },
                       "content": [
                         {
@@ -158,9 +168,19 @@
                           "element": "enum",
                           "attributes": {
                             "samples": [
-                              "<example value>"
+                              [
+                                {
+                                  "element": "string",
+                                  "content": "<example value>"
+                                }
+                              ]
                             ],
-                            "default": "<default value>"
+                            "default": [
+                              {
+                                "element": "string",
+                                "content": "<default value>"
+                              }
+                            ]
                           },
                           "content": [
                             {

--- a/features/fixtures/refract.yaml
+++ b/features/fixtures/refract.yaml
@@ -55,8 +55,14 @@ content:
                     element: "enum"
                     attributes:
                       samples:
-                        - "<example value>"
-                      default: "<default value>"
+                        -
+                          -
+                            element: "string"
+                            content: "<example value>"
+                      default:
+                        -
+                          element: "string"
+                          content: "<default value>"
                     content:
                       -
                         element: "string"
@@ -111,8 +117,14 @@ content:
                         element: "enum"
                         attributes:
                           samples:
-                            - "<example value>"
-                          default: "<default value>"
+                            -
+                              -
+                                element: "string"
+                                content: "<example value>"
+                          default:
+                            -
+                              element: "string"
+                              content: "<default value>"
                         content:
                           -
                             element: "string"

--- a/test/fixtures/api/resource-parameters.json
+++ b/test/fixtures/api/resource-parameters.json
@@ -45,9 +45,19 @@
                       "element": "enum",
                       "attributes": {
                         "samples": [
-                          23
+                          [
+                            {
+                              "element": "number",
+                              "content": 23
+                            }
+                          ]
                         ],
-                        "default": 1
+                        "default": [
+                          {
+                            "element": "number",
+                            "content": 1
+                          }
+                        ]
                       },
                       "content": [
                         {


### PR DESCRIPTION
This PR makes sure that whenever a parameter has `enum`, then the `samples` and `default` are correctly getting serialized.

@klokane Please review and merge.