### PR TITLE
Improve enum parsing

### DIFF
--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -514,6 +514,8 @@ namespace drafter {
 
         ExtractValueMember<ElementType>(data, defaultNestedType)(value);
 
+        size_t valuesCount = data.values.size();
+
         if (!data.descriptions.empty()) {
                 element->meta[SerializeKey::Description] = refract::IElement::Create(*data.descriptions.begin());
         }
@@ -521,6 +523,15 @@ namespace drafter {
         SetElementType(element, value.valueDefinition.typeDefinition);
 
         std::for_each(value.sections.begin(), value.sections.end(), ExtractTypeSection<T>(data, value));
+
+        
+        if (!value.valueDefinition.values.empty() && (valuesCount != data.values.size())) { 
+            // there are some values coming from TypeSections -> move first value into examples
+            ElementType* element = new ElementType;
+            element->set(data.values.front());
+            data.samples.insert(data.samples.begin(), element);
+            data.values.erase(data.values.begin());
+        }
 
         TransformElementData(element, data);
 

--- a/src/refract/AppendDecorator.h
+++ b/src/refract/AppendDecorator.h
@@ -30,23 +30,9 @@ namespace refract
             // FIXME: snowcrash warn about "Primitive type can not have member"
             // but in real it create "empty" member
             //
-            // solution for now: silently ignore
-        }
-    };
-
-    template <typename T>
-    struct AppendDecorator<T, std::string> {
-        typedef T ElementType;
-        typedef typename T::ValueType ValueType;
-        ElementType*& element;
-
-        AppendDecorator(ElementType*& e) : element(e)
-        {
-        }
-
-        void operator()(const std::string& value) {
-            if (!value.empty()) {
-                element->value.append(value);
+            // solution for now: set if element has no already value, otherwise silently ignore
+            if (element->empty()) {
+                element->set(value);
             }
         }
     };
@@ -63,13 +49,9 @@ namespace refract
 
         void operator()(const ValueType& value)
         {
-            std::copy(value.begin(), value.end(), std::back_inserter(element->value));
-            if (!value.empty()) {
-                element->hasContent = true;
-            }
+            for_each(value.begin(), value.end(), std::bind1st(std::mem_fun(&ElementType::push_back), element));
         }
     };
-
 
 }; // namespace refract
 

--- a/test/fixtures/mson/enum-variants.apib
+++ b/test/fixtures/mson/enum-variants.apib
@@ -1,0 +1,66 @@
+
+# Data Structures       
+
+# Enum behavior (object)
+- size1: L (enum) - content ['L']
+
+- size2: S, M, L, XL (enum) - content ['S','M','L','XL']
+
+- size3: L (enum) - sample [['L']], content ['S','M','L','XL']
+    - S
+    - M
+    - L
+    - XL
+
+- size4: L (enum) - sample [['L']], content [ 'S, M, L, XL' ] - FIXME: from snowcrash we receive "enum of strings" should be string "S, M, L, XL"
+    - S, M, L, XL
+
+- size5: *L* (enum) - sample [['L']]
+
+- size6: L (enum, sample) - sample [['L']]
+
+- size7 (enum) - content ['S','M','L','XL','XXL','XXXL']
+    - S
+    - M
+    - L
+    - XL
+
+    - items
+        - XXL
+        - XXXL
+
+- size8: S (enum) - content ['T'], samples [[ 'S' ],[ 'U']]
+    - T
+
+    - sample
+        - U
+
+- size9: L (enum, sample) - sample [['L'],['M','N']]
+    - M
+    - N
+
+- size10: L (enum, sample) - sample [['L'],['M','N']] 
+    - items
+        - M
+        - M
+
+- size11 (enum[string, number]) - content['M','N']
+    - M
+    - N
+
+- size12: L (enum,default) - default['M','N'] - FIXME: current default['L'], sample[['M','N']]
+    - M
+    - N
+
+- size13: L (enum,default) - default['M','N'] - FIXME: current default['L'], sample[['M','N']]
+    - items
+        - M
+        - N
+
+- size14 (enum,sample) - sample[['M','N']] - FIXME: curent content[['M','N']]
+    - M
+    - N
+
+- size15 (enum,default) - default['M','N'] - FIXME: curent content[['M','N']]
+    - M
+    - N

