### PR TITLE
Use JSON Schema content type for messageBodySchema

### DIFF
--- a/features/fixtures/refract.json
+++ b/features/fixtures/refract.json
@@ -746,7 +746,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"<data structure property name>\": {\n      \"type\": \"string\",\n      \"description\": \"<data structure property description>\"\n    }\n  }\n}"
                             }

--- a/features/fixtures/refract.sourcemap.json
+++ b/features/fixtures/refract.sourcemap.json
@@ -1720,7 +1720,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"<data structure property name>\": {\n      \"type\": \"string\",\n      \"description\": \"<data structure property description>\"\n    }\n  }\n}"
                             }

--- a/features/fixtures/refract.sourcemap.yaml
+++ b/features/fixtures/refract.sourcemap.yaml
@@ -1111,7 +1111,7 @@ content:
                               classes:
                                 - "messageBodySchema"
                             attributes:
-                              contentType: "application/json"
+                              contentType: "application/schema+json"
                             content: "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"<data structure property name>\": {\n      \"type\": \"string\",\n      \"description\": \"<data structure property description>\"\n    }\n  }\n}"
       -
         element: "category"

--- a/features/fixtures/refract.yaml
+++ b/features/fixtures/refract.yaml
@@ -507,7 +507,7 @@ content:
                               classes:
                                 - "messageBodySchema"
                             attributes:
-                              contentType: "application/json"
+                              contentType: "application/schema+json"
                             content: "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"<data structure property name>\": {\n      \"type\": \"string\",\n      \"description\": \"<data structure property description>\"\n    }\n  }\n}"
       -
         element: "category"

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -275,10 +275,11 @@ namespace drafter {
 
         // Get content type
         std::string contentType = getContentTypeFromHeaders(payload.node->headers);
+        std::string schemaContentType = (payload.node->schema == payloadSchema.first ? contentType : JSONSchemaContentType);
 
         // Assets
         content.push_back(AssetToRefract(NodeInfo<snowcrash::Asset>(payloadBody), contentType, SerializeKey::MessageBody));
-        content.push_back(AssetToRefract(NodeInfo<snowcrash::Asset>(payloadSchema), contentType, SerializeKey::MessageBodySchema));
+        content.push_back(AssetToRefract(NodeInfo<snowcrash::Asset>(payloadSchema), schemaContentType, SerializeKey::MessageBodySchema));
 
         RemoveEmptyElements(content);
         element->set(content);

--- a/src/Render.cc
+++ b/src/Render.cc
@@ -43,6 +43,7 @@ namespace drafter {
     NodeInfoByValue<Asset> renderPayloadBody(const NodeInfo<Payload>& payload,
                                              const NodeInfo<Action>& action,
                                              const refract::Registry& registry) {
+
         NodeInfoByValue<Asset> body = std::make_pair(payload.node->body, &payload.sourceMap->body);
         RenderFormat renderFormat = findRenderFormat(getContentTypeFromHeaders(payload.node->headers));
 
@@ -91,10 +92,12 @@ namespace drafter {
         return body;
     }
 
-    NodeInfoByValue<Asset> renderPayloadSchema(const NodeInfo<snowcrash::Payload>& payload, const NodeInfo<snowcrash::Action>& action, const refract::Registry& registry) {
+    NodeInfoByValue<Asset> renderPayloadSchema(const NodeInfo<snowcrash::Payload>& payload,
+                                               const NodeInfo<snowcrash::Action>& action,
+                                               const refract::Registry& registry) {
 
-        NodeInfoByValue<Asset> schema = std::make_pair(payload.node->schema,
-                                                       &payload.sourceMap->schema);
+        NodeInfoByValue<Asset> schema = std::make_pair(payload.node->schema, &payload.sourceMap->schema);
+
         NodeInfo<Attributes> payloadAttributes = MAKE_NODE_INFO(payload, attributes);
         NodeInfo<Attributes> actionAttributes = MAKE_NODE_INFO(action, attributes);
 

--- a/src/Render.h
+++ b/src/Render.h
@@ -13,6 +13,8 @@
 
 namespace drafter {
 
+    const char* const JSONSchemaContentType = "application/schema+json";
+
     enum RenderFormat {
         UndefinedRenderFormat = 0,   // Undefined format
         JSONRenderFormat = 1,        // JSON format

--- a/test/fixtures/api/asset.json
+++ b/test/fixtures/api/asset.json
@@ -111,7 +111,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/api/asset.sourcemap.json
+++ b/test/fixtures/api/asset.sourcemap.json
@@ -262,7 +262,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/api/attributes-array-nested-named-type.json
+++ b/test/fixtures/api/attributes-array-nested-named-type.json
@@ -166,7 +166,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"array\"\n}"
                             }

--- a/test/fixtures/api/attributes-named-type-enum-reference.json
+++ b/test/fixtures/api/attributes-named-type-enum-reference.json
@@ -159,7 +159,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"a\": {\n      \"type\": \"string\",\n      \"enum\": [\n        \"valueB\",\n        \"valueA\"\n      ]\n    }\n  },\n  \"required\": [\n    \"a\"\n  ]\n}"
                             }

--- a/test/fixtures/api/attributes-named-type-member-reference.json
+++ b/test/fixtures/api/attributes-named-type-member-reference.json
@@ -157,7 +157,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"a\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"b\": {\n          \"type\": \"string\"\n        }\n      }\n    }\n  }\n}"
                             }

--- a/test/fixtures/api/attributes-named-type-mixin.json
+++ b/test/fixtures/api/attributes-named-type-mixin.json
@@ -174,7 +174,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"b\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/api/attributes-references.json
+++ b/test/fixtures/api/attributes-references.json
@@ -110,7 +110,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"user\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"name\": {\n          \"type\": \"string\"\n        }\n      }\n    }\n  }\n}"
                             }

--- a/test/fixtures/api/payload-attributes.json
+++ b/test/fixtures/api/payload-attributes.json
@@ -80,6 +80,9 @@
                                   "messageBodySchema"
                                 ]
                               },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                             }
                           ]

