### PR TITLE
Make sure drafter errors are serialized as errors

### DIFF
--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -50,27 +50,25 @@ sos::Object WrapParseResultAST(snowcrash::ParseResult<snowcrash::Blueprint>& blu
     sos::Object object;
     snowcrash::Error error;
 
-    try {
-        object.set(SerializeKey::Version, sos::String(PARSE_RESULT_SERIALIZATION_VERSION));
-        object.set(SerializeKey::Ast, WrapBlueprint(blueprint, options.expandMSON));
+    object.set(SerializeKey::Version, sos::String(PARSE_RESULT_SERIALIZATION_VERSION));
 
-        if (options.generateSourceMap) {
-            object.set(SerializeKey::Sourcemap, WrapBlueprintSourcemap(blueprint.sourceMap));
+    if (blueprint.report.error.code == snowcrash::Error::OK) {
+        try {
+            object.set(SerializeKey::Ast, WrapBlueprint(blueprint, options.expandMSON));
+
+            if (options.generateSourceMap) {
+                object.set(SerializeKey::Sourcemap, WrapBlueprintSourcemap(blueprint.sourceMap));
+            }
         }
-    }
-    catch (std::exception& e) {
-        error = snowcrash::Error(e.what(), snowcrash::MSONError);
-    }
-    catch (snowcrash::Error& e) {
-        error = e;
-    }
+        catch (std::exception& e) {
+            error = snowcrash::Error(e.what(), snowcrash::MSONError);
+        }
+        catch (snowcrash::Error& e) {
+            error = e;
+        }
 
-    if (error.code != snowcrash::Error::OK) {
-        if (blueprint.report.error.code != snowcrash::Error::OK) {
+        if (error.code != snowcrash::Error::OK) {
             blueprint.report.error = error;
-        }
-        else {
-            blueprint.report.warnings.push_back(error);
         }
     }
 

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -119,12 +119,7 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
         GetNamedTypesRegistry().clearAll(true);
 
         if (error.code != snowcrash::Error::OK) {
-            if (blueprint.report.error.code != snowcrash::Error::OK) {
-                blueprint.report.error = error;
-            }
-            else {
-                blueprint.report.warnings.push_back(error);
-            }
+            blueprint.report.error = error;
         }
 
         if (blueprintRefract) {

--- a/src/cdrafter.cc
+++ b/src/cdrafter.cc
@@ -51,10 +51,13 @@ SC_API int drafter_c_parse(const char* source,
         try {
             serializer.process(drafter::WrapResult(blueprint, wrapperOptions), resultStream);
         }
-        catch (std::exception& e) {
-            blueprint.report.error.message = e.what();
-            blueprint.report.error.code = snowcrash::ApplicationError;
+        catch (snowcrash::Error& e) {
+            blueprint.report.error = e;
         }
+        catch (std::exception& e) {
+            blueprint.report.error = snowcrash::Error(e.what(), snowcrash::ApplicationError);
+        }
+
         resultStream << "\n";
         *result = ToString(resultStream);
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -73,8 +73,7 @@ int main(int argc, const char *argv[])
         blueprint.report.error = e;
     }
     catch (std::exception& e) {
-        blueprint.report.error.message = e.what();
-        blueprint.report.error.code = snowcrash::ApplicationError;
+        blueprint.report.error = snowcrash::Error(e.what(), snowcrash::ApplicationError);
     }
 
     delete out;


### PR DESCRIPTION
Fixes #255.

@kylef Remember the small bit of code we talked about being nonsense? That is the one causing this issue.

PS: The current test blueprint we have is producing an error in drafter due to bug. Once that bug is fixed, this test won't work anymore. I am unable to get a blueprint which produces error in drafter (without it not being due to bug).

Maybe @w-vi or @klokane has a few ideas for the test case.