### PR TITLE
Set indentation to 4 spaces in Xcode project

### DIFF
--- a/drafter.xcodeproj/project.pbxproj
+++ b/drafter.xcodeproj/project.pbxproj
@@ -301,7 +301,9 @@
 				19A129F01B70B88F00366AA7 /* libsos */,
 				19BD7B981B70AAAF00A11E83 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		19BD7B981B70AAAF00A11E83 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Seem's this project uses 4 spaces so I'm explicitly setting this in the project. My global Xcode defaults differ.
