### PR TITLE
Give priority to sourcemap in wrapper options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ std::cout << "API Name: " << ast.node.name << std::endl;
 
 // Serialization to JSON format
 sos::SerializeJSON serializer;
-serializer.process(drafter::WrapBlueprint(ast.node, drafter::WrapperOptions(drafter::RefractASTType, false, false)), std::cout);
+serializer.process(drafter::WrapBlueprint(ast.node, drafter::WrapperOptions(drafter::RefractASTType)), std::cout);
 
 ```
 

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -42,11 +42,17 @@ namespace drafter {
     // Options struct for drafter
     struct WrapperOptions {
         const ASTType astType;
-        const bool expandMSON;
         const bool exportSourceMap;
+        const bool expandMSON;
 
-        WrapperOptions(const ASTType astType, const bool expandMSON, const bool exportSourceMap)
-        : astType(astType), expandMSON(expandMSON), exportSourceMap(exportSourceMap) {}
+        WrapperOptions(const ASTType astType, const bool exportSourceMap, const bool expandMSON)
+        : astType(astType), exportSourceMap(exportSourceMap), expandMSON(expandMSON) {}
+
+        WrapperOptions(const ASTType astType, const bool exportSourceMap)
+        : astType(astType), exportSourceMap(exportSourceMap), expandMSON(false) {}
+
+        WrapperOptions(const ASTType astType)
+        : astType(astType), exportSourceMap(false), expandMSON(false) {}
     };
 
     refract::Registry& GetNamedTypesRegistry();

--- a/src/cdrafter.cc
+++ b/src/cdrafter.cc
@@ -46,7 +46,7 @@ SC_API int drafter_c_parse(const char* source,
 
     if (result) {
         std::stringstream resultStream;
-        drafter::WrapperOptions wrapperOptions(drafter::ASTType(astType), false, options & SC_EXPORT_SORUCEMAP_OPTION);
+        drafter::WrapperOptions wrapperOptions(drafter::ASTType(astType), options & SC_EXPORT_SORUCEMAP_OPTION);
 
         try {
             serializer.process(drafter::WrapResult(blueprint, wrapperOptions), resultStream);

--- a/src/main.cc
+++ b/src/main.cc
@@ -71,7 +71,7 @@ int main(int argc, const char *argv[])
         std::ostream *out = CreateStreamFromName<std::ostream>(config.output);
 
         try {
-            Serialization(out, drafter::WrapResult(blueprint, drafter::WrapperOptions(config.astType, false, config.sourceMap)), serializer);
+            Serialization(out, drafter::WrapResult(blueprint, drafter::WrapperOptions(config.astType, config.sourceMap)), serializer);
         }
         catch (snowcrash::Error& e) {
             blueprint.report.error = e;

--- a/test/draftertest.h
+++ b/test/draftertest.h
@@ -12,25 +12,24 @@
 #include "SerializeResult.h"
 #include "sosJSON.h"
 
-
 #define TEST_DRAFTER(description, category, name, tag,  wrapper, options, mustBeOk) TEST_CASE(description " " category " " name, "[" tag "][" category "]") { \
     REQUIRE(FixtureHelper::handleResultJSON(wrapper, "test/fixtures/" category "/" name, options, mustBeOk)); \
 }
 
 #define TEST_REFRACT(category, name) TEST_CASE("Testing refract serialization for " category " " name, "[refract][" category "]") { \
-    FixtureHelper::handleResultJSON(&drafter::WrapResult, "test/fixtures/" category "/" name, drafter::WrapperOptions(drafter::RefractASTType, false, false)); \
+    FixtureHelper::handleResultJSON(&drafter::WrapResult, "test/fixtures/" category "/" name, drafter::WrapperOptions(drafter::RefractASTType)); \
 }
 
 #define TEST_REFRACT_SOURCE_MAP(category, name) TEST_CASE("Testing refract + source map serialization for " category " " name, "[refract][" category "]") { \
-    FixtureHelper::handleResultJSON(&drafter::WrapResult, "test/fixtures/" category "/" name, drafter::WrapperOptions(drafter::RefractASTType, false, true)); \
+    FixtureHelper::handleResultJSON(&drafter::WrapResult, "test/fixtures/" category "/" name, drafter::WrapperOptions(drafter::RefractASTType, true)); \
 }
 
 #define TEST_AST(category, name) TEST_CASE("Testing AST serialization for " category " " name, "[ast][" category "]") { \
-    FixtureHelper::handleResultJSON(&drafter::WrapResult, "test/fixtures/" category "/" name, drafter::WrapperOptions(drafter::NormalASTType, false, false)); \
+    FixtureHelper::handleResultJSON(&drafter::WrapResult, "test/fixtures/" category "/" name, drafter::WrapperOptions(drafter::NormalASTType)); \
 }
 
 #define TEST_AST_SOURCE_MAP(category, name) TEST_CASE("Testing AST + source map serialization for " category " " name, "[ast][" category "]") { \
-    FixtureHelper::handleResultJSON(&drafter::WrapResult, "test/fixtures/" category "/" name, drafter::WrapperOptions(drafter::NormalASTType, false, true)); \
+    FixtureHelper::handleResultJSON(&drafter::WrapResult, "test/fixtures/" category "/" name, drafter::WrapperOptions(drafter::NormalASTType, true)); \
 }
 
 namespace draftertest {

--- a/test/test-RefractDataStructureTest.cc
+++ b/test/test-RefractDataStructureTest.cc
@@ -2,7 +2,7 @@
 
 using namespace draftertest;
 
-static drafter::WrapperOptions MSONTestOptions(drafter::NormalASTType, true, false);
+static drafter::WrapperOptions MSONTestOptions(drafter::NormalASTType, false, true);
 
 #define TEST_MSON(file, mustBeOk) TEST_DRAFTER("Testing MSON serialization for", "mson", file, "ast", &drafter::WrapBlueprint, MSONTestOptions, mustBeOk)
 #define TEST_MSON_SUCCESS(file) TEST_MSON(file, true)


### PR DESCRIPTION
This PR also adds a few convenience constructors to `WrapperOptions`.