### PR TITLE
Handle `UndefinedRenderFormat` in switch statement

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ test:
   pre:
     - ./configure -i
   override:
-    - make test
+    - env CXXFLAGS="-Werror" make test
     - docker run -v $(pwd):/src -t apiaryio/base-emscripten-dev emcc/emcbuild.sh
     - npm test
 

--- a/src/Render.cc
+++ b/src/Render.cc
@@ -102,6 +102,9 @@ namespace drafter {
 
                 return std::make_pair(result, NodeInfo<Asset>::NullSourceMap());
             }
+
+            case UndefinedRenderFormat:
+                break;
         }
 
         // Throw exception


### PR DESCRIPTION
This pull request fixes a warning introduced by #234 by handling the `UndefinedRenderFormat` case in a switch statement.

I've also added the `CXXFLAG` `-Werror` in CI so we treat warnings as errors during out CI. This allows us to prevent warnings being introduced into master, but also allows people to still compile Drafter providing there are warnings introduced.