### PR TITLE
SourceMaps always from SC

### DIFF
--- a/src/NamedTypesRegistry.cc
+++ b/src/NamedTypesRegistry.cc
@@ -26,13 +26,13 @@ namespace drafter {
             for (NodeInfoCollection<snowcrash::Elements>::const_iterator i = elements.begin(); i != elements.end(); ++i) {
 
                 if (i->node->element == snowcrash::Element::DataStructureElement) {
-                    found.push_back(MakeNodeInfo(i->node->content.dataStructure, i->sourceMap->content.dataStructure, i->hasSourceMap()));
+                    found.push_back(MakeNodeInfo(i->node->content.dataStructure, i->sourceMap->content.dataStructure));
                 }
                 else if (!i->node->content.resource.attributes.empty()) {
-                    found.push_back(MakeNodeInfo(i->node->content.resource.attributes, i->sourceMap->content.resource.attributes, i->hasSourceMap()));
+                    found.push_back(MakeNodeInfo(i->node->content.resource.attributes, i->sourceMap->content.resource.attributes));
                 }
                 else if (i->node->element == snowcrash::Element::CategoryElement) {
-                    NodeInfoCollection<snowcrash::Elements> children(MakeNodeInfo(i->node->content.elements(), i->sourceMap->content.elements(), i->hasSourceMap()));
+                    NodeInfoCollection<snowcrash::Elements> children(MakeNodeInfo(i->node->content.elements(), i->sourceMap->content.elements()));
                     FindNamedTypes(children, found);
                 }
             }

--- a/src/NodeInfo.h
+++ b/src/NodeInfo.h
@@ -13,7 +13,7 @@
 #include <algorithm>
 
 #define NODE_INFO(from, member) from.node->member, from.sourceMap->member
-#define MAKE_NODE_INFO(from, member) MakeNodeInfo(NODE_INFO(from, member), from.hasSourceMap())
+#define MAKE_NODE_INFO(from, member) MakeNodeInfo(NODE_INFO(from, member))
 
 namespace drafter {
 
@@ -67,8 +67,8 @@ namespace drafter {
             return &nullSourceMap;
         }
 
-        bool isNull() const { 
-            return empty; 
+        bool isNull() const {
+            return empty;
         }
 
         bool hasSourceMap() const {
@@ -78,15 +78,15 @@ namespace drafter {
     };
 
     template <typename T>
-    NodeInfo<T> MakeNodeInfo(const T& node, const snowcrash::SourceMap<T>& sourceMap, const bool hasSourceMap)
+    NodeInfo<T> MakeNodeInfo(const T& node, const snowcrash::SourceMap<T>& sourceMap)
     {
-        return NodeInfo<T>(&node, hasSourceMap ? &sourceMap : NodeInfo<T>::NullSourceMap());
+        return NodeInfo<T>(&node, &sourceMap);
     }
 
     template <typename T>
-    NodeInfo<T> MakeNodeInfo(const T* node, const snowcrash::SourceMap<T>* sourceMap, const bool hasSourceMap)
+    NodeInfo<T> MakeNodeInfo(const T* node, const snowcrash::SourceMap<T>* sourceMap)
     {
-        return NodeInfo<T>(node, hasSourceMap ? sourceMap : NodeInfo<T>::NullSourceMap());
+        return NodeInfo<T>(node, sourceMap);
     }
 
     template <typename T>
@@ -123,8 +123,8 @@ namespace drafter {
                 std::copy(nodes.begin(), nodes.end(), std::back_inserter(*this));
             }
             else {
-                std::transform(collection.begin(), collection.end(), 
-                               std::back_inserter(*this), 
+                std::transform(collection.begin(), collection.end(),
+                               std::back_inserter(*this),
                                MakeNodeInfoWithoutSourceMap<typename T::value_type>);
             }
         }
@@ -137,8 +137,8 @@ namespace drafter {
                 std::copy(nodes.begin(), nodes.end(), std::back_inserter(*this));
             }
             else {
-                std::transform(collection.begin(), collection.end(), 
-                               std::back_inserter(*this), 
+                std::transform(collection.begin(), collection.end(),
+                               std::back_inserter(*this),
                                MakeNodeInfoWithoutSourceMap<typename T::value_type>);
             }
         }

--- a/src/NodeInfo.h
+++ b/src/NodeInfo.h
@@ -70,11 +70,6 @@ namespace drafter {
         bool isNull() const {
             return empty;
         }
-
-        bool hasSourceMap() const {
-            const SourceMapType* null = NullSourceMap();
-            return sourceMap != null;
-        }
     };
 
     template <typename T>

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -443,7 +443,7 @@ namespace drafter {
         }
 
         if (!element.node->content.elements().empty()) {
-            const NodeInfo<snowcrash::Elements> elementsNodeInfo = MakeNodeInfo(&element.node->content.elements(), GetElementChildrenSourceMap(element), element.hasSourceMap());
+            const NodeInfo<snowcrash::Elements> elementsNodeInfo = MakeNodeInfo(&element.node->content.elements(), GetElementChildrenSourceMap(element));
 
             NodeInfoToElements(elementsNodeInfo, ElementToRefract, content);
         }

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -517,11 +517,7 @@ namespace drafter {
             template <typename S>
             void operator()(S& storage, const NodeInfo<mson::ValueMember>& valueMember) {
                 snowcrash::SourceMap<typename T::ValueType> sourceMap = *NodeInfo<typename T::ValueType>::NullSourceMap();
-
-                // if (valueMember.hasSourceMap()) {
                 sourceMap.sourceMap = valueMember.sourceMap->valueDefinition.sourceMap;
-//                }
-
                 storage.push_back(sourceMap);
             }
         };

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -310,10 +310,6 @@ namespace drafter {
         struct FetchSourceMap {
             snowcrash::SourceMap<U> operator()(const NodeInfo<mson::TypeSection>& typeSection, const mson::BaseTypeName& defaultNestedType) {
                 // conversion of source map from "string" into "typed" sourcemap
-                if (!typeSection.hasSourceMap()) {
-                    return *NodeInfo<U>::NullSourceMap();
-                }
-
                 snowcrash::SourceMap<U> sourceMap;
                 sourceMap.sourceMap = typeSection.sourceMap->value.sourceMap;
                 return sourceMap;
@@ -522,9 +518,9 @@ namespace drafter {
             void operator()(S& storage, const NodeInfo<mson::ValueMember>& valueMember) {
                 snowcrash::SourceMap<typename T::ValueType> sourceMap = *NodeInfo<typename T::ValueType>::NullSourceMap();
 
-                if (valueMember.hasSourceMap()) {
-                    sourceMap.sourceMap = valueMember.sourceMap->valueDefinition.sourceMap;
-                }
+                // if (valueMember.hasSourceMap()) {
+                sourceMap.sourceMap = valueMember.sourceMap->valueDefinition.sourceMap;
+//                }
 
                 storage.push_back(sourceMap);
             }
@@ -661,23 +657,20 @@ namespace drafter {
 
         template <typename T>
         struct MakeNodeInfoFunctor {
-            const bool hasSourceMap;
-            MakeNodeInfoFunctor(bool hasSourceMap) : hasSourceMap(hasSourceMap) {}
-
             NodeInfo<T> operator()(const T& v, const snowcrash::SourceMap<T>& sm) {
                 return MakeNodeInfo<T>(v, sm);
             }
         };
 
         template<typename T>
-        void TransformElementData(T* element, ElementData<T>& data, bool hasSourceMap) {
+        void TransformElementData(T* element, ElementData<T>& data) {
 
             if (data.values.size() != data.valuesSourceMap.size()) {
                 throw snowcrash::Error("count of source maps is not equal to count of elements");
             }
 
             typedef std::vector<NodeInfo< typename T::ValueType> > ValueNodeInfoCollection;
-            ValueNodeInfoCollection valuesNodeInfo = Zip<ValueNodeInfoCollection>(data.values, data.valuesSourceMap, MakeNodeInfoFunctor<typename T::ValueType>(hasSourceMap));
+            ValueNodeInfoCollection valuesNodeInfo = Zip<ValueNodeInfoCollection>(data.values, data.valuesSourceMap, MakeNodeInfoFunctor<typename T::ValueType>());
 
             std::for_each(valuesNodeInfo.begin(), valuesNodeInfo.end(), Append<T>(element));
 
@@ -743,7 +736,7 @@ namespace drafter {
             data.valuesSourceMap.erase(data.valuesSourceMap.begin());
         }
 
-        TransformElementData(element, data, value.hasSourceMap());
+        TransformElementData(element, data);
 
         return element;
     }
@@ -1030,7 +1023,7 @@ namespace drafter {
 
         std::for_each(typeSections.begin(), typeSections.end(), ExtractTypeSection<T>(data, ds));
 
-        TransformElementData<T>(element, data, ds.hasSourceMap());
+        TransformElementData<T>(element, data);
 
         if (refract::IElement* description = DescriptionToRefract(data)) {
             element->meta[SerializeKey::Description] = description;

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -1100,13 +1100,13 @@ namespace drafter {
         return element;
     }
 
-    sos::Object SerializeRefract(refract::IElement* element)
+    sos::Object SerializeRefract(refract::IElement* element, bool exportSourceMap /* = true*/)
     {
         if (!element) {
             return sos::Object();
         }
 
-        refract::SerializeVisitor serializer;
+        refract::SerializeVisitor serializer(exportSourceMap);
         serializer.visit(*element);
 
         return serializer.get();

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -301,8 +301,7 @@ namespace drafter {
         struct Fetch<RefractElements, dummy> {
             RefractElements operator()(const NodeInfo<mson::TypeSection>& typeSection, const mson::BaseTypeName& defaultNestedType) {
                 return MsonElementsToRefract(MakeNodeInfo(typeSection.node->content.elements(),
-                                                          typeSection.sourceMap->elements(),
-                                                          typeSection.hasSourceMap()),
+                                                          typeSection.sourceMap->elements()),
                                              defaultNestedType);
             }
         };
@@ -666,7 +665,7 @@ namespace drafter {
             MakeNodeInfoFunctor(bool hasSourceMap) : hasSourceMap(hasSourceMap) {}
 
             NodeInfo<T> operator()(const T& v, const snowcrash::SourceMap<T>& sm) {
-                return MakeNodeInfo<T>(v, sm, hasSourceMap);
+                return MakeNodeInfo<T>(v, sm);
             }
         };
 
@@ -759,7 +758,7 @@ namespace drafter {
             snowcrash::SourceMap<mson::Literal> sourceMap;
             sourceMap.sourceMap.append(property.sourceMap->name.sourceMap);
 
-            refract::IElement* key = PrimitiveToRefract(MakeNodeInfo(property.node->name.literal, sourceMap, property.hasSourceMap()));
+            refract::IElement* key = PrimitiveToRefract(MakeNodeInfo(property.node->name.literal, sourceMap));
 
             element->set(key, value);
         }
@@ -783,7 +782,7 @@ namespace drafter {
                 }
             }
 
-            refract::IElement* key = PrimitiveToRefract(MakeNodeInfo(property.node->name.variable.values.begin()->literal, sourceMap, property.hasSourceMap()));
+            refract::IElement* key = PrimitiveToRefract(MakeNodeInfo(property.node->name.variable.values.begin()->literal, sourceMap));
 
             key->attributes[SerializeKey::Variable] = refract::IElement::Create(true);
 
@@ -844,7 +843,7 @@ namespace drafter {
         }
 
         if (!description.empty()) {
-            element->meta[SerializeKey::Description] = PrimitiveToRefract(MakeNodeInfo(description, sourceMap, property.hasSourceMap()));
+            element->meta[SerializeKey::Description] = PrimitiveToRefract(MakeNodeInfo(description, sourceMap));
         }
 
         return element;
@@ -955,7 +954,7 @@ namespace drafter {
             // we can not use MsonElementToRefract() for groups,
             // "option" element handles directly all elements in group
             if (it->node->klass == mson::Element::GroupClass) {
-                option->set(MsonElementsToRefract(MakeNodeInfo(it->node->content.elements(), it->sourceMap->elements(), it->hasSourceMap())));
+                option->set(MsonElementsToRefract(MakeNodeInfo(it->node->content.elements(), it->sourceMap->elements())));
             }
             else {
                 option->push_back(MsonElementToRefract(*it, mson::StringTypeName));
@@ -988,16 +987,16 @@ namespace drafter {
     {
         switch (mse.node->klass) {
             case mson::Element::PropertyClass:
-                return MsonMemberToRefract<PropertyTrait>(MakeNodeInfo(mse.node->content.property, mse.sourceMap->property, mse.hasSourceMap()), defaultNestedType);
+                return MsonMemberToRefract<PropertyTrait>(MakeNodeInfo(mse.node->content.property, mse.sourceMap->property), defaultNestedType);
 
             case mson::Element::ValueClass:
-                return MsonMemberToRefract<ValueTrait>(MakeNodeInfo(mse.node->content.value, mse.sourceMap->value, mse.hasSourceMap()), defaultNestedType);
+                return MsonMemberToRefract<ValueTrait>(MakeNodeInfo(mse.node->content.value, mse.sourceMap->value), defaultNestedType);
 
             case mson::Element::MixinClass:
-                return MsonMixinToRefract(MakeNodeInfo(mse.node->content.mixin, mse.sourceMap->mixin, mse.hasSourceMap()));
+                return MsonMixinToRefract(MakeNodeInfo(mse.node->content.mixin, mse.sourceMap->mixin));
 
             case mson::Element::OneOfClass:
-                return MsonOneofToRefract(MakeNodeInfo(mse.node->content.oneOf(), mse.sourceMap->oneOf(), mse.hasSourceMap()));
+                return MsonOneofToRefract(MakeNodeInfo(mse.node->content.oneOf(), mse.sourceMap->oneOf()));
 
             case mson::Element::GroupClass:
                 throw snowcrash::Error("unable to handle element group", snowcrash::MSONError);
@@ -1019,7 +1018,7 @@ namespace drafter {
         if (!ds.node->name.symbol.literal.empty()) {
             snowcrash::SourceMap<mson::Literal> sourceMap = *NodeInfo<mson::Literal>::NullSourceMap();
             sourceMap.sourceMap.append(ds.sourceMap->name.sourceMap);
-            element->meta[SerializeKey::Id] = PrimitiveToRefract(MakeNodeInfo(ds.node->name.symbol.literal, sourceMap, ds.hasSourceMap()));
+            element->meta[SerializeKey::Id] = PrimitiveToRefract(MakeNodeInfo(ds.node->name.symbol.literal, sourceMap));
         }
 
         ElementData<T> data;

--- a/src/RefractDataStructure.h
+++ b/src/RefractDataStructure.h
@@ -16,7 +16,7 @@ namespace drafter {
     refract::IElement* MSONToRefract(const NodeInfo<snowcrash::DataStructure>& dataStructure);
     refract::IElement* ExpandRefract(refract::IElement*, const refract::Registry&);
 
-    sos::Object SerializeRefract(refract::IElement*);
+    sos::Object SerializeRefract(refract::IElement*, bool exportSourceMap = true);
 
 }
 

--- a/src/RefractSourceMap.h
+++ b/src/RefractSourceMap.h
@@ -19,7 +19,7 @@ namespace drafter {
     template<typename T>
     void AttachSourceMap(refract::IElement* element, const T& nodeInfo)
     {
-        if (nodeInfo.hasSourceMap() && !nodeInfo.sourceMap->sourceMap.empty()) {
+        if (!nodeInfo.sourceMap->sourceMap.empty()) {
             element->attributes[SerializeKey::SourceMap] = SourceMapToRefract(nodeInfo.sourceMap->sourceMap);
             element->renderType(refract::IElement::rFull);
         }

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -813,7 +813,7 @@ sos::Object drafter::WrapBlueprint(const snowcrash::ParseResult<snowcrash::Bluep
         ExpandMSON = expandMSON;
         bool hasSourceMap = (blueprint.node.content.elements().size() == blueprint.sourceMap.content.elements().collection.size());
 
-        RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements(), hasSourceMap));
+        RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements()));
         blueprintObject = WrapBlueprintAST(blueprint.node);
     }
     catch (std::exception& e) {

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -811,7 +811,6 @@ sos::Object drafter::WrapBlueprint(const snowcrash::ParseResult<snowcrash::Bluep
 
     try {
         ExpandMSON = expandMSON;
-        bool hasSourceMap = (blueprint.node.content.elements().size() == blueprint.sourceMap.content.elements().collection.size());
 
         RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements()));
         blueprintObject = WrapBlueprintAST(blueprint.node);

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -147,7 +147,7 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
     sos::Object result;
 
     // NOTE: can throw(), but it will be handled in main
-    result = SerializeRefract(parseResult);
+    result = SerializeRefract(parseResult, options.exportSourceMap);
 
     if (parseResult) {
         delete parseResult;

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -107,8 +107,8 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
     try {
         bool hasSourceMap = blueprint.node.content.elements().size() == blueprint.sourceMap.content.elements().collection.size();
 
-        RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements(), hasSourceMap));
-        blueprintRefract = BlueprintToRefract(MakeNodeInfo(blueprint.node, blueprint.sourceMap, options.exportSourceMap));
+        RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements()));
+        blueprintRefract = BlueprintToRefract(MakeNodeInfo(blueprint.node, blueprint.sourceMap));
     }
     catch (std::exception& e) {
         error = snowcrash::Error(e.what(), snowcrash::MSONError);
@@ -145,7 +145,7 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
     }
 
     sos::Object result;
-   
+
     // NOTE: can throw(), but it will be handled in main
     result = SerializeRefract(parseResult);
 

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -105,8 +105,6 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
     parseResult->element(SerializeKey::ParseResult);
 
     try {
-        bool hasSourceMap = blueprint.node.content.elements().size() == blueprint.sourceMap.content.elements().collection.size();
-
         RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements()));
         blueprintRefract = BlueprintToRefract(MakeNodeInfo(blueprint.node, blueprint.sourceMap));
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -52,18 +52,12 @@ int main(int argc, const char *argv[])
     Config config;
     ParseCommadLineOptions(argc, argv, config);
 
-    sc::BlueprintParserOptions options = 0;  // Or snowcrash::RequireBlueprintNameOption
-
-    if (config.sourceMap) {
-        options |= snowcrash::ExportSourcemapOption;
-    }
-
     std::stringstream inputStream;
     std::auto_ptr<std::istream> in(CreateStreamFromName<std::istream>(config.input));
     inputStream << in->rdbuf();
 
     sc::ParseResult<sc::Blueprint> blueprint;
-    sc::parse(inputStream.str(), options, blueprint);
+    sc::parse(inputStream.str(), snowcrash::ExportSourcemapOption, blueprint);
 
     sos::Serialize* serializer = CreateSerializer(config.format);
     std::ostream *out = CreateStreamFromName<std::ostream>(config.output);

--- a/src/refract/SerializeCompactVisitor.cc
+++ b/src/refract/SerializeCompactVisitor.cc
@@ -42,17 +42,17 @@ namespace refract
 
     namespace {
 
-        void SerializeValues(sos::Array& array, const RefractElements& values)
+        void SerializeValues(sos::Array& array, const RefractElements& values, bool exportSourceMap)
         {
 
             for (RefractElements::const_iterator it = values.begin(); it != values.end(); ++it) {
                 if (IsFullRender((*it))) {
-                    SerializeVisitor s;
+                    SerializeVisitor s(exportSourceMap);
                     s.visit(*(*it));
                     array.push(s.get());
                 }
                 else {
-                    SerializeCompactVisitor s;
+                    SerializeCompactVisitor s(exportSourceMap);
                     (*it)->content(s);
                     array.push(s.value());
                 }
@@ -63,21 +63,21 @@ namespace refract
     void SerializeCompactVisitor::visit(const EnumElement& e)
     {
         sos::Array array;
-        SerializeValues(array, e.value);
+        SerializeValues(array, e.value, exportSourceMap);
         value_ = array;
     }
 
     void SerializeCompactVisitor::visit(const ArrayElement& e)
     {
         sos::Array array;
-        SerializeValues(array, e.value);
+        SerializeValues(array, e.value, exportSourceMap);
         value_ = array;
     }
 
     void SerializeCompactVisitor::visit(const MemberElement& e)
     {
         if (e.value.first) {
-            SerializeCompactVisitor s;
+            SerializeCompactVisitor s(exportSourceMap);
             e.value.first->content(s);
             key_ = s.value().str;
         }
@@ -87,7 +87,7 @@ namespace refract
                 e.value.second->content(*this);
             }
             else { // value has request to be serialized in Expanded form
-                SerializeVisitor s;
+                SerializeVisitor s(exportSourceMap);
                 s.visit(*e.value.second);
                 value_ = s.get();
             }
@@ -106,7 +106,7 @@ namespace refract
             sos::Array arr;
 
             for (iterator it = e.value.begin(); it != e.value.end(); ++it) {
-                SerializeVisitor s;
+                SerializeVisitor s(exportSourceMap);
                 s.visit(*(*it));
                 arr.push(s.get());
             }
@@ -117,7 +117,7 @@ namespace refract
             sos::Object obj;
 
             for (iterator it = e.value.begin(); it != e.value.end(); ++it) {
-                SerializeCompactVisitor sv;
+                SerializeCompactVisitor sv(exportSourceMap);
                 (*it)->content(sv);
                 obj.set(sv.key(), sv.value());
             }
@@ -126,7 +126,7 @@ namespace refract
         }
     }
 
-    void SerializeCompactVisitor::visit(const ExtendElement& e) 
+    void SerializeCompactVisitor::visit(const ExtendElement& e)
     {
         throw NotImplemented("ExtendElement serialization Not Implemented");
     }

--- a/src/refract/SerializeCompactVisitor.h
+++ b/src/refract/SerializeCompactVisitor.h
@@ -21,9 +21,11 @@ namespace refract
     {
         std::string key_;
         sos::Base value_;
+        bool exportSourceMap;
 
     public:
-
+        SerializeCompactVisitor() : exportSourceMap(true) {}
+        SerializeCompactVisitor(bool exportSourceMap) : exportSourceMap(exportSourceMap) {}
         void visit(const IElement& e);
         void visit(const NullElement& e);
         void visit(const StringElement& e);

--- a/src/refract/SerializeVisitor.cc
+++ b/src/refract/SerializeVisitor.cc
@@ -7,7 +7,6 @@
 //
 #include "Element.h"
 #include "Visitors.h"
-#include <iostream>
 
 namespace refract
 {
@@ -21,6 +20,7 @@ namespace refract
             sos::Object result;
 
             for (iterator it = collection.begin(); it != collection.end(); ++it) {
+
                 if (!exportSourceMap) {
                     StringElement* str = TypeQueryVisitor::as<StringElement>((*it)->value.first);
                     if (str && str->value == "sourceMap"){

--- a/src/refract/SerializeVisitor.h
+++ b/src/refract/SerializeVisitor.h
@@ -23,12 +23,14 @@ namespace refract
         sos::Object result;
         sos::Base partial;
         std::string key;
+        bool exportSourceMap;
+
 
         static void SetSerializerValue(SerializeVisitor& s, sos::Base& value);
 
      public:
 
-        SerializeVisitor() : partial(sos::Null()) {}
+        SerializeVisitor(bool exportSourceMap) : partial(sos::Null()), exportSourceMap(exportSourceMap) {}
 
         void visit(const IElement& e);
         void visit(const NullElement& e);


### PR DESCRIPTION
drafter now always wants sourcemaps from snowcrash and filters it from the output if not requested. This is not fixing the error reports from drafter yet but is a necessary step towards it.

*Note:*
The solution is not nice at all, and needs refactoring but  in order to not spend too much time on it leaving the refactoring for later so we can plan for it.