### PR TITLE
Prevent recursion while converting MSON type members to refract

### DIFF
--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -892,13 +892,15 @@ namespace drafter {
                 else if (ValueHasName(input.node) || ValueHasMembers(input.node)) {
                     return Trait::template Invoke<refract::ObjectElement>(input, defaultNestedType);
                 }
+                else if (nameType != defaultNestedType) {
+                    return MsonMemberToRefract<Trait>(input, defaultNestedType, defaultNestedType);
+                }
 
-                return MsonMemberToRefract<Trait>(input, defaultNestedType, defaultNestedType);
+                return MsonMemberToRefract<Trait>(input, mson::StringTypeName, defaultNestedType);
             }
-
-            default:
-                throw snowcrash::Error("unknown type of mson member", snowcrash::MSONError, input.sourceMap->sourceMap);
         }
+
+        throw snowcrash::Error("unknown type of mson member", snowcrash::MSONError, input.sourceMap->sourceMap);
     }
 
     static refract::IElement* MsonOneofToRefract(const NodeInfo<mson::OneOf>& oneOf)

--- a/test/fixtures/mson/regression-267.apib
+++ b/test/fixtures/mson/regression-267.apib
@@ -1,0 +1,4 @@
+## Data Structures
+### Object
++ thing (optional, array[])
+    + foo: bar

--- a/test/fixtures/mson/regression-267.ast.json
+++ b/test/fixtures/mson/regression-267.ast.json
@@ -1,0 +1,54 @@
+{
+  "_version": "4.0",
+  "metadata": [],
+  "name": "",
+  "description": "",
+  "element": "category",
+  "resourceGroups": [],
+  "content": [
+    {
+      "element": "category",
+      "content": [
+        {
+          "element": "dataStructure",
+          "content": [
+            {
+              "element": "object",
+              "meta": {
+                "id": "Object"
+              },
+              "content": [
+                {
+                  "element": "member",
+                  "attributes": {
+                    "typeAttributes": [
+                      "optional"
+                    ]
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "thing"
+                    },
+                    "value": {
+                      "element": "array",
+                      "content": [
+                        {
+                          "element": "object"
+                        },
+                        {
+                          "element": "string",
+                          "content": "foo: bar"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test-RefractDataStructureTest.cc
+++ b/test/test-RefractDataStructureTest.cc
@@ -50,6 +50,7 @@ TEST_MSON_SUCCESS("reference-override");
 TEST_MSON_SUCCESS("enum-variants");
 TEST_MSON_SUCCESS("inheritance-primitive");
 TEST_MSON_SUCCESS("regression-207");
+TEST_MSON_SUCCESS("regression-267");
 
 TEST_REFRACT("mson", "variable-property-name");
 


### PR DESCRIPTION
While the type is the same as the default nested type, we would be causing recursion by calling ourself with the same arguments.

Fixes #267.

---

Perhaps there is a better solution, welcome to suggestions.