### PR TITLE
Attach source maps to httpRequest and httpResponse

### DIFF
--- a/features/fixtures/refract.sourcemap.json
+++ b/features/fixtures/refract.sourcemap.json
@@ -611,6 +611,17 @@
                               },
                               "content": "<request name>"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    1039,
+                                    37
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [
@@ -807,6 +818,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    1242,
+                                    27
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [
@@ -1025,6 +1047,17 @@
                               },
                               "content": "<request name>"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    1039,
+                                    37
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [
@@ -1221,6 +1254,17 @@
                               },
                               "content": "201"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    1438,
+                                    14
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [
@@ -1411,6 +1455,17 @@
                               },
                               "content": "<request name>"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    1039,
+                                    37
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [
@@ -1607,6 +1662,17 @@
                               },
                               "content": "201"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    1479,
+                                    32
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [

--- a/features/fixtures/refract.sourcemap.yaml
+++ b/features/fixtures/refract.sourcemap.yaml
@@ -393,6 +393,13 @@ content:
                                       - 1039
                                       - 37
                             content: "<request name>"
+                          sourceMap:
+                            -
+                              element: "sourceMap"
+                              content:
+                                -
+                                  - 1039
+                                  - 37
                           headers:
                             element: "httpHeaders"
                             content:
@@ -520,6 +527,13 @@ content:
                                       - 1242
                                       - 27
                             content: "200"
+                          sourceMap:
+                            -
+                              element: "sourceMap"
+                              content:
+                                -
+                                  - 1242
+                                  - 27
                           headers:
                             element: "httpHeaders"
                             content:
@@ -661,6 +675,13 @@ content:
                                       - 1039
                                       - 37
                             content: "<request name>"
+                          sourceMap:
+                            -
+                              element: "sourceMap"
+                              content:
+                                -
+                                  - 1039
+                                  - 37
                           headers:
                             element: "httpHeaders"
                             content:
@@ -788,6 +809,13 @@ content:
                                       - 1438
                                       - 14
                             content: "201"
+                          sourceMap:
+                            -
+                              element: "sourceMap"
+                              content:
+                                -
+                                  - 1438
+                                  - 14
                           headers:
                             element: "httpHeaders"
                             content:
@@ -910,6 +938,13 @@ content:
                                       - 1039
                                       - 37
                             content: "<request name>"
+                          sourceMap:
+                            -
+                              element: "sourceMap"
+                              content:
+                                -
+                                  - 1039
+                                  - 37
                           headers:
                             element: "httpHeaders"
                             content:
@@ -1037,6 +1072,13 @@ content:
                                       - 1479
                                       - 32
                             content: "201"
+                          sourceMap:
+                            -
+                              element: "sourceMap"
+                              content:
+                                -
+                                  - 1479
+                                  - 32
                           headers:
                             element: "httpHeaders"
                             content:

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -249,6 +249,8 @@ namespace drafter {
             }
         }
 
+        AttachSourceMap(element, payload);
+
         // If no payload, return immediately
         if (payload.isNull()) {
             element->set(content);

--- a/test/fixtures/api/action-attributes.sourcemap.json
+++ b/test/fixtures/api/action-attributes.sourcemap.json
@@ -210,7 +210,18 @@
                                 ]
                               },
                               "content": "200"
-                            }
+                            },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    109,
+                                    14
+                                  ]
+                                ]
+                              }
+                            ]
                           },
                           "content": [
                             {

--- a/test/fixtures/api/action-parameters.sourcemap.json
+++ b/test/fixtures/api/action-parameters.sourcemap.json
@@ -230,6 +230,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    137,
+                                    33
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [

--- a/test/fixtures/api/action.sourcemap.json
+++ b/test/fixtures/api/action.sourcemap.json
@@ -176,7 +176,18 @@
                                 ]
                               },
                               "content": "200"
-                            }
+                            },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    104,
+                                    14
+                                  ]
+                                ]
+                              }
+                            ]
                           },
                           "content": [
                             {

--- a/test/fixtures/api/advanced-action.sourcemap.json
+++ b/test/fixtures/api/advanced-action.sourcemap.json
@@ -178,7 +178,18 @@
                                 ]
                               },
                               "content": "200"