--- a/test/fixtures/api/payload-attributes.sourcemap.json
+++ b/test/fixtures/api/payload-attributes.sourcemap.json
@@ -218,6 +218,9 @@
                                   "messageBodySchema"
                                 ]
                               },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                             }
                           ]

--- a/test/fixtures/circular/array-in-object.json
+++ b/test/fixtures/circular/array-in-object.json
@@ -96,7 +96,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"string\"\n    },\n    \"data\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/circular/array.json
+++ b/test/fixtures/circular/array.json
@@ -96,7 +96,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"array\"\n}"
                             }

--- a/test/fixtures/circular/cross.json
+++ b/test/fixtures/circular/cross.json
@@ -96,7 +96,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"b\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"a\": {\n          \"type\": \"object\",\n          \"properties\": {}\n        }\n      }\n    }\n  }\n}"
                             }

--- a/test/fixtures/circular/embed.json
+++ b/test/fixtures/circular/embed.json
@@ -96,7 +96,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"b\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"b\": {\n          \"type\": \"object\",\n          \"properties\": {}\n        }\n      }\n    }\n  }\n}"
                             }

--- a/test/fixtures/circular/enum.json
+++ b/test/fixtures/circular/enum.json
@@ -96,7 +96,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"string\"\n    },\n    \"data\": {\n      \"anyOf\": [\n        {\n          \"type\": \"object\",\n          \"properties\": {}\n        },\n        {\n          \"type\": \"array\",\n          \"enum\": [\n            [\n              {}\n            ]\n          ]\n        }\n      ]\n    }\n  }\n}"
                             }

