### PR TITLE
Only generate JSON Schema for JSON responses

### DIFF
--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -283,7 +283,7 @@ namespace drafter {
         // Push BodySchema Asset if body is not JSON Schema already
         RenderFormat renderFormat = findRenderFormat(contentType);
 
-        if (renderFormat != JSONSchemaRenderFormat) {
+        if (renderFormat == JSONRenderFormat) {
             content.push_back(AssetToRefract(NodeInfo<snowcrash::Asset>(payloadSchema), schemaContentType, SerializeKey::MessageBodySchema));
         }
 

--- a/test/fixtures/api/payload-attributes.json
+++ b/test/fixtures/api/payload-attributes.json
@@ -72,18 +72,6 @@
                                   ]
                                 }
                               ]
-                            },
-                            {
-                              "element": "asset",
-                              "meta": {
-                                "classes": [
-                                  "messageBodySchema"
-                                ]
-                              },
-                              "attributes": {
-                                "contentType": "application/schema+json"
-                              },
-                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                             }
                           ]
                         }

--- a/test/fixtures/api/payload-attributes.sourcemap.json
+++ b/test/fixtures/api/payload-attributes.sourcemap.json
@@ -210,18 +210,6 @@
                                   ]
                                 }
                               ]
-                            },
-                            {
-                              "element": "asset",
-                              "meta": {
-                                "classes": [
-                                  "messageBodySchema"
-                                ]
-                              },
-                              "attributes": {
-                                "contentType": "application/schema+json"
-                              },
-                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"username\": {\n      \"type\": \"string\"\n    }\n  }\n}"
                             }
                           ]
                         }


### PR DESCRIPTION
We should not be rendering JSON Schema's when the content-type is not JSON.

Here's examples:

```apib
+ Response 200
    + Attributes
        + name: kyle

+ Response 200 (application/xml)
    + Attributes
        + name: kyle
```