### PR TITLE
Support for MSVS2015

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Always use LF for .apib files
+*.apib text eol=lf

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,11 @@
 version: 1.0.{build}
 
+# Operating system (build VM template)
+os: Visual Studio 2015 CTP
+
 environment:
   matrix:
-#   - VS_VERSION: MSVC2012
-    - VS_VERSION: MSVC2013
+    - VS_VERSION: MSVC2015
 
 build_script:
   - git submodule update --init --recursive

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -36,6 +36,7 @@ if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
 if /i "%1"=="nobuild"       set nobuild=1&goto arg-ok
 if /i "%1"=="test"          set test=test&goto arg-ok
 if /i "%1"=="inttest"       set inttest=1&goto arg-ok
+if /i "%1"=="MSVC2015"      set GYP_MSVS_VERSION=2015&goto arg-ok
 if /i "%1"=="MSVC2013"      set GYP_MSVS_VERSION=2013&goto arg-ok
 if /i "%1"=="MSVC2012"      set GYP_MSVS_VERSION=2012&goto arg-ok
 if /i "%1"=="MSVC2010"      set GYP_MSVS_VERSION=2010&goto arg-ok
@@ -71,11 +72,20 @@ ENDLOCAL
 :msbuild
 @rem Skip project generation if requested.
 if defined nobuild goto exit
+if "%GYP_MSVS_VERSION%"=="2013" goto vc-set-2013
 if "%GYP_MSVS_VERSION%"=="2012" goto vc-set-2012
 if "%GYP_MSVS_VERSION%"=="2010" goto vc-set-2010
 if "%GYP_MSVS_VERSION%"=="2008" goto vc-set-2008
 
-@rem Look for Visual Studio 2013
+
+@rem MSVS 2015 is VS14
+if not defined VS140COMNTOOLS goto vc-set-2013
+if not exist "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2013
+call "%VS140COMNTOOLS%\..\..\vc\vcvarsall.bat"
+if not defined VCINSTALLDIR goto msbuild-not-found
+goto msbuild-found
+
+:vc-set-2013
 if not defined VS120COMNTOOLS goto vc-set-2012
 if not exist "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat" goto vc-set-2012
 call "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat"


### PR DESCRIPTION
## Support for MSVS2015

This PR updates Snow Crash to the latest master in order to bring updated GYP version to support Microsoft Visual Studio 2015 (Microsoft Visual C++ 2015).

In addition it updates the Windows batch build file to support the `MSVC2015` option. The `.gitattributes` file is introduced to preserve LF line endings on Windows systems. Finally, the AppVeyor configuration has been changed to use the Visual Studio 2015 CTP image instead of previous Windows Server 2012.