--- a/test/fixtures/circular/simple.json
+++ b/test/fixtures/circular/simple.json
@@ -96,7 +96,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"a\": {\n      \"type\": \"object\",\n      \"properties\": {}\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/array-fixed-inline-samples.json
+++ b/test/fixtures/schema/array-fixed-inline-samples.json
@@ -137,7 +137,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"address\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"city\"\n          ]\n        }\n      ]\n    }\n  },\n  \"required\": [\n    \"address\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/array-fixed-inline.json
+++ b/test/fixtures/schema/array-fixed-inline.json
@@ -129,7 +129,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"address\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"street\"\n          ]\n        },\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"city\"\n          ]\n        },\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"state\"\n          ]\n        }\n      ]\n    }\n  },\n  \"required\": [\n    \"address\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/array-fixed-samples-complex.json
+++ b/test/fixtures/schema/array-fixed-samples-complex.json
@@ -180,7 +180,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"hello\"\n          ]\n        },\n        {\n          \"type\": \"object\",\n          \"properties\": {\n            \"name\": {\n              \"type\": \"string\"\n            },\n            \"color\": {\n              \"type\": \"string\",\n              \"enum\": [\n                \"white\"\n              ]\n            },\n            \"description\": {\n              \"type\": \"string\"\n            }\n          },\n          \"required\": [\n            \"name\",\n            \"color\",\n            \"description\"\n          ],\n          \"additionalProperties\": false\n        },\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"world\"\n          ]\n        }\n      ]\n    }\n  },\n  \"required\": [\n    \"tags\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/array-fixed-samples.json
+++ b/test/fixtures/schema/array-fixed-samples.json
@@ -133,7 +133,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"string\"\n        },\n        {\n          \"type\": \"number\"\n        }\n      ]\n    }\n  },\n  \"required\": [\n    \"tags\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/array-fixed-types-only.json
+++ b/test/fixtures/schema/array-fixed-types-only.json
@@ -123,7 +123,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"string\"\n        },\n        {\n          \"type\": \"number\"\n        }\n      ]\n    }\n  },\n  \"required\": [\n    \"tags\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/array-fixed.json
+++ b/test/fixtures/schema/array-fixed.json
@@ -125,7 +125,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"hello\"\n          ]\n        },\n        {\n          \"type\": \"number\",\n          \"enum\": [\n            42\n          ]\n        }\n      ]\n    }\n  },\n  \"required\": [\n    \"tags\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/array-inline.json
+++ b/test/fixtures/schema/array-inline.json
@@ -124,7 +124,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"address\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/array-of-arrays.json
+++ b/test/fixtures/schema/array-of-arrays.json
@@ -133,7 +133,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/array-of-types-mixed-complex.json
+++ b/test/fixtures/schema/array-of-types-mixed-complex.json
@@ -146,7 +146,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/array-of-types-mixed.json
+++ b/test/fixtures/schema/array-of-types-mixed.json
@@ -120,7 +120,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/array-of-types-only.json
+++ b/test/fixtures/schema/array-of-types-only.json
@@ -118,7 +118,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/array-of-types.json
+++ b/test/fixtures/schema/array-of-types.json
@@ -120,7 +120,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/array-simple.json
+++ b/test/fixtures/schema/array-simple.json
@@ -124,7 +124,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"address\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/array-with-nested-type.json
+++ b/test/fixtures/schema/array-with-nested-type.json
@@ -127,7 +127,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"address\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/array-with-nested-types.json
+++ b/test/fixtures/schema/array-with-nested-types.json
@@ -134,7 +134,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"address\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/boolean-literal.json
+++ b/test/fixtures/schema/boolean-literal.json
@@ -128,7 +128,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"street\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"boolean\",\n          \"enum\": [\n            true\n          ]\n        },\n        {\n          \"type\": \"boolean\",\n          \"enum\": [\n            false\n          ]\n        }\n      ]\n    }\n  },\n  \"required\": [\n    \"street\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/boolean.json
+++ b/test/fixtures/schema/boolean.json
@@ -110,7 +110,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"street\": {\n      \"type\": \"boolean\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/default-attribute.json
+++ b/test/fixtures/schema/default-attribute.json
@@ -130,7 +130,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"list\": {\n      \"type\": \"string\",\n      \"enum\": [\n        \"3\",\n        \"4\"\n      ],\n      \"default\": \"4\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/default-sample.json
+++ b/test/fixtures/schema/default-sample.json
@@ -132,7 +132,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"list\": {\n      \"type\": \"array\",\n      \"default\": [\n        \"4\"\n      ]\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/default-section.json
+++ b/test/fixtures/schema/default-section.json
@@ -128,7 +128,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"list\": {\n      \"type\": \"string\",\n      \"enum\": [\n        \"3\",\n        \"4\"\n      ],\n      \"default\": \"4\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/description.json
+++ b/test/fixtures/schema/description.json
@@ -183,7 +183,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"number\",\n      \"description\": \"The unique identifier for a product\"\n    },\n    \"name\": {\n      \"type\": \"string\",\n      \"description\": \"Name of the product\"\n    },\n    \"price\": {\n      \"type\": \"number\"\n    },\n    \"tags\": {\n      \"type\": \"array\",\n      \"description\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit.\\n\\nSed sed lacus a arcu vehicula ultricies sed vel nibh. Mauris id cursus felis.\\n\\nInterdum et malesuada fames ac ante ipsum primis in faucibus.\\n\\n- unus\\n\\n- duo\\n\\n- tres\\n\\n- quattuor\\n\"\n    }\n  },\n  \"required\": [\n    \"id\",\n    \"name\",\n    \"price\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/enum-containing-enum.json
+++ b/test/fixtures/schema/enum-containing-enum.json
@@ -141,7 +141,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"enum\": {\n      \"anyOf\": [\n        {\n          \"type\": \"number\",\n          \"enum\": [\n            1,\n            2,\n            3,\n            4\n          ]\n        },\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"something\",\n            \"anything\"\n          ]\n        }\n      ]\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/enum-containing-object.json
+++ b/test/fixtures/schema/enum-containing-object.json
@@ -147,7 +147,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tag\": {\n      \"anyOf\": [\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"green\"\n          ]\n        },\n        {\n          \"type\": \"object\",\n          \"properties\": {\n            \"tag_id\": {\n              \"type\": \"string\"\n            },\n            \"label\": {\n              \"type\": \"string\"\n            }\n          }\n        }\n      ]\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/enum-containing-sample.json
+++ b/test/fixtures/schema/enum-containing-sample.json
@@ -124,7 +124,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tag\": {\n      \"anyOf\": [\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"green\"\n          ]\n        },\n        {\n          \"type\": \"number\"\n        }\n      ]\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/enum-of-strings.json
+++ b/test/fixtures/schema/enum-of-strings.json
@@ -120,7 +120,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"gender\": {\n      \"type\": \"string\",\n      \"enum\": [\n        \"male\",\n        \"female\"\n      ]\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/enum-with-type.json
+++ b/test/fixtures/schema/enum-with-type.json
@@ -124,7 +124,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"address\": {\n      \"type\": \"number\",\n      \"enum\": [\n        4,\n        2,\n        42\n      ]\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/escaping.json
+++ b/test/fixtures/schema/escaping.json
@@ -152,7 +152,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"listing\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"description\": {\n          \"type\": \"string\"\n        },\n        \"date_listed\": {\n          \"type\": \"string\"\n        },\n        \"some:location\": {\n          \"type\": \"string\"\n        }\n      },\n      \"description\": \"Our real estate listing has different properties available.\\n\\n- `Properties`\\n    - This one.\\n    - That one.\\n\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/mixin-simple.json
+++ b/test/fixtures/schema/mixin-simple.json
@@ -96,7 +96,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"string\"\n    },\n    \"device_type\": {\n      \"type\": \"string\",\n      \"description\": \"The platform. Should be `ios` or `gcm`.\"\n    },\n    \"token\": {\n      \"type\": \"string\",\n      \"description\": \"The token given by the platform.\"\n    },\n    \"links\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"user\": {\n          \"type\": \"string\"\n        }\n      }\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/number-literal.json
+++ b/test/fixtures/schema/number-literal.json
@@ -132,7 +132,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"street\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"number\",\n          \"enum\": [\n            0\n          ]\n        },\n        {\n          \"type\": \"number\",\n          \"enum\": [\n            1.5\n          ]\n        },\n        {\n          \"type\": \"number\",\n          \"enum\": [\n            340\n          ]\n        }\n      ]\n    }\n  },\n  \"required\": [\n    \"street\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/number.json
+++ b/test/fixtures/schema/number.json
@@ -110,7 +110,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"street\": {\n      \"type\": \"number\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/object-complex.json
+++ b/test/fixtures/schema/object-complex.json
@@ -208,7 +208,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"string\"\n    },\n    \"name\": {\n      \"type\": \"string\"\n    },\n    \"price\": {\n      \"type\": \"number\"\n    },\n    \"tags\": {\n      \"type\": \"array\"\n    },\n    \"vector\": {\n      \"type\": \"array\"\n    },\n    \"available\": {\n      \"type\": \"boolean\"\n    }\n  },\n  \"required\": [\n    \"id\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/object-fixed-optional.json
+++ b/test/fixtures/schema/object-fixed-optional.json
@@ -146,7 +146,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"person\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"first_name\": {\n          \"type\": \"string\"\n        },\n        \"last_name\": {\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"first_name\"\n      ],\n      \"additionalProperties\": false\n    }\n  },\n  \"required\": [\n    \"person\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/object-fixed-values.json
+++ b/test/fixtures/schema/object-fixed-values.json
@@ -143,7 +143,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"person\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"first_name\": {\n          \"type\": \"string\",\n          \"enum\": [\n            \"Andrew\"\n          ]\n        },\n        \"last_name\": {\n          \"type\": \"string\",\n          \"enum\": [\n            \"Smith\"\n          ]\n        }\n      },\n      \"required\": [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"additionalProperties\": false\n    }\n  },\n  \"required\": [\n    \"person\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/object-fixed.json
+++ b/test/fixtures/schema/object-fixed.json
@@ -141,7 +141,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"person\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"first_name\": {\n          \"type\": \"string\"\n        },\n        \"last_name\": {\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"additionalProperties\": false\n    }\n  },\n  \"required\": [\n    \"person\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/object-simple.json
+++ b/test/fixtures/schema/object-simple.json
@@ -153,7 +153,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"address\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"street\": {\n          \"type\": \"string\"\n        },\n        \"city\": {\n          \"type\": \"string\"\n        },\n        \"state\": {\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"state\"\n      ]\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/object-very-complex.json
+++ b/test/fixtures/schema/object-very-complex.json
@@ -325,7 +325,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"string\"\n    },\n    \"name\": {\n      \"type\": \"string\"\n    },\n    \"price\": {\n      \"type\": \"number\"\n    },\n    \"tags\": {\n      \"type\": \"array\"\n    },\n    \"vector\": {\n      \"type\": \"array\"\n    },\n    \"address\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"street\": {\n          \"type\": \"string\"\n        },\n        \"number\": {\n          \"type\": \"number\"\n        },\n        \"zip_code\": {\n          \"type\": \"string\"\n        },\n        \"state\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"name\": {\n              \"type\": \"string\"\n            },\n            \"code\": {\n              \"type\": \"string\"\n            }\n          }\n        },\n        \"country\": {\n          \"type\": \"string\",\n          \"enum\": [\n            \"Czech Republic\",\n            \"United States of America\"\n          ]\n        }\n      },\n      \"required\": [\n        \"street\",\n        \"number\",\n        \"zip_code\",\n        \"country\"\n      ]\n    }\n  },\n  \"required\": [\n    \"id\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/optional.json
+++ b/test/fixtures/schema/optional.json
@@ -115,7 +115,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"street\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/required-array.json
+++ b/test/fixtures/schema/required-array.json
@@ -120,7 +120,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"digits\": {\n      \"type\": \"array\"\n    }\n  },\n  \"required\": [\n    \"digits\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/required-object.json
+++ b/test/fixtures/schema/required-object.json
@@ -130,7 +130,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"items\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"count\": {\n          \"type\": \"string\"\n        }\n      }\n    }\n  },\n  \"required\": [\n    \"items\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/required.json
+++ b/test/fixtures/schema/required.json
@@ -115,7 +115,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"street\": {\n      \"type\": \"string\"\n    }\n  },\n  \"required\": [\n    \"street\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/sample-complex.json
+++ b/test/fixtures/schema/sample-complex.json
@@ -130,7 +130,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"colors\": {\n      \"type\": \"array\"\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/sample-inline-attribute.json
+++ b/test/fixtures/schema/sample-inline-attribute.json
@@ -124,7 +124,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"list\": {}\n  }\n}"
                             }

--- a/test/fixtures/schema/sample-inline-variable.json
+++ b/test/fixtures/schema/sample-inline-variable.json
@@ -120,7 +120,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"list\": {\n      \"type\": \"string\",\n      \"enum\": [\n        \"*3\",\n        \"4*\"\n      ]\n    }\n  }\n}"
                             }

--- a/test/fixtures/schema/sample.json
+++ b/test/fixtures/schema/sample.json
@@ -124,7 +124,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"list\": {}\n  }\n}"
                             }

--- a/test/fixtures/schema/string-literal.json
+++ b/test/fixtures/schema/string-literal.json
@@ -128,7 +128,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"street\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"bye bye\"\n          ]\n        },\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"san francisco\"\n          ]\n        }\n      ]\n    }\n  },\n  \"required\": [\n    \"street\"\n  ]\n}"
                             }

--- a/test/fixtures/schema/string.json
+++ b/test/fixtures/schema/string.json
@@ -110,7 +110,7 @@
                                 ]
                               },
                               "attributes": {
-                                "contentType": "application/json"
+                                "contentType": "application/schema+json"
                               },
                               "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"street\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                             }


### PR DESCRIPTION
This PR fixes the content type of generated `messageBodySchema` element.