### PR TITLE
Fix upload asset name

### DIFF
--- a/emcc/release.sh
+++ b/emcc/release.sh
@@ -9,7 +9,7 @@ tar -xjf $OS-amd64-github-release.tar.bz2
 
 ./bin/$OS/amd64/github-release release -u apiaryio -r drafter --tag $TAG
 ./bin/$OS/amd64/github-release upload -u apiaryio -r drafter --tag $TAG --name drafter.js --file emcc/drafter.js
-./bin/$OS/amd64/github-release upload -u apiaryio -r drafter --tag $TAG --name drafter.js --file emcc/drafter.js.mem
+./bin/$OS/amd64/github-release upload -u apiaryio -r drafter --tag $TAG --name drafter.js.mem --file emcc/drafter.js.mem
 
 # Publish to npm
 npm --no-git-tag-version version $TAG


### PR DESCRIPTION
Fixes the release issue from the latest pre-release. There was a bug in the script where it tried to upload two files to the same name.

Both files are now uploaded to the latest release; this fix will apply to the next release:

https://github.com/apiaryio/drafter/releases/tag/v2.0.0-pre.0

Thanks!