### PR TITLE
Removed WITH_REFRACT from most places

### DIFF
--- a/src/Render.cc
+++ b/src/Render.cc
@@ -48,7 +48,6 @@ namespace drafter {
             return body;
         }
 
-#if _WITH_REFRACT_
         switch (renderFormat) {
             case JSONRenderFormat:
             {
@@ -65,7 +64,6 @@ namespace drafter {
             default:
                 break;
         }
-#endif
 
         return body;
     }

--- a/src/Serialize.cc
+++ b/src/Serialize.cc
@@ -11,7 +11,6 @@
 
 using namespace drafter;
 
-#ifdef _WITH_REFRACT_
 namespace drafter {
 
     /**
@@ -25,7 +24,6 @@ namespace drafter {
         return namedTypesRegistry;
     }
 }
-#endif
 
 const std::string SerializeKey::Metadata = "metadata";
 const std::string SerializeKey::Reference = "reference";

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -31,9 +31,7 @@ namespace drafter {
         UnknownASTType = -1
     };
 
-#ifdef _WITH_REFRACT_
     refract::Registry& GetNamedTypesRegistry();
-#endif
 
     /**
      *  AST and Refract entities serialization keys


### PR DESCRIPTION
This PR along with #126 removes most of the WITH_REFRACT macros except the main one. This PR fixes #103