### PR TITLE
Updated APIB AST and ParseResult version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ std::cout << "API Name: " << ast.node.name << std::endl;
 
 // Serialization to JSON format
 sos::SerializeJSON serializer;
-serializer.process(drafter::WrapBlueprint(ast.node), std::cout);
+serializer.process(drafter::WrapBlueprint(ast.node, drafter::RefractASTType), std::cout);
 
 ```
 
@@ -60,7 +60,7 @@ For purpose of [bindings](#bindings) to other languages Drafter provides very si
 
 const char* source = "# My API\n## GET /message\n + Response 200 (text/plain)\n\n        Hello World\n";
 char *result = NULL;
-int ret = drafter_c_parse(source, 0, &result);
+int ret = drafter_c_parse(source, 0, DRAFTER_REFRACT_AST_TYPE, &result);
 
 printf("Result: %s\n", ret == 0 ? "OK" : "ERROR");
 printf("Serialized JSON result:\n%s\n", result);
@@ -82,9 +82,11 @@ $ cat << 'EOF' > blueprint.apib
 EOF
 
 $ drafter blueprint.apib 
-_version: 4.0
-metadata:
-name: "My API"
+element: "category"
+meta:
+  classes:
+    - "api"
+  title: "My API"
  ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ cat << 'EOF' > blueprint.apib
 EOF
 
 $ drafter blueprint.apib 
-_version: 3.0
+_version: 4.0
 metadata:
 name: "My API"
  ...

--- a/features/fixtures/ast.json
+++ b/features/fixtures/ast.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [
     {
       "name": "Format",

--- a/features/fixtures/ast.yaml
+++ b/features/fixtures/ast.yaml
@@ -1,4 +1,4 @@
-_version: "3.0"
+_version: "4.0"
 metadata:
   -
     name: "Format"

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -20,8 +20,8 @@
 #include "refract/Visitors.h"
 
 /** Version of API Blueprint serialization */
-#define AST_SERIALIZATION_VERSION "3.0"
-#define PARSE_RESULT_SERIALIZATION_VERSION "2.1"
+#define AST_SERIALIZATION_VERSION "4.0"
+#define PARSE_RESULT_SERIALIZATION_VERSION "2.2"
 
 namespace drafter {
 

--- a/src/drafter.cc
+++ b/src/drafter.cc
@@ -14,8 +14,8 @@ namespace drafter {
      * For now just redirect to snowcrash::parse()
      */
     int ParseBlueprint(const mdp::ByteBuffer& source,
-              snowcrash::BlueprintParserOptions options,
-              const snowcrash::ParseResultRef<snowcrash::Blueprint>& out)
+                       snowcrash::BlueprintParserOptions options,
+                       const snowcrash::ParseResultRef<snowcrash::Blueprint>& out)
     {
         return snowcrash::parse(source, options, out);
     }

--- a/src/drafter.h
+++ b/src/drafter.h
@@ -30,8 +30,8 @@ namespace drafter {
      *  \return Error status code. Zero represents success, non-zero a failure.
      */
     int ParseBlueprint(const mdp::ByteBuffer& source,
-              snowcrash::BlueprintParserOptions options,
-              const snowcrash::ParseResultRef<snowcrash::Blueprint>& out);
+                       snowcrash::BlueprintParserOptions options,
+                       const snowcrash::ParseResultRef<snowcrash::Blueprint>& out);
 }
 
 #endif // #ifndef DRAFTER_H

--- a/test/fixtures/blueprint.ast.json
+++ b/test/fixtures/blueprint.ast.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [
     {
       "name": "FORMAT",

--- a/test/fixtures/blueprint.result.json
+++ b/test/fixtures/blueprint.result.json
@@ -1,7 +1,7 @@
 {
-  "_version": "2.1",
+  "_version": "2.2",
   "ast": {
-    "_version": "3.0",
+    "_version": "4.0",
     "metadata": [
       {
         "name": "FORMAT",

--- a/test/fixtures/blueprint.result.sourcemap.json
+++ b/test/fixtures/blueprint.result.sourcemap.json
@@ -1,7 +1,7 @@
 {
-  "_version": "2.1",
+  "_version": "2.2",
   "ast": {
-    "_version": "3.0",
+    "_version": "4.0",
     "metadata": [
       {
         "name": "FORMAT",

--- a/test/fixtures/mson/array-reference.json
+++ b/test/fixtures/mson/array-reference.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "Tesla",
   "description": "",

--- a/test/fixtures/mson/array-sample.json
+++ b/test/fixtures/mson/array-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/array-typed-content.json
+++ b/test/fixtures/mson/array-typed-content.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/empty-sample.json
+++ b/test/fixtures/mson/empty-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/enum-members-description.json
+++ b/test/fixtures/mson/enum-members-description.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/enum-sample.json
+++ b/test/fixtures/mson/enum-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/enum.json
+++ b/test/fixtures/mson/enum.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/group.json
+++ b/test/fixtures/mson/group.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/inheritance.json
+++ b/test/fixtures/mson/inheritance.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/inner-inheritance.json
+++ b/test/fixtures/mson/inner-inheritance.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/mixin-nonexistent.json
+++ b/test/fixtures/mson/mixin-nonexistent.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/mixin.json
+++ b/test/fixtures/mson/mixin.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/multiline-description.json
+++ b/test/fixtures/mson/multiline-description.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/multiple-default.json
+++ b/test/fixtures/mson/multiple-default.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/named-with-types.json
+++ b/test/fixtures/mson/named-with-types.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/nontyped-array-sample.json
+++ b/test/fixtures/mson/nontyped-array-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/nontyped-array.json
+++ b/test/fixtures/mson/nontyped-array.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/nontyped-object.json
+++ b/test/fixtures/mson/nontyped-object.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/number-wrong-value.json
+++ b/test/fixtures/mson/number-wrong-value.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/object-sample.json
+++ b/test/fixtures/mson/object-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/oneof-sample.json
+++ b/test/fixtures/mson/oneof-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/oneof.json
+++ b/test/fixtures/mson/oneof.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/primitive-variables.json
+++ b/test/fixtures/mson/primitive-variables.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/primitive-with-members.json
+++ b/test/fixtures/mson/primitive-with-members.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/primitives.json
+++ b/test/fixtures/mson/primitives.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/reference-override.json
+++ b/test/fixtures/mson/reference-override.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "Tesla",
   "description": "",

--- a/test/fixtures/mson/resource-anonymous.json
+++ b/test/fixtures/mson/resource-anonymous.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/resource-nested-inheritance.json
+++ b/test/fixtures/mson/resource-nested-inheritance.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/resource-nested-member.json
+++ b/test/fixtures/mson/resource-nested-member.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/resource-nested-mixin.json
+++ b/test/fixtures/mson/resource-nested-mixin.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/resource-primitive-mixin.json
+++ b/test/fixtures/mson/resource-primitive-mixin.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/resource-resolve-basetype.json
+++ b/test/fixtures/mson/resource-resolve-basetype.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/resource-unresolved-reference.json
+++ b/test/fixtures/mson/resource-unresolved-reference.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/mson/string-sample.json
+++ b/test/fixtures/mson/string-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/typed-array-sample.json
+++ b/test/fixtures/mson/typed-array-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/typed-array.json
+++ b/test/fixtures/mson/typed-array.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/mson/typed-object.json
+++ b/test/fixtures/mson/typed-object.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "<API name>",
   "description": "<API description>\n\n",

--- a/test/fixtures/render/array-mixin.json
+++ b/test/fixtures/render/array-mixin.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/array-nested-array.json
+++ b/test/fixtures/render/array-nested-array.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/array-nested-object.json
+++ b/test/fixtures/render/array-nested-object.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/array-ref-array.json
+++ b/test/fixtures/render/array-ref-array.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/array-ref-object.json
+++ b/test/fixtures/render/array-ref-object.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/array-samples.json
+++ b/test/fixtures/render/array-samples.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/complex-object.json
+++ b/test/fixtures/render/complex-object.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/content-type.json
+++ b/test/fixtures/render/content-type.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/inheritance-array-sample.json
+++ b/test/fixtures/render/inheritance-array-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/inheritance-object-sample.json
+++ b/test/fixtures/render/inheritance-object-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/mixin-array-sample.json
+++ b/test/fixtures/render/mixin-array-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/mixin-object-sample.json
+++ b/test/fixtures/render/mixin-object-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/nested-object.json
+++ b/test/fixtures/render/nested-object.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/object-mixin.json
+++ b/test/fixtures/render/object-mixin.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/object-ref-object.json
+++ b/test/fixtures/render/object-ref-object.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/object-samples.json
+++ b/test/fixtures/render/object-samples.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/object-without-sample.json
+++ b/test/fixtures/render/object-without-sample.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/primitive-samples.json
+++ b/test/fixtures/render/primitive-samples.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/simple-array.json
+++ b/test/fixtures/render/simple-array.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",

--- a/test/fixtures/render/simple-object.json
+++ b/test/fixtures/render/simple-object.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0",
+  "_version": "4.0",
   "metadata": [],
   "name": "",
   "description": "",


### PR DESCRIPTION
This PR updates APIB AST version to 4.0 and APIB Parse Result version to 2.2

This PR also changes the README to reflect to new C++/C API.