### PR TITLE
Fix missing 'ws' module during browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "install": "echo 'Setting up Drafter.js...'",
     "test": "cd emcc && node test-drafter"
   },
+  "browser": {
+    "ws": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/apiaryio/drafter"


### PR DESCRIPTION
Without this fix `browserify` give following error:
```
 Running "browserify:main" (browserify) task
>> Error: Cannot find module 'ws' from '/home/ivang/dev/api-spec-converter/node_modules/drafter.js/emcc'
```
Inside `drafter.nomem.js`:
```js
var WebSocket = ENVIRONMENT_IS_NODE ? require("ws") : window["WebSocket"];
```
Problem that `browserify` can't statically analyze `ENVIRONMENT_IS_NODE` value.
It browser if will always evaluate to `false`, so it safe to disable `ws` module.

This issue significantly blocks me, pleaser merge it and release updated NPM package.