### PR TITLE
Handle JSON Schema rendering for messageBody

### DIFF
--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -277,9 +277,15 @@ namespace drafter {
         std::string contentType = getContentTypeFromHeaders(payload.node->headers);
         std::string schemaContentType = (payload.node->schema == payloadSchema.first ? contentType : JSONSchemaContentType);
 
-        // Assets
+        // Push Body Asset
         content.push_back(AssetToRefract(NodeInfo<snowcrash::Asset>(payloadBody), contentType, SerializeKey::MessageBody));
-        content.push_back(AssetToRefract(NodeInfo<snowcrash::Asset>(payloadSchema), schemaContentType, SerializeKey::MessageBodySchema));
+
+        // Push BodySchema Asset if body is not JSON Schema already
+        RenderFormat renderFormat = findRenderFormat(contentType);
+
+        if (renderFormat != JSONSchemaRenderFormat) {
+            content.push_back(AssetToRefract(NodeInfo<snowcrash::Asset>(payloadSchema), schemaContentType, SerializeKey::MessageBodySchema));
+        }
 
         RemoveEmptyElements(content);
         element->set(content);

--- a/src/Render.cc
+++ b/src/Render.cc
@@ -8,6 +8,8 @@
 
 #include "Render.h"
 #include "RefractDataStructure.h"
+
+#include "SourceAnnotation.h"
 #include "BlueprintUtility.h"
 #include "RegexMatch.h"
 
@@ -100,14 +102,10 @@ namespace drafter {
 
                 return std::make_pair(result, NodeInfo<Asset>::NullSourceMap());
             }
-
-            default:
-                break;
         }
 
-        // Just to be cautious
-        delete expanded;
-        return body;
+        // Throw exception
+        throw snowcrash::Error("unknown content type for messageBody to be rendered", snowcrash::ApplicationError);
     }
 
     NodeInfoByValue<Asset> renderPayloadSchema(const NodeInfo<snowcrash::Payload>& payload,

--- a/test/fixtures/api/schema-body.apib
+++ b/test/fixtures/api/schema-body.apib
@@ -1,0 +1,11 @@
+# API name
+
+# Group Users
+
+## User [/users]
+
+### List all users [GET]
+
++ Response 200 (application/schema+json ; hello=world)
+    + Attributes
+        + username: pavan

--- a/test/fixtures/api/schema-body.json
+++ b/test/fixtures/api/schema-body.json
@@ -1,0 +1,119 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "API name"
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": "Users"
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": "User"
+              },
+              "attributes": {
+                "href": "/users"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "List all users"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/schema+json ; hello=world"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "dataStructure",
+                              "content": [
+                                {
+                                  "element": "object",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "username"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "content": "pavan"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json ; hello=world"
+                              },
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    }\n  }\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/api/schema-body.sourcemap.json
+++ b/test/fixtures/api/schema-body.sourcemap.json
@@ -1,0 +1,270 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": {
+          "element": "string",
+          "attributes": {
+            "sourceMap": [
+              {
+                "element": "sourceMap",
+                "content": [
+                  [
+                    0,
+                    12
+                  ]
+                ]
+              }
+            ]
+          },
+          "content": "API name"
+        }
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": {
+              "element": "string",
+              "attributes": {
+                "sourceMap": [
+                  {
+                    "element": "sourceMap",
+                    "content": [
+                      [
+                        12,
+                        15
+                      ]
+                    ]
+                  }
+                ]
+              },
+              "content": "Users"
+            }
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "attributes": {
+                    "sourceMap": [
+                      {
+                        "element": "sourceMap",
+                        "content": [
+                          [
+                            27,
+                            18
+                          ]
+                        ]
+                      }
+                    ]
+                  },
+                  "content": "User"
+                }
+              },
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "attributes": {
+                    "sourceMap": [
+                      {
+                        "element": "sourceMap",
+                        "content": [
+                          [
+                            27,
+                            18
+                          ]
+                        ]
+                      }
+                    ]
+                  },
+                  "content": "/users"
+                }
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": {
+                      "element": "string",
+                      "attributes": {
+                        "sourceMap": [
+                          {
+                            "element": "sourceMap",
+                            "content": [
+                              [
+                                45,
+                                26
+                              ]
+                            ]
+                          }
+                        ]
+                      },
+                      "content": "List all users"
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": {
+                              "element": "string",
+                              "attributes": {
+                                "sourceMap": [
+                                  {
+                                    "element": "sourceMap",
+                                    "content": [
+                                      [
+                                        45,
+                                        26
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              },
+                              "content": "GET"
+                            }
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": {
+                              "element": "string",
+                              "attributes": {
+                                "sourceMap": [
+                                  {
+                                    "element": "sourceMap",
+                                    "content": [
+                                      [
+                                        73,
+                                        53
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              },
+                              "content": "200"
+                            },
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "attributes": {
+                                    "sourceMap": [
+                                      {
+                                        "element": "sourceMap",
+                                        "content": [
+                                          [
+                                            73,
+                                            53
+                                          ]
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/schema+json ; hello=world"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "dataStructure",
+                              "content": [
+                                {
+                                  "element": "object",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "attributes": {
+                                            "sourceMap": [
+                                              {
+                                                "element": "sourceMap",
+                                                "content": [
+                                                  [
+                                                    153,
+                                                    16
+                                                  ]
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          "content": "username"
+                                        },
+                                        "value": {
+                                          "element": "string",
+                                          "attributes": {
+                                            "sourceMap": [
+                                              {
+                                                "element": "sourceMap",
+                                                "content": [
+                                                  [
+                                                    153,
+                                                    16
+                                                  ]
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          "content": "pavan"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json ; hello=world"
+                              },
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    }\n  }\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test-RefractAPITest.cc
+++ b/test/test-RefractAPITest.cc
@@ -20,6 +20,7 @@ TEST_REFRACT("api", "action-parameters");
 TEST_REFRACT("api", "request-parameters");
 TEST_REFRACT("api", "request-only");
 TEST_REFRACT("api", "asset");
+TEST_REFRACT("api", "schema-body");
 TEST_REFRACT("api", "attributes-references");
 TEST_REFRACT("api", "action-request-attributes");
 

--- a/test/test-RefractSourceMapTest.cc
+++ b/test/test-RefractSourceMapTest.cc
@@ -19,4 +19,5 @@ TEST_REFRACT_SOURCE_MAP("api", "resource-parameters");
 TEST_REFRACT_SOURCE_MAP("api", "action-parameters");
 TEST_REFRACT_SOURCE_MAP("api", "request-parameters");
 TEST_REFRACT_SOURCE_MAP("api", "asset");
+TEST_REFRACT_SOURCE_MAP("api", "schema-body");
 TEST_REFRACT_SOURCE_MAP("api", "mson");


### PR DESCRIPTION
This PR handles the case where a user might give the content type of a messageBody to be `application/schema+json`.