### PR TITLE
Added support for MSVC2012.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,15 @@
 version: 1.0.{build}
 
+environment:
+  matrix:
+#   - VS_VERSION: MSVC2012
+    - VS_VERSION: MSVC2013
+
 build_script:
   - git submodule update --init --recursive
   - gem install bundler
-  - vcbuild.bat MSVC2013
+  - vcbuild.bat %VS_VERSION%
 
 test_script:
-  - vcbuild.bat MSVC2013 test
-  - vcbuild.bat MSVC2013 inttest
+  - vcbuild.bat %VS_VERSION% test
+  - vcbuild.bat %VS_VERSION% inttest

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -493,7 +493,7 @@ sos::Object WrapAsset(const Asset& asset, const AssetRole& role)
     return assetObject;
 }
 
-sos::Object WrapPayload(const Payload& payload, const Action* action = NULL)
+sos::Object WrapPayload(const Payload& payload, const Action* action)
 {
     sos::Object payloadObject;
 
@@ -663,7 +663,7 @@ sos::Object WrapResource(const Resource& resource)
     resourceObject.set(SerializeKey::URITemplate, sos::String(resource.uriTemplate));
 
     // Model
-    sos::Object model = (resource.model.name.empty() ? sos::Object() : WrapPayload(resource.model));
+    sos::Object model = (resource.model.name.empty() ? sos::Object() : WrapPayload(resource.model, NULL));
     resourceObject.set(SerializeKey::Model, model);
 
     // Parameters


### PR DESCRIPTION
This PR also adds matrix build support for MSVC2012 in appveyor along with MSVC2013.

Fixes #149 