### PR TITLE
Key 'warnings' in WrapResult should be an empty array

### DIFF
--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -16,7 +16,7 @@
 
 using namespace drafter;
 
-static sos::Object WrapLocation(const mdp::BytesRange& range)
+sos::Object WrapLocation(const mdp::BytesRange& range)
 {
     sos::Object location;
 
@@ -26,7 +26,7 @@ static sos::Object WrapLocation(const mdp::BytesRange& range)
     return location;
 }
 
-static sos::Object WrapAnnotation(const snowcrash::SourceAnnotation& annotation)
+sos::Object drafter::WrapAnnotation(const snowcrash::SourceAnnotation& annotation)
 {
     sos::Object object;
 

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -51,10 +51,7 @@ sos::Object WrapParseResultAST(const snowcrash::ParseResult<snowcrash::Blueprint
     }
 
     object.set(SerializeKey::Error, WrapAnnotation(blueprint.report.error));
-
-    if (!blueprint.report.warnings.empty()) {
-        object.set(SerializeKey::Warnings, WrapCollection<snowcrash::SourceAnnotation>()(blueprint.report.warnings, WrapAnnotation));
-    }
+    object.set(SerializeKey::Warnings, WrapCollection<snowcrash::SourceAnnotation>()(blueprint.report.warnings, WrapAnnotation));
 
     return object;
 }

--- a/src/SerializeResult.h
+++ b/src/SerializeResult.h
@@ -15,6 +15,7 @@
 
 namespace drafter {
 
+    sos::Object WrapAnnotation(const snowcrash::SourceAnnotation& annotation);
     sos::Object WrapParseResult(const snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const snowcrash::BlueprintParserOptions options);
     sos::Object WrapResult(const snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const snowcrash::BlueprintParserOptions options, const ASTType astType);
 }


### PR DESCRIPTION
This PR makes sure that the `warnings` key in `drafter::WrapResult` should be an empty array when no warnings are present. I am doing this because that is how protagonist has been serialising until now. And since `WrapResult` is synonymous with the output from protagonist, we need to make sure they are similar.

This PR also does the following minor things:

* Expose `drafter::WrapAnnotation` so that protagonist can use it.
* Updates the sos submodule.

Blocked by #126 and need to be rebased once that is merged.