### PR TITLE
Expose `WrapAnnotation()` back to public

### DIFF
--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -26,7 +26,7 @@ sos::Object WrapLocation(const mdp::BytesRange& range)
     return location;
 }
 
-sos::Object WrapAnnotation(const snowcrash::SourceAnnotation& annotation)
+sos::Object drafter::WrapAnnotation(const snowcrash::SourceAnnotation& annotation)
 {
     sos::Object object;
 

--- a/src/SerializeResult.h
+++ b/src/SerializeResult.h
@@ -10,9 +10,15 @@
 #define DRAFTER_SERIALIZERESULT_H
 
 #include "Serialize.h"
+#include "SectionParserData.h"
+
+namespace snowcrash {
+    struct SourceAnnotation;
+}
 
 namespace drafter {
 
+    sos::Object WrapAnnotation(const snowcrash::SourceAnnotation& annotation);
     sos::Object WrapResult(const snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const WrapperOptions& options);
 }
 


### PR DESCRIPTION
it is required by protagonist