### PR TITLE
Speed up Appveyor CI time by disabling gem documentation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 
 build_script:
   - git submodule update --init --recursive
-  - gem install bundler
+  - gem install --no-document bundler
   - vcbuild.bat %VS_VERSION%
 
 test_script:


### PR DESCRIPTION
Gem install takes forever installing pointless documentation