-                            }
+                            },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    84,
+                                    14
+                                  ]
+                                ]
+                              }
+                            ]
                           },
                           "content": [
                             {

--- a/test/fixtures/api/asset.sourcemap.json
+++ b/test/fixtures/api/asset.sourcemap.json
@@ -160,6 +160,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    73,
+                                    32
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [

--- a/test/fixtures/api/headers.sourcemap.json
+++ b/test/fixtures/api/headers.sourcemap.json
@@ -160,6 +160,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    73,
+                                    32
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [

--- a/test/fixtures/api/payload-attributes.sourcemap.json
+++ b/test/fixtures/api/payload-attributes.sourcemap.json
@@ -160,6 +160,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    73,
+                                    32
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [

--- a/test/fixtures/api/relation.sourcemap.json
+++ b/test/fixtures/api/relation.sourcemap.json
@@ -178,7 +178,18 @@
                                 ]
                               },
                               "content": "200"
-                            }
+                            },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    91,
+                                    14
+                                  ]
+                                ]
+                              }
+                            ]
                           },
                           "content": [
                             {

--- a/test/fixtures/api/request-parameters.sourcemap.json
+++ b/test/fixtures/api/request-parameters.sourcemap.json
@@ -236,6 +236,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    188,
+                                    33
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [
@@ -364,6 +375,17 @@
                               },
                               "content": "Only one user"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    361,
+                                    22
+                                  ]
+                                ]
+                              }
+                            ],
                             "hrefVariables": {
                               "element": "hrefVariables",
                               "content": [
@@ -431,6 +453,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    423,
+                                    33
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [

--- a/test/fixtures/api/resource-parameters.sourcemap.json
+++ b/test/fixtures/api/resource-parameters.sourcemap.json
@@ -313,6 +313,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    282,
+                                    33
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [

--- a/test/fixtures/api/schema-body.sourcemap.json
+++ b/test/fixtures/api/schema-body.sourcemap.json
@@ -160,6 +160,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    73,
+                                    53
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [

--- a/test/fixtures/api/schema-custom.sourcemap.json
+++ b/test/fixtures/api/schema-custom.sourcemap.json
@@ -96,6 +96,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    11,
+                                    31
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [

--- a/test/fixtures/api/transaction.sourcemap.json
+++ b/test/fixtures/api/transaction.sourcemap.json
@@ -153,7 +153,18 @@
                                 ]
                               },
                               "content": "Normal"
-                            }
+                            },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    73,
+                                    16
+                                  ]
+                                ]
+                              }
+                            ]
                           },
                           "content": [
                             {
@@ -199,7 +210,18 @@
                                 ]
                               },
                               "content": "200"
-                            }
+                            },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    103,
+                                    14
+                                  ]
+                                ]
+                              }
+                            ]
                           },
                           "content": [
                             {

--- a/test/fixtures/api/xml-body.sourcemap.json
+++ b/test/fixtures/api/xml-body.sourcemap.json
@@ -96,6 +96,17 @@
                               },
                               "content": "200"
                             },
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "content": [
+                                  [
+                                    11,
+                                    31
+                                  ]
+                                ]
+                              }
+                            ],
                             "headers": {
                               "element": "httpHeaders",
                               "content": [


### PR DESCRIPTION
Source map info was not attached to httpRequest and httpResponse, see #259 for more info.

#### Dependencies

- [x] https://github.com/apiaryio/snowcrash/pull/376
- [x] Account for changes in Snowcrash ([removal of source map options](https://github.com/apiaryio/snowcrash/pull/369)), I believe this was intended to be addressed in https://github.com/apiaryio/drafter/pull/240, if this isn't the case I'm happy to do it.

Closes #259