### PR TITLE
Fix memory allocation - emscripten

### DIFF
--- a/emcc/post.js
+++ b/emcc/post.js
@@ -16,7 +16,8 @@ Module['parse'] = function(blueprint, options) {
   }
 
   var chptr = _malloc(4);
-  var buffer = _malloc(blueprint.length+1);
+  // at most 4 bytes per UTF-8 code point, +1 for the trailing '\0'
+  var buffer = _malloc(4*blueprint.length+1);
   var parseOptions = 0;
   var astType = 1;
 


### PR DESCRIPTION
Lib crashed when I try to parse specs with Unicode symbols in them.
I debug issue and took solution from here https://github.com/kripken/emscripten/blob/42fb486c53d627b203b77af6e5d0c088c0ad03ad/src/preamble.js#L158
Please add Unicode tests to your testsuite.