### PR TITLE
Use NPM_TOKEN CI host env var for releases

### DIFF
--- a/emcc/release.sh
+++ b/emcc/release.sh
@@ -11,6 +11,9 @@ tar -xjf $OS-amd64-github-release.tar.bz2
 ./bin/$OS/amd64/github-release upload -u apiaryio -r drafter --tag $TAG --name drafter.js --file emcc/drafter.js
 ./bin/$OS/amd64/github-release upload -u apiaryio -r drafter --tag $TAG --name drafter.js.mem --file emcc/drafter.js.mem
 
+# Use the CI host's NPM_TOKEN environment variable for auth
+echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >.npmrc
+
 # Publish to npm
 npm --no-git-tag-version version $TAG
 npm publish


### PR DESCRIPTION
The `.npmrc` file would cause issues when `NPM_TOKEN` is not defined, so it was removed in f0df9c07795b0b5dfc3bc7dc98e499a8468f4dce. That inadvertently broke the release script, so this PR fixes it by creating the file on the fly. I chose this instead of [another method](http://glebbahmutov.com/blog/automatically-publish-to-npm/) because it [keeps my password a secret](http://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules) to those with access to the CI host configuration.