--- a/test/fixtures/mson/enum-variants.json
+++ b/test/fixtures/mson/enum-variants.json
@@ -1,0 +1,513 @@
+{
+  "_version": "4.0",
+  "metadata": [],
+  "name": "",
+  "description": "",
+  "element": "category",
+  "resourceGroups": [],
+  "content": [
+    {
+      "element": "category",
+      "content": [
+        {
+          "element": "dataStructure",
+          "content": [
+            {
+              "element": "object",
+              "meta": {
+                "id": "Enum behavior"
+              },
+              "content": [
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "content ['L']"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size1"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "L"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "content ['S','M','L','XL']"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size2"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "S"
+                        },
+                        {
+                          "element": "string",
+                          "content": "M"
+                        },
+                        {
+                          "element": "string",
+                          "content": "L"
+                        },
+                        {
+                          "element": "string",
+                          "content": "XL"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "sample [['L']], content ['S','M','L','XL']"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size3"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "attributes": {
+                        "samples": [
+                          [
+                            {
+                              "element": "string",
+                              "content": "L"
+                            }
+                          ]
+                        ]
+                      },
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "S"
+                        },
+                        {
+                          "element": "string",
+                          "content": "M"
+                        },
+                        {
+                          "element": "string",
+                          "content": "L"
+                        },
+                        {
+                          "element": "string",
+                          "content": "XL"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "sample [['L']], content [ 'S, M, L, XL' ] - FIXME: from snowcrash we receive \"enum of strings\" should be string \"S, M, L, XL\""
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size4"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "attributes": {
+                        "samples": [
+                          [
+                            {
+                              "element": "string",
+                              "content": "L"
+                            }
+                          ]
+                        ]
+                      },
+                      "content": [
+                        {
+                          "element": "array",
+                          "content": [
+                            {
+                              "element": "string",
+                              "content": "S"
+                            },
+                            {
+                              "element": "string",
+                              "content": "M"
+                            },
+                            {
+                              "element": "string",
+                              "content": "L"
+                            },
+                            {
+                              "element": "string",
+                              "content": "XL"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "sample [['L']]"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size5"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "content": [
+                        {
+                          "element": "string",
+                          "attributes": {
+                            "samples": [
+                              "L"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "sample [['L']]"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size6"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "attributes": {
+                        "samples": [
+                          [
+                            {
+                              "element": "string",
+                              "content": "L"
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "content ['S','M','L','XL','XXL','XXXL']"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size7"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "S"
+                        },
+                        {
+                          "element": "string",
+                          "content": "M"
+                        },
+                        {
+                          "element": "string",
+                          "content": "L"
+                        },
+                        {
+                          "element": "string",
+                          "content": "XL"
+                        },
+                        {
+                          "element": "string",
+                          "content": "XXL"
+                        },
+                        {
+                          "element": "string",
+                          "content": "XXXL"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "content ['T'], samples [[ 'S' ],[ 'U']]"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size8"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "attributes": {
+                        "samples": [
+                          [
+                            {
+                              "element": "string",
+                              "content": "S"
+                            }
+                          ],
+                          [
+                            {
+                              "element": "string",
+                              "content": "U"
+                            }
+                          ]
+                        ]
+                      },
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "T"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "sample [['L'],['M','N']]"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size9"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "attributes": {
+                        "samples": [
+                          [
+                            {
+                              "element": "string",
+                              "content": "M"
+                            },
+                            {
+                              "element": "string",
+                              "content": "N"
+                            }
+                          ],
+                          [
+                            {
+                              "element": "string",
+                              "content": "L"
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "sample [['L'],['M','N']]"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size10"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "attributes": {
+                        "samples": [
+                          [
+                            {
+                              "element": "string",
+                              "content": "M"
+                            },
+                            {
+                              "element": "string",
+                              "content": "M"
+                            }
+                          ],
+                          [
+                            {
+                              "element": "string",
+                              "content": "L"
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size11"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "M"
+                        },
+                        {
+                          "element": "string",
+                          "content": "N"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "default['M','N'] - FIXME: current default['L'], sample[['M','N']]"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size12"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "attributes": {
+                        "samples": [
+                          [
+                            {
+                              "element": "string",
+                              "content": "M"
+                            },
+                            {
+                              "element": "string",
+                              "content": "N"
+                            }
+                          ]
+                        ],
+                        "default": [
+                          {
+                            "element": "string",
+                            "content": "L"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "default['M','N'] - FIXME: current default['L'], sample[['M','N']]"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size13"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "attributes": {
+                        "samples": [
+                          [
+                            {
+                              "element": "string",
+                              "content": "M"
+                            },
+                            {
+                              "element": "string",
+                              "content": "N"
+                            }
+                          ]
+                        ],
+                        "default": [
+                          {
+                            "element": "string",
+                            "content": "L"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "sample[['M','N']] - FIXME: curent content[['M','N']]"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size14"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "M"
+                        },
+                        {
+                          "element": "string",
+                          "content": "N"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "default['M','N'] - FIXME: curent content[['M','N']]"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "size15"
+                    },
+                    "value": {
+                      "element": "enum",
+                      "content": [
+                        {
+                          "element": "string",
+                          "content": "M"
+                        },
+                        {
+                          "element": "string",
+                          "content": "N"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test-RefractDataStructureTest.cc
+++ b/test/test-RefractDataStructureTest.cc
@@ -181,3 +181,8 @@ TEST_CASE("Testing refract reference getting overridden", "[refract][mson]")
 {
     REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/reference-override", drafter::NormalASTType, true));
 }
+
+TEST_CASE("Testing refract enum count of different variants value/samples", "[refract][mson]")
+{
+    REQUIRE(FixtureHelper::handleBlueprintJSON("test/fixtures/mson/enum-variants", drafter::NormalASTType, true));
+}


### PR DESCRIPTION
Closes #97 

Changes in `ExtractValueMember<T>`.
- now just extracting data from `mson::ValueMember` instead of manipulation with *Element*
(like `ExtractTypeInfo<>`)

- `TypeSectionData` renamed to `ElementData`
- `TransformTypeSectionData` renamed to `TransformElementData`
- add fixtures to handle improved enum|array parsing
