### PR TITLE
Use generateSourceMap variable name

### DIFF
--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -1067,13 +1067,13 @@ namespace drafter {
         return element;
     }
 
-    sos::Object SerializeRefract(refract::IElement* element, bool exportSourceMap /* = true*/)
+    sos::Object SerializeRefract(refract::IElement* element, bool generateSourceMap /* = true*/)
     {
         if (!element) {
             return sos::Object();
         }
 
-        refract::SerializeVisitor serializer(exportSourceMap);
+        refract::SerializeVisitor serializer(generateSourceMap);
         serializer.visit(*element);
 
         return serializer.get();

--- a/src/RefractDataStructure.h
+++ b/src/RefractDataStructure.h
@@ -16,7 +16,7 @@ namespace drafter {
     refract::IElement* MSONToRefract(const NodeInfo<snowcrash::DataStructure>& dataStructure);
     refract::IElement* ExpandRefract(refract::IElement*, const refract::Registry&);
 
-    sos::Object SerializeRefract(refract::IElement*, bool exportSourceMap = true);
+    sos::Object SerializeRefract(refract::IElement*, bool generateSourceMap = true);
 
 }
 

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -49,17 +49,17 @@ namespace drafter {
     // Options struct for drafter
     struct WrapperOptions {
         const ASTType astType;
-        const bool exportSourceMap;
+        const bool generateSourceMap;
         const bool expandMSON;
 
-        WrapperOptions(const ASTType astType, const bool exportSourceMap, const bool expandMSON)
-        : astType(astType), exportSourceMap(exportSourceMap), expandMSON(expandMSON) {}
+        WrapperOptions(const ASTType astType, const bool generateSourceMap, const bool expandMSON)
+        : astType(astType), generateSourceMap(generateSourceMap), expandMSON(expandMSON) {}
 
-        WrapperOptions(const ASTType astType, const bool exportSourceMap)
-        : astType(astType), exportSourceMap(exportSourceMap), expandMSON(false) {}
+        WrapperOptions(const ASTType astType, const bool generateSourceMap)
+        : astType(astType), generateSourceMap(generateSourceMap), expandMSON(false) {}
 
         WrapperOptions(const ASTType astType)
-        : astType(astType), exportSourceMap(false), expandMSON(false) {}
+        : astType(astType), generateSourceMap(false), expandMSON(false) {}
     };
 
     /**

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -54,7 +54,7 @@ sos::Object WrapParseResultAST(snowcrash::ParseResult<snowcrash::Blueprint>& blu
         object.set(SerializeKey::Version, sos::String(PARSE_RESULT_SERIALIZATION_VERSION));
         object.set(SerializeKey::Ast, WrapBlueprint(blueprint, options.expandMSON));
 
-        if (options.exportSourceMap) {
+        if (options.generateSourceMap) {
             object.set(SerializeKey::Sourcemap, WrapBlueprintSourcemap(blueprint.sourceMap));
         }
     }
@@ -147,7 +147,7 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
     sos::Object result;
 
     // NOTE: can throw(), but it will be handled in main
-    result = SerializeRefract(parseResult, options.exportSourceMap);
+    result = SerializeRefract(parseResult, options.generateSourceMap);
 
     if (parseResult) {
         delete parseResult;

--- a/src/refract/SerializeCompactVisitor.cc
+++ b/src/refract/SerializeCompactVisitor.cc
@@ -16,9 +16,9 @@ namespace refract
         typedef const bool second_argument_type;
         typedef const bool result_type;
 
-        bool operator()(const IElement* element, const bool exportSourceMap) const {
+        bool operator()(const IElement* element, const bool generateSourceMap) const {
 
-            if (exportSourceMap) {
+            if (generateSourceMap) {
                 IElement::MemberElementCollection::const_iterator it = element->attributes.find("sourceMap");
                 // there is sourceMap in attributes
                 if (it != element->attributes.end()) {
@@ -57,17 +57,17 @@ namespace refract
 
     namespace {
 
-        void SerializeValues(sos::Array& array, const RefractElements& values, bool exportSourceMap)
+        void SerializeValues(sos::Array& array, const RefractElements& values, bool generateSourceMap)
         {
 
             for (RefractElements::const_iterator it = values.begin(); it != values.end(); ++it) {
-                if (IsFullRender()((*it), exportSourceMap)) {
-                    SerializeVisitor s(exportSourceMap);
+                if (IsFullRender()((*it), generateSourceMap)) {
+                    SerializeVisitor s(generateSourceMap);
                     s.visit(*(*it));
                     array.push(s.get());
                 }
                 else {
-                    SerializeCompactVisitor s(exportSourceMap);
+                    SerializeCompactVisitor s(generateSourceMap);
                     (*it)->content(s);
                     array.push(s.value());
                 }
@@ -78,31 +78,31 @@ namespace refract
     void SerializeCompactVisitor::visit(const EnumElement& e)
     {
         sos::Array array;
-        SerializeValues(array, e.value, exportSourceMap);
+        SerializeValues(array, e.value, generateSourceMap);
         value_ = array;
     }
 
     void SerializeCompactVisitor::visit(const ArrayElement& e)
     {
         sos::Array array;
-        SerializeValues(array, e.value, exportSourceMap);
+        SerializeValues(array, e.value, generateSourceMap);
         value_ = array;
     }
 
     void SerializeCompactVisitor::visit(const MemberElement& e)
     {
         if (e.value.first) {
-            SerializeCompactVisitor s(exportSourceMap);
+            SerializeCompactVisitor s(generateSourceMap);
             e.value.first->content(s);
             key_ = s.value().str;
         }
 
         if (e.value.second) {
-            if (!IsFullRender()(e.value.second, exportSourceMap)) {
+            if (!IsFullRender()(e.value.second, generateSourceMap)) {
                 e.value.second->content(*this);
             }
             else { // value has request to be serialized in Expanded form
-                SerializeVisitor s(exportSourceMap);
+                SerializeVisitor s(generateSourceMap);
                 s.visit(*e.value.second);
                 value_ = s.get();
             }
@@ -113,7 +113,7 @@ namespace refract
     {
 
         typedef ObjectElement::ValueType::const_iterator iterator;
-        iterator it = find_if(e.value.begin(), e.value.end(), std::bind2nd(IsFullRender(), exportSourceMap));
+        iterator it = find_if(e.value.begin(), e.value.end(), std::bind2nd(IsFullRender(), generateSourceMap));
 
         // if there is ANY element required to be serialized in Full
         // we must use array to serialize
@@ -121,7 +121,7 @@ namespace refract
             sos::Array arr;
 
             for (iterator it = e.value.begin(); it != e.value.end(); ++it) {
-                SerializeVisitor s(exportSourceMap);
+                SerializeVisitor s(generateSourceMap);
                 s.visit(*(*it));
                 arr.push(s.get());
             }
@@ -132,7 +132,7 @@ namespace refract
             sos::Object obj;
 
             for (iterator it = e.value.begin(); it != e.value.end(); ++it) {
-                SerializeCompactVisitor sv(exportSourceMap);
+                SerializeCompactVisitor sv(generateSourceMap);
                 (*it)->content(sv);
                 obj.set(sv.key(), sv.value());
             }

--- a/src/refract/SerializeCompactVisitor.h
+++ b/src/refract/SerializeCompactVisitor.h
@@ -21,11 +21,11 @@ namespace refract
     {
         std::string key_;
         sos::Base value_;
-        bool exportSourceMap;
+        bool generateSourceMap;
 
     public:
-        SerializeCompactVisitor() : exportSourceMap(true) {}
-        SerializeCompactVisitor(bool exportSourceMap) : exportSourceMap(exportSourceMap) {}
+        SerializeCompactVisitor() : generateSourceMap(true) {}
+        SerializeCompactVisitor(bool generateSourceMap) : generateSourceMap(generateSourceMap) {}
         void visit(const IElement& e);
         void visit(const NullElement& e);
         void visit(const StringElement& e);

--- a/src/refract/SerializeVisitor.cc
+++ b/src/refract/SerializeVisitor.cc
@@ -13,7 +13,7 @@ namespace refract
 
     namespace
     {
-        sos::Object SerializeElementCollection(const IElement::MemberElementCollection& collection, bool exportSourceMap)
+        sos::Object SerializeElementCollection(const IElement::MemberElementCollection& collection, bool generateSourceMap)
         {
             typedef IElement::MemberElementCollection::const_iterator iterator;
 
@@ -21,14 +21,14 @@ namespace refract
 
             for (iterator it = collection.begin(); it != collection.end(); ++it) {
 
-                if (!exportSourceMap) {
+                if (!generateSourceMap) {
                     StringElement* str = TypeQueryVisitor::as<StringElement>((*it)->value.first);
                     if (str && str->value == "sourceMap"){
                         continue;
                     }
                 }
 
-                SerializeCompactVisitor s(exportSourceMap);
+                SerializeCompactVisitor s(generateSourceMap);
                 s.visit(*(*it));
                 result.set(s.key(), s.value());
             }
@@ -36,28 +36,28 @@ namespace refract
             return result;
         }
 
-        sos::Object ElementToObject(const IElement* e, bool exportSourceMap)
+        sos::Object ElementToObject(const IElement* e, bool generateSourceMap)
         {
-            SerializeVisitor s(exportSourceMap);
+            SerializeVisitor s(generateSourceMap);
             s.visit(*e);
             return s.get();
         }
 
         template <typename T>
-        sos::Array SerializeValueList(const T& e, bool exportSourceMap) {
+        sos::Array SerializeValueList(const T& e, bool generateSourceMap) {
             sos::Array array;
             typedef typename T::ValueType::const_iterator iterator;
 
             for (iterator it = e.value.begin(); it != e.value.end(); ++it) {
-                array.push(ElementToObject(*it, exportSourceMap));
+                array.push(ElementToObject(*it, generateSourceMap));
             }
 
             return array;
         }
 
-        IElement::renderFlags SelectSerializationType(const IElement& e, bool exportSourceMap) {
+        IElement::renderFlags SelectSerializationType(const IElement& e, bool generateSourceMap) {
 
-            if (exportSourceMap) {
+            if (generateSourceMap) {
                 IElement::MemberElementCollection::const_iterator it = e.attributes.find("sourceMap");
                 // there is sourceMap in attributes
                 if (it != e.attributes.end()) {
@@ -77,7 +77,7 @@ namespace refract
     void SerializeVisitor::visit(const IElement& e)
     {
         result.set("element", sos::String(e.element()));
-        bool sourceMap = exportSourceMap;
+        bool sourceMap = generateSourceMap;
 
         sos::Object meta = SerializeElementCollection(e.meta, sourceMap);
         if (!meta.empty()) {
@@ -95,10 +95,10 @@ namespace refract
         if (e.empty())
             return;
 
-        const IElement::renderFlags render = SelectSerializationType(e, exportSourceMap);
+        const IElement::renderFlags render = SelectSerializationType(e, generateSourceMap);
 
         if (render == IElement::rCompact) {
-            SerializeCompactVisitor s(exportSourceMap);
+            SerializeCompactVisitor s(generateSourceMap);
             e.content(s);
             result.set("content", s.value());
         } else {
@@ -162,11 +162,11 @@ namespace refract
         sos::Object object;
 
         if (e.value.first) {
-            object.set("key", ElementToObject(e.value.first, exportSourceMap));
+            object.set("key", ElementToObject(e.value.first, generateSourceMap));
         }
 
         if (e.value.second) {
-            object.set("value", ElementToObject(e.value.second, exportSourceMap));
+            object.set("value", ElementToObject(e.value.second, generateSourceMap));
         }
 
         SetSerializerValue(*this, object);
@@ -174,25 +174,25 @@ namespace refract
 
     void SerializeVisitor::visit(const ArrayElement& e)
     {
-        sos::Array array = SerializeValueList(e, exportSourceMap);
+        sos::Array array = SerializeValueList(e, generateSourceMap);
         SetSerializerValue(*this, array);
     }
 
     void SerializeVisitor::visit(const EnumElement& e)
     {
-        sos::Array array = SerializeValueList(e, exportSourceMap);
+        sos::Array array = SerializeValueList(e, generateSourceMap);
         SetSerializerValue(*this, array);
     }
 
     void SerializeVisitor::visit(const ObjectElement& e)
     {
-        sos::Array array = SerializeValueList(e, exportSourceMap);
+        sos::Array array = SerializeValueList(e, generateSourceMap);
         SetSerializerValue(*this, array);
     }
 
     void SerializeVisitor::visit(const ExtendElement& e)
     {
-        sos::Array array = SerializeValueList(e, exportSourceMap);
+        sos::Array array = SerializeValueList(e, generateSourceMap);
         SetSerializerValue(*this, array);
     }
 

--- a/src/refract/SerializeVisitor.h
+++ b/src/refract/SerializeVisitor.h
@@ -23,14 +23,14 @@ namespace refract
         sos::Object result;
         sos::Base partial;
         std::string key;
-        bool exportSourceMap;
+        bool generateSourceMap;
 
 
         static void SetSerializerValue(SerializeVisitor& s, sos::Base& value);
 
      public:
 
-        SerializeVisitor(bool exportSourceMap) : partial(sos::Null()), exportSourceMap(exportSourceMap) {}
+        SerializeVisitor(bool generateSourceMap) : partial(sos::Null()), generateSourceMap(generateSourceMap) {}
 
         void visit(const IElement& e);
         void visit(const NullElement& e);

--- a/test/draftertest.h
+++ b/test/draftertest.h
@@ -119,13 +119,13 @@ namespace draftertest {
         static std::string getFixtureExtension(const drafter::WrapperOptions& options) {
 
             if (options.astType == drafter::RefractASTType) {
-              if (options.exportSourceMap) {
+              if (options.generateSourceMap) {
                 return ext::sourceMapJson;
               } else {
                 return ext::json;
               }
             } else {
-              if (options.exportSourceMap) {
+              if (options.generateSourceMap) {
                 return ext::astSourceMapJson;
               } else {
                 return ext::astJson;


### PR DESCRIPTION
Let's use `generateSourceMap` in all our codebases. It is the standard variable name for exporting source maps anyway.

PS: This doesn't change anything public facing.