### PR TITLE
Upload release tarballs to GitHub release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,4 +35,4 @@ deployment:
   release:
     tag: /v.*/
     commands:
-      - ./emcc/release.sh
+      - ./tools/release.sh

--- a/emcc/release.sh
+++ b/emcc/release.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
-OS=`uname -s | tr '[:upper:]' '[:lower:]'`
+
+if [ "x$1" = "x" ] ; then
+  echo "Usage: $0 GIT_RELEASE_BIN"
+  exit 1
+fi
+
 TAG=`git describe --tags $CIRCLE_SHA1`
 
-# Publish to GitHub releases
-curl -L -O https://github.com/aktau/github-release/releases/download/v0.6.2/$OS-amd64-github-release.tar.bz2
-
-tar -xjf $OS-amd64-github-release.tar.bz2
-
-./bin/$OS/amd64/github-release release -u apiaryio -r drafter --tag $TAG
-./bin/$OS/amd64/github-release upload -u apiaryio -r drafter --tag $TAG --name drafter.js --file emcc/drafter.js
-./bin/$OS/amd64/github-release upload -u apiaryio -r drafter --tag $TAG --name drafter.js.mem --file emcc/drafter.js.mem
+$1 upload -u apiaryio -r drafter --tag $TAG --name drafter.js --file emcc/drafter.js
+$1 upload -u apiaryio -r drafter --tag $TAG --name drafter.js.mem --file emcc/drafter.js.mem
 
 # Use the CI host's NPM_TOKEN environment variable for auth
 echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >.npmrc

--- a/tools/make-tarball.sh
+++ b/tools/make-tarball.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+if [ "x$1" = "xcheckout" ] ; then
+  # Recursively checkout a repository to destination
+  # Usage: tools/make-tarball.sh checkout DESTINATION
+
+  git checkout-index --all --prefix=$2
+  git submodule foreach --quiet "$0 checkout $2"'$path/'
+
+  exit 0
+fi
+
+TMPDIR=`mktemp -d`
+trap 'rm -rf $TMPDIR' EXIT
+VERSION=$1
+
+if [ "x$VERSION" = "x" ] ; then
+  echo "Usage: $0 VERSION"
+  exit 1
+fi
+
+DIR=drafter-$VERSION
+TARBALL=$(pwd)/drafter-$VERSION.tar.gz
+
+echo "Exporting to $TMPDIR/$DIR"
+
+$(pwd)/tools/make-tarball.sh checkout $TMPDIR/$DIR/
+
+(
+  # Remove unnessecery files
+  cd $TMPDIR/$DIR
+  rm -fr appveyor.yml circle.yml .npmignore tools/ package.json emcc/
+)
+
+(
+  cd $TMPDIR
+  echo "Creating tarball"
+  env GZIP=-9 tar -czf $TARBALL $DIR
+)

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+OS=`uname -s | tr '[:upper:]' '[:lower:]'`
+TAG=`git describe --tags $CIRCLE_SHA1`
+
+# Download GitHub releases script
+curl -L -O https://github.com/aktau/github-release/releases/download/v0.6.2/$OS-amd64-github-release.tar.bz2
+tar -xjf $OS-amd64-github-release.tar.bz2
+GITHUB_RELEASE=./bin/$OS/amd64/github-release
+
+# Create GitHub release
+$GITHUB_RELEASE release -u apiaryio -r drafter --tag $TAG
+
+# Create and upload tarball
+TARBALL=drafter-$TAG.tar.gz
+./tools/make-tarball.sh $TAG
+$GITHUB_RELEASE upload -u apiaryio -r drafter --tag $TAG --name $TARBALL --file $TARBALL
+
+# Create emcc release
+./emcc/release.sh $GITHUB_RELEASE


### PR DESCRIPTION
Unfortunately the "Source Code" tarballs that GitHub creates won't include the recursive submodules in the source and therefore are not usable to install drafter. The only way to install drafter is via a recursive git checkout.

This makes it difficult to package since it relies on git and many packaging systems don't allow this (Debian, Arch linux etc). This change will also allow us to provide a non-HEAD homebrew formula that uses the tarball so we can allow `brew update` to actually work.

Therefore, I've modified the release process that Circle CI runs to package up all the source code. This is broken up into two components, the first a script to generate a tarball. Here is the usage/showing that it works:

```shell
$ ./tools/make-tarball.sh 2.0.0
Exporting to /var/folders/tj/rgvrw2vj6ygbxvg2kd8f0gl00000gn/T/tmp.RbOmmoXi/drafter-2.0.0
Creating tarball
$ tar xf drafter-2.0.0.tar.gz
$ cd drafter-2.0.0/
$ ./configure
creating ./config.gypi
creating ./config.mk
creating makefiles
All OK.
$ make
...
```

And to check the whole flow from `./tools/release.sh`, we can disable github release script and instead use echo:

```diff
# Download GitHub releases script
- curl -L -O https://github.com/aktau/github-release/releases/download/v0.6.2/$OS-amd64-github-release.tar.bz2
- tar -xjf $OS-amd64-github-release.tar.bz2
- GITHUB_RELEASE=./bin/$OS/amd64/github-release
+ GITHUB_RELEASE=echo
```

**NOTE**: *You will also need comment out npm publish from `emcc/release.sh`*.

Then when we run the modified release script, we can see it works:

```shell
$ ./tools/release.sh
release -u apiaryio -r drafter --tag v2.0.1
Exporting to /var/folders/tj/rgvrw2vj6ygbxvg2kd8f0gl00000gn/T/tmp.136Wgski/drafter-v2.0.1
Creating tarball
upload -u apiaryio -r drafter --tag v2.0.1 --name drafter-v2.0.1.tar.gz --file drafter-v2.0.1.tar.gz
upload -u apiaryio -r drafter --tag v2.0.1 --name drafter.js --file emcc/drafter.js
upload -u apiaryio -r drafter --tag v2.0.1 --name drafter.js.mem --file emcc/drafter.js.mem
...
```

Next steps (once this is merged):

- [ ] I will manually upload the drafter 2.0.1 tarball to GitHub for the previous release
- [ ] I can make a [homebrew-formulae](https://github.com/QueryKit/homebrew-formulae) repository which would then allow us to install drafter via `brew install apiaryio/formulae/drafter` and `brew update` will correctly work for upgrading drafter via homebrew.
