### PR TITLE
Fixes bug in `classes` key of asset element

### DIFF
--- a/features/fixtures/refract.json
+++ b/features/fixtures/refract.json
@@ -280,7 +280,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "text/plain"
@@ -290,7 +292,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageSchema"
+                                "classes": [
+                                  "messageSchema"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "text/plain"
@@ -369,7 +373,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "text/plain"
@@ -379,7 +385,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageSchema"
+                                "classes": [
+                                  "messageSchema"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "text/plain"
@@ -464,7 +472,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "text/plain"
@@ -474,7 +484,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageSchema"
+                                "classes": [
+                                  "messageSchema"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "text/plain"
@@ -540,14 +552,18 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "content": "<resource model body>\n"
                             },
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageSchema"
+                                "classes": [
+                                  "messageSchema"
+                                ]
                               },
                               "content": "<resource model schema>\n"
                             }
@@ -629,7 +645,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "text/plain"
@@ -639,7 +657,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageSchema"
+                                "classes": [
+                                  "messageSchema"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "text/plain"
@@ -709,7 +729,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/features/fixtures/refract.sourcemap.json
+++ b/features/fixtures/refract.sourcemap.json
@@ -742,7 +742,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -763,7 +765,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageSchema"
+                                "classes": [
+                                  "messageSchema"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -934,7 +938,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -955,7 +961,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageSchema"
+                                "classes": [
+                                  "messageSchema"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -1148,7 +1156,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -1169,7 +1179,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageSchema"
+                                "classes": [
+                                  "messageSchema"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -1314,7 +1326,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -1334,7 +1348,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageSchema"
+                                "classes": [
+                                  "messageSchema"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -1526,7 +1542,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -1547,7 +1565,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageSchema"
+                                "classes": [
+                                  "messageSchema"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -1683,7 +1703,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/features/fixtures/refract.sourcemap.yaml
+++ b/features/fixtures/refract.sourcemap.yaml
@@ -479,7 +479,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               sourceMap:
                                 -
@@ -493,7 +494,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageSchema"
+                              classes:
+                                - "messageSchema"
                             attributes:
                               sourceMap:
                                 -
@@ -604,7 +606,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               sourceMap:
                                 -
@@ -618,7 +621,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageSchema"
+                              classes:
+                                - "messageSchema"
                             attributes:
                               sourceMap:
                                 -
@@ -743,7 +747,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               sourceMap:
                                 -
@@ -757,7 +762,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageSchema"
+                              classes:
+                                - "messageSchema"
                             attributes:
                               sourceMap:
                                 -
@@ -851,7 +857,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               sourceMap:
                                 -
@@ -864,7 +871,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageSchema"
+                              classes:
+                                - "messageSchema"
                             attributes:
                               sourceMap:
                                 -
@@ -988,7 +996,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               sourceMap:
                                 -
@@ -1002,7 +1011,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageSchema"
+                              classes:
+                                - "messageSchema"
                             attributes:
                               sourceMap:
                                 -
@@ -1090,7 +1100,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               contentType: "application/json"
                             content: "{\n  \"<data structure property name>\": \"<data structure property value>\"\n}"

--- a/features/fixtures/refract.yaml
+++ b/features/fixtures/refract.yaml
@@ -193,14 +193,16 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               contentType: "text/plain"
                             content: "<request body>\n"
                           -
                             element: "asset"
                             meta:
-                              classes: "messageSchema"
+                              classes:
+                                - "messageSchema"
                             attributes:
                               contentType: "text/plain"
                             content: "<request schema>\n"
@@ -254,14 +256,16 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               contentType: "text/plain"
                             content: "<response body>\n"
                           -
                             element: "asset"
                             meta:
-                              classes: "messageSchema"
+                              classes:
+                                - "messageSchema"
                             attributes:
                               contentType: "text/plain"
                             content: "<response schema>\n"
@@ -319,14 +323,16 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               contentType: "text/plain"
                             content: "<request body>\n"
                           -
                             element: "asset"
                             meta:
-                              classes: "messageSchema"
+                              classes:
+                                - "messageSchema"
                             attributes:
                               contentType: "text/plain"
                             content: "<request schema>\n"
@@ -371,12 +377,14 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             content: "<resource model body>\n"
                           -
                             element: "asset"
                             meta:
-                              classes: "messageSchema"
+                              classes:
+                                - "messageSchema"
                             content: "<resource model schema>\n"
                   -
                     element: "httpTransaction"
@@ -432,14 +440,16 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               contentType: "text/plain"
                             content: "<request body>\n"
                           -
                             element: "asset"
                             meta:
-                              classes: "messageSchema"
+                              classes:
+                                - "messageSchema"
                             attributes:
                               contentType: "text/plain"
                             content: "<request schema>\n"
@@ -486,7 +496,8 @@ content:
                           -
                             element: "asset"
                             meta:
-                              classes: "messageBody"
+                              classes:
+                                - "messageBody"
                             attributes:
                               contentType: "application/json"
                             content: "{\n  \"<data structure property name>\": \"<data structure property value>\"\n}"

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -243,7 +243,7 @@ namespace drafter {
         refract::IElement* element = PrimitiveToRefract(asset);
 
         element->element(SerializeKey::Asset);
-        element->meta[SerializeKey::Classes] = refract::ArrayElement::Create(metaClass);
+        element->meta[SerializeKey::Classes] = CreateArrayElement(metaClass);
 
         if (!contentType.empty()) {
             // FIXME: "contentType" has no sourceMap?

--- a/test/fixtures/api/action-attributes.json
+++ b/test/fixtures/api/action-attributes.json
@@ -78,7 +78,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "content": "[]\n"
                             }

--- a/test/fixtures/api/action-attributes.sourcemap.json
+++ b/test/fixtures/api/action-attributes.sourcemap.json
@@ -216,7 +216,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [

--- a/test/fixtures/api/action-parameters.json
+++ b/test/fixtures/api/action-parameters.json
@@ -99,7 +99,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/action-parameters.sourcemap.json
+++ b/test/fixtures/api/action-parameters.sourcemap.json
@@ -266,7 +266,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [

--- a/test/fixtures/api/action-request-attributes.json
+++ b/test/fixtures/api/action-request-attributes.json
@@ -90,7 +90,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/action.json
+++ b/test/fixtures/api/action.json
@@ -57,7 +57,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "content": "[]\n"
                             }

--- a/test/fixtures/api/action.sourcemap.json
+++ b/test/fixtures/api/action.sourcemap.json
@@ -182,7 +182,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [

--- a/test/fixtures/api/advanced-action.json
+++ b/test/fixtures/api/advanced-action.json
@@ -56,7 +56,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "content": "[]\n"
                             }

--- a/test/fixtures/api/advanced-action.sourcemap.json
+++ b/test/fixtures/api/advanced-action.sourcemap.json
@@ -184,7 +184,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [

--- a/test/fixtures/api/asset.json
+++ b/test/fixtures/api/asset.json
@@ -94,7 +94,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/asset.sourcemap.json
+++ b/test/fixtures/api/asset.sourcemap.json
@@ -245,7 +245,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/attributes-array-nested-named-type.json
+++ b/test/fixtures/api/attributes-array-nested-named-type.json
@@ -149,7 +149,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/attributes-named-type-enum-reference.json
+++ b/test/fixtures/api/attributes-named-type-enum-reference.json
@@ -142,7 +142,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/attributes-named-type-member-reference.json
+++ b/test/fixtures/api/attributes-named-type-member-reference.json
@@ -140,7 +140,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/attributes-named-type-mixin.json
+++ b/test/fixtures/api/attributes-named-type-mixin.json
@@ -157,7 +157,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/attributes-references.json
+++ b/test/fixtures/api/attributes-references.json
@@ -93,7 +93,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/headers.json
+++ b/test/fixtures/api/headers.json
@@ -84,7 +84,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/headers.sourcemap.json
+++ b/test/fixtures/api/headers.sourcemap.json
@@ -222,7 +222,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [

--- a/test/fixtures/api/relation.json
+++ b/test/fixtures/api/relation.json
@@ -56,7 +56,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "content": "[]\n"
                             }

--- a/test/fixtures/api/relation.sourcemap.json
+++ b/test/fixtures/api/relation.sourcemap.json
@@ -184,7 +184,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [

--- a/test/fixtures/api/request-only.json
+++ b/test/fixtures/api/request-only.json
@@ -47,7 +47,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "content": "{}\n"
                             }

--- a/test/fixtures/api/resource-parameters.json
+++ b/test/fixtures/api/resource-parameters.json
@@ -126,7 +126,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "contentType": "application/json"

--- a/test/fixtures/api/resource-parameters.sourcemap.json
+++ b/test/fixtures/api/resource-parameters.sourcemap.json
@@ -349,7 +349,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [

--- a/test/fixtures/api/transaction.json
+++ b/test/fixtures/api/transaction.json
@@ -47,7 +47,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "content": "{}\n"
                             }
@@ -62,7 +64,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "content": "[]\n"
                             }

--- a/test/fixtures/api/transaction.sourcemap.json
+++ b/test/fixtures/api/transaction.sourcemap.json
@@ -159,7 +159,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [
@@ -203,7 +205,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "attributes": {
                                 "sourceMap": [

--- a/test/fixtures/parse-result/warnings.json
+++ b/test/fixtures/parse-result/warnings.json
@@ -53,7 +53,9 @@
                             {
                               "element": "asset",
                               "meta": {
-                                "classes": "messageBody"
+                                "classes": [
+                                  "messageBody"
+                                ]
                               },
                               "content": "{}\n"
                             }


### PR DESCRIPTION
The current master branch serialises AssetElement as

```json
{
  "element": "asset",
  "classes": "messageBody"
}
```

when it should be according to the spec

```json
{
  "element": "asset",
  "classes": [
    "messageBody"
  ]
}
```