### PR TITLE
Introduce conversion context for thread safety

### DIFF
--- a/drafter.gyp
+++ b/drafter.gyp
@@ -49,6 +49,8 @@
         "src/NamedTypesRegistry.h",
         "src/RefractElementFactory.h",
         "src/RefractElementFactory.cc",
+        "src/ConversionContext.h",
+        # "src/ConversionContext.cc",
 
         # librefract parts - will be separated into other project
 

--- a/drafter.gyp
+++ b/drafter.gyp
@@ -50,7 +50,6 @@
         "src/RefractElementFactory.h",
         "src/RefractElementFactory.cc",
         "src/ConversionContext.h",
-        # "src/ConversionContext.cc",
 
         # librefract parts - will be separated into other project
 

--- a/src/ConversionContext.h
+++ b/src/ConversionContext.h
@@ -8,9 +8,15 @@
 #ifndef DRAFTER_CONVERSIONCONTEXT_H
 #define DRAFTER_CONVERSIONCONTEXT_H
 
+#include "refract/Registry.h"
+
 namespace drafter {
 
     class ConversionContext {
+        refract::Registry registry;
+
+    public:
+        inline refract::Registry& GetNamedTypesRegistry() { return registry; }
     };
 
 }

--- a/src/ConversionContext.h
+++ b/src/ConversionContext.h
@@ -1,0 +1,17 @@
+//
+//  ConversionContext.h
+//  drafter
+//
+//  Created by Jiri Kratochvil on 06-04-2016
+//  Copyright (c) 2016 Apiary Inc. All rights reserved.
+//
+#ifndef DRAFTER_CONVERSIONCONTEXT_H
+#define DRAFTER_CONVERSIONCONTEXT_H
+
+namespace drafter {
+
+    class ConversionContext {
+    };
+
+}
+#endif // #ifndef DRAFTER_CONVERSIONCONTEXT_H

--- a/src/NamedTypesRegistry.cc
+++ b/src/NamedTypesRegistry.cc
@@ -333,13 +333,6 @@ namespace drafter {
 
     } // ns anonymous
 
-    refract::Registry& GetNamedTypesRegistry()
-    {
-        static refract::Registry namedTypesRegistry;
-
-        return namedTypesRegistry;
-    }
-
     void RegisterNamedTypes(const NodeInfo<snowcrash::Elements>& elements, ConversionContext& context)
     {
         DataStructures found;
@@ -367,7 +360,7 @@ namespace drafter {
             refract::IElement* element = factory.Create(std::string(), false);
             element->meta["id"] = refract::IElement::Create(name);
 
-            GetNamedTypesRegistry().add(element);
+            context.GetNamedTypesRegistry().add(element);
         }
 
         for (DataStructures::const_iterator i = found.begin(); i != found.end(); ++i) {
@@ -384,11 +377,11 @@ namespace drafter {
 #endif /* DEBUG_DEPENDENCIES */
 
                 // remove preregistrated element
-                refract::IElement* pre = GetNamedTypesRegistry().find(name);
-                GetNamedTypesRegistry().remove(name);
+                refract::IElement* pre = context.GetNamedTypesRegistry().find(name);
+                context.GetNamedTypesRegistry().remove(name);
                 delete pre;
 
-                GetNamedTypesRegistry().add(element);
+                context.GetNamedTypesRegistry().add(element);
             }
         }
 

--- a/src/NamedTypesRegistry.cc
+++ b/src/NamedTypesRegistry.cc
@@ -15,6 +15,8 @@
 #include "RefractDataStructure.h"
 #include "RefractElementFactory.h"
 
+#include "ConversionContext.h"
+
 #undef DEBUG_DEPENDENCIES
 
 #ifdef DEBUG_DEPENDENCIES
@@ -338,7 +340,7 @@ namespace drafter {
         return namedTypesRegistry;
     }
 
-    void RegisterNamedTypes(const NodeInfo<snowcrash::Elements>& elements)
+    void RegisterNamedTypes(const NodeInfo<snowcrash::Elements>& elements, ConversionContext& context)
     {
         DataStructures found;
         NodeInfoCollection<snowcrash::Elements> elementCollection(elements);
@@ -373,7 +375,7 @@ namespace drafter {
             if (!i->node->name.symbol.literal.empty()) {
 
                 const std::string& name = i->node->name.symbol.literal;
-                refract::IElement* element = MSONToRefract(*i);
+                refract::IElement* element = MSONToRefract(*i, context);
 
 #ifdef DEBUG_DEPENDENCIES
                 refract::TypeQueryVisitor v;

--- a/src/NamedTypesRegistry.h
+++ b/src/NamedTypesRegistry.h
@@ -20,8 +20,10 @@ namespace drafter {
     template <typename T>
     struct NodeInfo;
 
+    class ConversionContext;
+
     refract::Registry& GetNamedTypesRegistry();
-    void RegisterNamedTypes(const NodeInfo<snowcrash::Elements>& elements);
+    void RegisterNamedTypes(const NodeInfo<snowcrash::Elements>& elements, ConversionContext& context);
 
 }
 #endif // #ifndef DRAFTER_NAMEDTYPESREGISRTY_H

--- a/src/NamedTypesRegistry.h
+++ b/src/NamedTypesRegistry.h
@@ -22,7 +22,6 @@ namespace drafter {
 
     class ConversionContext;
 
-    refract::Registry& GetNamedTypesRegistry();
     void RegisterNamedTypes(const NodeInfo<snowcrash::Elements>& elements, ConversionContext& context);
 
 }

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -120,7 +120,7 @@ namespace drafter {
         return element;
     }
 
-    refract::IElement* CopyToRefract(const NodeInfo<std::string>& copy, ConversionContext& context)
+    refract::IElement* CopyToRefract(const NodeInfo<std::string>& copy)
     {
         if (copy.node->empty()) {
             return NULL;
@@ -295,7 +295,7 @@ namespace drafter {
                                                                                                     refract::IElement::rFull);
         }
 
-        content.push_back(CopyToRefract(MAKE_NODE_INFO(payload, description), context));
+        content.push_back(CopyToRefract(MAKE_NODE_INFO(payload, description)));
         content.push_back(DataStructureToRefract(MAKE_NODE_INFO(payload, attributes), context));
 
         try {
@@ -348,7 +348,7 @@ namespace drafter {
         RefractElements content;
 
         element->element(SerializeKey::HTTPTransaction);
-        content.push_back(CopyToRefract(MAKE_NODE_INFO(transaction, description), context));
+        content.push_back(CopyToRefract(MAKE_NODE_INFO(transaction, description)));
 
         content.push_back(PayloadToRefract(request, action, context));
         content.push_back(PayloadToRefract(response, NodeInfo<snowcrash::Action>(), context));
@@ -389,7 +389,7 @@ namespace drafter {
             element->attributes[SerializeKey::Data] = dataStructure;
         }
 
-        content.push_back(CopyToRefract(MAKE_NODE_INFO(action, description), context));
+        content.push_back(CopyToRefract(MAKE_NODE_INFO(action, description)));
 
         typedef NodeInfoCollection<snowcrash::TransactionExamples> ExamplesType;
         ExamplesType examples(MAKE_NODE_INFO(action, examples));
@@ -457,7 +457,7 @@ namespace drafter {
             element->attributes[SerializeKey::HrefVariables] = ParametersToRefract(MAKE_NODE_INFO(resource, parameters), context);
         }
 
-        content.push_back(CopyToRefract(MAKE_NODE_INFO(resource, description), context));
+        content.push_back(CopyToRefract(MAKE_NODE_INFO(resource, description)));
         content.push_back(DataStructureToRefract(MAKE_NODE_INFO(resource, attributes), context));
         NodeInfoToElements(MAKE_NODE_INFO(resource, actions), ActionToRefract, content, context);
 
@@ -510,7 +510,7 @@ namespace drafter {
             case snowcrash::Element::DataStructureElement:
                 return DataStructureToRefract(MAKE_NODE_INFO(element, content.dataStructure), context);
             case snowcrash::Element::CopyElement:
-                return CopyToRefract(MAKE_NODE_INFO(element, content.copy), context);
+                return CopyToRefract(MAKE_NODE_INFO(element, content.copy));
             case snowcrash::Element::CategoryElement:
                 return CategoryToRefract(element, context);
             default:
@@ -532,7 +532,7 @@ namespace drafter {
         ast->meta[SerializeKey::Classes] = CreateArrayElement(SerializeKey::API);
         ast->meta[SerializeKey::Title] = PrimitiveToRefract(MAKE_NODE_INFO(blueprint, name));
 
-        content.push_back(CopyToRefract(MAKE_NODE_INFO(blueprint, description), context));
+        content.push_back(CopyToRefract(MAKE_NODE_INFO(blueprint, description)));
 
         if (!blueprint.node->metadata.empty()) {
             ast->attributes[SerializeKey::Meta] = CollectionToRefract<refract::ArrayElement>(MAKE_NODE_INFO(blueprint, metadata), context, MetadataToRefract);

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -89,7 +89,7 @@ namespace drafter {
         refract::IElement* msonElement = MSONToRefract(dataStructure, context);
 
         if (expand) {
-            refract::IElement* msonExpanded = ExpandRefract(msonElement, context, context.GetNamedTypesRegistry());
+            refract::IElement* msonExpanded = ExpandRefract(msonElement, context);
             msonElement = msonExpanded;
         }
 
@@ -300,8 +300,8 @@ namespace drafter {
 
         try {
             // Render using boutique
-            NodeInfoByValue<snowcrash::Asset> payloadBody = renderPayloadBody(payload, action, context, context.GetNamedTypesRegistry());
-            NodeInfoByValue<snowcrash::Asset> payloadSchema = renderPayloadSchema(payload, action, context, context.GetNamedTypesRegistry());
+            NodeInfoByValue<snowcrash::Asset> payloadBody = renderPayloadBody(payload, action, context);
+            NodeInfoByValue<snowcrash::Asset> payloadSchema = renderPayloadSchema(payload, action, context);
 
             // Get content type
             std::string contentType = getContentTypeFromHeaders(payload.node->headers);

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -89,7 +89,7 @@ namespace drafter {
         refract::IElement* msonElement = MSONToRefract(dataStructure, context);
 
         if (expand) {
-            refract::IElement* msonExpanded = ExpandRefract(msonElement, context, GetNamedTypesRegistry());
+            refract::IElement* msonExpanded = ExpandRefract(msonElement, context, context.GetNamedTypesRegistry());
             msonElement = msonExpanded;
         }
 
@@ -300,8 +300,8 @@ namespace drafter {
 
         try {
             // Render using boutique
-            NodeInfoByValue<snowcrash::Asset> payloadBody = renderPayloadBody(payload, action, context, GetNamedTypesRegistry());
-            NodeInfoByValue<snowcrash::Asset> payloadSchema = renderPayloadSchema(payload, action, context, GetNamedTypesRegistry());
+            NodeInfoByValue<snowcrash::Asset> payloadBody = renderPayloadBody(payload, action, context, context.GetNamedTypesRegistry());
+            NodeInfoByValue<snowcrash::Asset> payloadSchema = renderPayloadSchema(payload, action, context, context.GetNamedTypesRegistry());
 
             // Get content type
             std::string contentType = getContentTypeFromHeaders(payload.node->headers);

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -89,7 +89,7 @@ namespace drafter {
         refract::IElement* msonElement = MSONToRefract(dataStructure, context);
 
         if (expand) {
-            refract::IElement* msonExpanded = ExpandRefract(msonElement, GetNamedTypesRegistry());
+            refract::IElement* msonExpanded = ExpandRefract(msonElement, context, GetNamedTypesRegistry());
             msonElement = msonExpanded;
         }
 
@@ -300,8 +300,8 @@ namespace drafter {
 
         try {
             // Render using boutique
-            NodeInfoByValue<snowcrash::Asset> payloadBody = renderPayloadBody(payload, action, GetNamedTypesRegistry());
-            NodeInfoByValue<snowcrash::Asset> payloadSchema = renderPayloadSchema(payload, action, GetNamedTypesRegistry());
+            NodeInfoByValue<snowcrash::Asset> payloadBody = renderPayloadBody(payload, action, context, GetNamedTypesRegistry());
+            NodeInfoByValue<snowcrash::Asset> payloadSchema = renderPayloadSchema(payload, action, context, GetNamedTypesRegistry());
 
             // Get content type
             std::string contentType = getContentTypeFromHeaders(payload.node->headers);

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -52,14 +52,14 @@ namespace drafter {
             }
         };
 
-        template <typename T, typename F>
-        void NodeInfoToElements(const NodeInfo<T>& nodeInfo, const F& transformFunctor, RefractElements& content, ConversionContext& context)
+        template <typename T, typename Functor>
+        void NodeInfoToElements(const NodeInfo<T>& nodeInfo, const Functor& transformFunctor, RefractElements& content, ConversionContext& context)
         {
             NodeInfoCollection<T> nodeInfoCollection(nodeInfo);
 
             std::transform(nodeInfoCollection.begin(), nodeInfoCollection.end(),
                            std::back_inserter(content),
-                           ContextBinder<typename T::value_type, F>(transformFunctor, context));
+                           ContextBinder<typename T::value_type, Functor>(transformFunctor, context));
         }
 
         template<typename T, typename C, typename F>

--- a/src/RefractAPI.h
+++ b/src/RefractAPI.h
@@ -17,10 +17,12 @@ namespace snowcrash {
 
 namespace drafter {
 
+    class ConversionContext;
+
     refract::IElement* AnnotationToRefract(const snowcrash::SourceAnnotation& annotation, const std::string& key);
 
-    refract::IElement* DataStructureToRefract(const NodeInfo<snowcrash::DataStructure>& dataStructure, bool expand = false);
-    refract::IElement* BlueprintToRefract(const NodeInfo<snowcrash::Blueprint>& blueprint);
+    refract::IElement* DataStructureToRefract(const NodeInfo<snowcrash::DataStructure>& dataStructure, ConversionContext& context, bool expand = false);
+    refract::IElement* BlueprintToRefract(const NodeInfo<snowcrash::Blueprint>& blueprint, ConversionContext& context);
 }
 
 #endif // #ifndef DRAFTER_REFRACTAST_H

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -1060,13 +1060,13 @@ namespace drafter {
         return element;
     }
 
-    refract::IElement* ExpandRefract(refract::IElement* element, ConversionContext& context, const refract::Registry& registry)
+    refract::IElement* ExpandRefract(refract::IElement* element, ConversionContext& context)
     {
         if (!element) {
             return element;
         }
 
-        refract::ExpandVisitor expander(registry);
+        refract::ExpandVisitor expander(context.GetNamedTypesRegistry());
         expander.visit(*element);
 
         if (refract::IElement* expanded = expander.get()) {

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -1006,7 +1006,7 @@ namespace drafter {
         return element;
     }
 
-    refract::IElement* MSONToRefract(const NodeInfo<snowcrash::DataStructure>& dataStructure)
+    refract::IElement* MSONToRefract(const NodeInfo<snowcrash::DataStructure>& dataStructure, ConversionContext& context)
     {
         if (dataStructure.node->empty()) {
             return NULL;

--- a/src/RefractDataStructure.h
+++ b/src/RefractDataStructure.h
@@ -13,7 +13,9 @@
 
 namespace drafter {
 
-    refract::IElement* MSONToRefract(const NodeInfo<snowcrash::DataStructure>& dataStructure);
+    class ConversionContext;
+
+    refract::IElement* MSONToRefract(const NodeInfo<snowcrash::DataStructure>& dataStructure, ConversionContext& context);
     refract::IElement* ExpandRefract(refract::IElement*, const refract::Registry&);
 
     sos::Object SerializeRefract(refract::IElement*, bool generateSourceMap = true);

--- a/src/RefractDataStructure.h
+++ b/src/RefractDataStructure.h
@@ -16,7 +16,7 @@ namespace drafter {
     class ConversionContext;
 
     refract::IElement* MSONToRefract(const NodeInfo<snowcrash::DataStructure>& dataStructure, ConversionContext& context);
-    refract::IElement* ExpandRefract(refract::IElement*, const refract::Registry&);
+    refract::IElement* ExpandRefract(refract::IElement* element, ConversionContext& context, const refract::Registry& registry);
 
     sos::Object SerializeRefract(refract::IElement*, bool generateSourceMap = true);
 

--- a/src/RefractDataStructure.h
+++ b/src/RefractDataStructure.h
@@ -16,7 +16,7 @@ namespace drafter {
     class ConversionContext;
 
     refract::IElement* MSONToRefract(const NodeInfo<snowcrash::DataStructure>& dataStructure, ConversionContext& context);
-    refract::IElement* ExpandRefract(refract::IElement* element, ConversionContext& context, const refract::Registry& registry);
+    refract::IElement* ExpandRefract(refract::IElement* element, ConversionContext& context);
 
     sos::Object SerializeRefract(refract::IElement*, bool generateSourceMap = true);
 

--- a/src/RefractSourceMap.h
+++ b/src/RefractSourceMap.h
@@ -10,7 +10,6 @@
 #define DRAFTER_REFRACTSOURCEMAP_H
 
 #include "Serialize.h"
-#include "ConversionContext.h"
 
 namespace drafter {
 
@@ -35,6 +34,8 @@ namespace drafter {
 
         return element;
     }
+
+    class ConversionContext;
 
     template<typename T>
     refract::IElement* LiteralToRefract(const NodeInfo<std::string>& literal, ConversionContext& context)

--- a/src/RefractSourceMap.h
+++ b/src/RefractSourceMap.h
@@ -10,9 +10,9 @@
 #define DRAFTER_REFRACTSOURCEMAP_H
 
 #include "Serialize.h"
+#include "ConversionContext.h"
 
 namespace drafter {
-
 
     refract::IElement* SourceMapToRefract(const mdp::CharactersRangeSet& sourceMap);
 
@@ -37,7 +37,7 @@ namespace drafter {
     }
 
     template<typename T>
-    refract::IElement* LiteralToRefract(const NodeInfo<std::string>& literal)
+    refract::IElement* LiteralToRefract(const NodeInfo<std::string>& literal, ConversionContext& context)
     {
         refract::IElement* element = refract::IElement::Create(LiteralTo<T>(*literal.node));
 

--- a/src/Render.cc
+++ b/src/Render.cc
@@ -13,6 +13,8 @@
 #include "BlueprintUtility.h"
 #include "RegexMatch.h"
 
+#include "ConversionContext.h"
+
 using namespace snowcrash;
 
 namespace drafter {
@@ -50,6 +52,8 @@ namespace drafter {
                                              const NodeInfo<Action>& action,
                                              const refract::Registry& registry) {
 
+        ConversionContext context; // FIXME: CTX
+
         NodeInfoByValue<Asset> body = std::make_pair(payload.node->body, &payload.sourceMap->body);
 
         NodeInfo<Attributes> payloadAttributes = MAKE_NODE_INFO(payload, attributes);
@@ -70,7 +74,7 @@ namespace drafter {
         }
 
         // Expand MSON into Refract
-        refract::IElement* element = MSONToRefract(*attributes);
+        refract::IElement* element = MSONToRefract(*attributes, context);
 
         if (!element) {
             return body;
@@ -116,6 +120,8 @@ namespace drafter {
                                                const NodeInfo<snowcrash::Action>& action,
                                                const refract::Registry& registry) {
 
+        ConversionContext context; // FIXME: CTX
+
         NodeInfoByValue<Asset> schema = std::make_pair(payload.node->schema, &payload.sourceMap->schema);
 
         NodeInfo<Attributes> payloadAttributes = MAKE_NODE_INFO(payload, attributes);
@@ -136,7 +142,7 @@ namespace drafter {
         }
 
         refract::JSONSchemaVisitor renderer;
-        refract::IElement* element = MSONToRefract(*attributes);
+        refract::IElement* element = MSONToRefract(*attributes, context);
 
         if (!element) {
             return schema;

--- a/src/Render.cc
+++ b/src/Render.cc
@@ -50,8 +50,7 @@ namespace drafter {
 
     NodeInfoByValue<Asset> renderPayloadBody(const NodeInfo<Payload>& payload,
                                              const NodeInfo<Action>& action,
-                                             ConversionContext& context,
-                                             const refract::Registry& registry) {
+                                             ConversionContext& context) {
 
         NodeInfoByValue<Asset> body = std::make_pair(payload.node->body, &payload.sourceMap->body);
 
@@ -79,7 +78,7 @@ namespace drafter {
             return body;
         }
 
-        refract::IElement* expanded = ExpandRefract(element, context, registry);
+        refract::IElement* expanded = ExpandRefract(element, context);
 
         if (!expanded) {
             return body;
@@ -117,8 +116,7 @@ namespace drafter {
 
     NodeInfoByValue<Asset> renderPayloadSchema(const NodeInfo<snowcrash::Payload>& payload,
                                                const NodeInfo<snowcrash::Action>& action,
-                                               ConversionContext& context,
-                                               const refract::Registry& registry) {
+                                               ConversionContext& context) {
 
         NodeInfoByValue<Asset> schema = std::make_pair(payload.node->schema, &payload.sourceMap->schema);
 
@@ -146,7 +144,7 @@ namespace drafter {
             return schema;
         }
 
-        refract::IElement* expanded = ExpandRefract(element, context, registry);
+        refract::IElement* expanded = ExpandRefract(element, context);
 
         if (!expanded) {
             return schema;

--- a/src/Render.cc
+++ b/src/Render.cc
@@ -50,9 +50,8 @@ namespace drafter {
 
     NodeInfoByValue<Asset> renderPayloadBody(const NodeInfo<Payload>& payload,
                                              const NodeInfo<Action>& action,
+                                             ConversionContext& context,
                                              const refract::Registry& registry) {
-
-        ConversionContext context; // FIXME: CTX
 
         NodeInfoByValue<Asset> body = std::make_pair(payload.node->body, &payload.sourceMap->body);
 
@@ -80,7 +79,7 @@ namespace drafter {
             return body;
         }
 
-        refract::IElement* expanded = ExpandRefract(element, registry);
+        refract::IElement* expanded = ExpandRefract(element, context, registry);
 
         if (!expanded) {
             return body;
@@ -118,9 +117,8 @@ namespace drafter {
 
     NodeInfoByValue<Asset> renderPayloadSchema(const NodeInfo<snowcrash::Payload>& payload,
                                                const NodeInfo<snowcrash::Action>& action,
+                                               ConversionContext& context,
                                                const refract::Registry& registry) {
-
-        ConversionContext context; // FIXME: CTX
 
         NodeInfoByValue<Asset> schema = std::make_pair(payload.node->schema, &payload.sourceMap->schema);
 
@@ -148,7 +146,7 @@ namespace drafter {
             return schema;
         }
 
-        refract::IElement* expanded = ExpandRefract(element, registry);
+        refract::IElement* expanded = ExpandRefract(element, context, registry);
 
         if (!expanded) {
             return schema;

--- a/src/Render.h
+++ b/src/Render.h
@@ -28,13 +28,11 @@ namespace drafter {
 
     NodeInfoByValue<snowcrash::Asset> renderPayloadBody(const NodeInfo<snowcrash::Payload>& payload,
                                                         const NodeInfo<snowcrash::Action>& action,
-                                                        ConversionContext& context,
-                                                        const refract::Registry& registry);
+                                                        ConversionContext& context);
 
     NodeInfoByValue<snowcrash::Asset> renderPayloadSchema(const NodeInfo<snowcrash::Payload>& payload,
                                                           const NodeInfo<snowcrash::Action>& action,
-                                                          ConversionContext& context,
-                                                          const refract::Registry& registry);
+                                                          ConversionContext& context);
 }
 
 #endif

--- a/src/Render.h
+++ b/src/Render.h
@@ -21,11 +21,20 @@ namespace drafter {
         JSONSchemaRenderFormat = 2   // JSON Schema format
     };
 
+    class ConversionContext;
+
     RenderFormat findRenderFormat(const std::string& contentType);
     std::string getContentTypeFromHeaders(const snowcrash::Headers& headers);
 
-    NodeInfoByValue<snowcrash::Asset> renderPayloadBody(const NodeInfo<snowcrash::Payload>& payload, const NodeInfo<snowcrash::Action>& action, const refract::Registry& registry);
-    NodeInfoByValue<snowcrash::Asset> renderPayloadSchema(const NodeInfo<snowcrash::Payload>& payload, const NodeInfo<snowcrash::Action>& action, const refract::Registry& registry);
+    NodeInfoByValue<snowcrash::Asset> renderPayloadBody(const NodeInfo<snowcrash::Payload>& payload,
+                                                        const NodeInfo<snowcrash::Action>& action,
+                                                        ConversionContext& context,
+                                                        const refract::Registry& registry);
+
+    NodeInfoByValue<snowcrash::Asset> renderPayloadSchema(const NodeInfo<snowcrash::Payload>& payload,
+                                                          const NodeInfo<snowcrash::Action>& action,
+                                                          ConversionContext& context,
+                                                          const refract::Registry& registry);
 }
 
 #endif

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -230,27 +230,56 @@ namespace drafter {
             return array;
         }
 
-        template<typename Collection, typename Functor, typename Argument>
-        R operator()(const Collection& collection, Functor &wrapper, Argument argument) const {
+        template<typename Collection, typename Functor, typename Arg1>
+        R operator()(const Collection& collection, Functor &wrapper, Arg1 arg1) const {
             typedef typename Collection::const_iterator iterator_type;
             R array;
 
             for (iterator_type it = collection.begin(); it != collection.end(); ++it) {
-                array.push(wrapper(*it, argument));
+                array.push(wrapper(*it, arg1));
             }
 
             return array;
         }
 
+        template<typename Collection, typename Functor, typename Arg1, typename Arg2>
+        R operator()(const Collection& collection, Functor &wrapper, Arg1 arg1, Arg2 arg2) const {
+            typedef typename Collection::const_iterator iterator_type;
+            R array;
+
+            for (iterator_type it = collection.begin(); it != collection.end(); ++it) {
+                array.push(wrapper(*it, arg1, arg2));
+            }
+
+            return array;
+        }
+    };
+
+    template<typename T, typename R = sos::Array>
+    struct WrapCollectionIf {
         // When we want to use predicate, let's use a dummy argument to distinguish it
         template<typename Collection, typename Functor, typename Predicate>
-        R operator()(const Collection& collection, Functor &wrapper, Predicate &predicate, bool dummy) const {
+        R operator()(const Collection& collection, Functor &wrapper, Predicate &predicate) const {
             typedef typename Collection::const_iterator iterator_type;
             R array;
 
             for (iterator_type it = collection.begin(); it != collection.end(); ++it) {
                 if (predicate(*it)) {
                     array.push(wrapper(*it));
+                }
+            }
+
+            return array;
+        }
+
+        template<typename Collection, typename Functor, typename Predicate, typename Argument>
+        R operator()(const Collection& collection, Functor &wrapper, Predicate &predicate, Argument& argument) const {
+            typedef typename Collection::const_iterator iterator_type;
+            R array;
+
+            for (iterator_type it = collection.begin(); it != collection.end(); ++it) {
+                if (predicate(*it)) {
+                    array.push(wrapper(*it, argument));
                 }
             }
 

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -272,14 +272,14 @@ namespace drafter {
             return array;
         }
 
-        template<typename Collection, typename Functor, typename Predicate, typename Argument>
-        R operator()(const Collection& collection, Functor &wrapper, Predicate &predicate, Argument& argument) const {
+        template<typename Collection, typename Functor, typename Predicate, typename Arg1>
+        R operator()(const Collection& collection, Functor &wrapper, Predicate &predicate, Arg1& arg1) const {
             typedef typename Collection::const_iterator iterator_type;
             R array;
 
             for (iterator_type it = collection.begin(); it != collection.end(); ++it) {
                 if (predicate(*it)) {
-                    array.push(wrapper(*it, argument));
+                    array.push(wrapper(*it, arg1));
                 }
             }
 

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -501,6 +501,7 @@ sos::Object WrapAsset(const Asset& asset, const AssetRole& role)
 sos::Object WrapPayload(const Payload& payload, const Action* action)
 {
     sos::Object payloadObject;
+    ConversionContext context;
 
     // Reference
     if (!payload.reference.id.empty()) {
@@ -517,8 +518,15 @@ sos::Object WrapPayload(const Payload& payload, const Action* action)
     payloadObject.set(SerializeKey::Headers,
                       WrapCollection<Header>()(payload.headers, WrapHeader));
 
-    snowcrash::Asset payloadBody = renderPayloadBody(MakeNodeInfoWithoutSourceMap(payload), action ? MakeNodeInfoWithoutSourceMap(*action) : NodeInfo<Action>(), GetNamedTypesRegistry()).first;
-    snowcrash::Asset payloadSchema = renderPayloadSchema(MakeNodeInfoWithoutSourceMap(payload), action ? MakeNodeInfoWithoutSourceMap(*action) : NodeInfo<Action>(), GetNamedTypesRegistry()).first;
+    snowcrash::Asset payloadBody = renderPayloadBody(MakeNodeInfoWithoutSourceMap(payload), 
+                                                     action ? MakeNodeInfoWithoutSourceMap(*action) : NodeInfo<Action>(),
+                                                     context,
+                                                     GetNamedTypesRegistry()).first;
+
+    snowcrash::Asset payloadSchema = renderPayloadSchema(MakeNodeInfoWithoutSourceMap(payload),
+                                                         action ? MakeNodeInfoWithoutSourceMap(*action) : NodeInfo<Action>(),
+                                                         context,
+                                                         GetNamedTypesRegistry()).first;
 
     // Body
     payloadObject.set(SerializeKey::Body, sos::String(payloadBody));

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -444,12 +444,11 @@ sos::Object WrapTypeSection(const mson::TypeSection& section)
     return object;
 }
 
-sos::Object WrapDataStructure(const DataStructure& dataStructure)
+sos::Object WrapDataStructure(const DataStructure& dataStructure, ConversionContext& context)
 {
     sos::Object dataStructureObject;
 
 #if _WITH_REFRACT_
-    ConversionContext context;
     refract::IElement *element = DataStructureToRefract(MakeNodeInfoWithoutSourceMap(dataStructure), context, ExpandMSON);
     dataStructureObject = SerializeRefract(element, false);
 
@@ -498,10 +497,9 @@ sos::Object WrapAsset(const Asset& asset, const AssetRole& role)
     return assetObject;
 }
 
-sos::Object WrapPayload(const Payload& payload, const Action* action)
+sos::Object WrapPayload(const Payload& payload, const Action* action, ConversionContext& context)
 {
     sos::Object payloadObject;
-    ConversionContext context;
 
     // Reference
     if (!payload.reference.id.empty()) {
@@ -521,12 +519,12 @@ sos::Object WrapPayload(const Payload& payload, const Action* action)
     snowcrash::Asset payloadBody = renderPayloadBody(MakeNodeInfoWithoutSourceMap(payload), 
                                                      action ? MakeNodeInfoWithoutSourceMap(*action) : NodeInfo<Action>(),
                                                      context,
-                                                     GetNamedTypesRegistry()).first;
+                                                     context.GetNamedTypesRegistry()).first;
 
     snowcrash::Asset payloadSchema = renderPayloadSchema(MakeNodeInfoWithoutSourceMap(payload),
                                                          action ? MakeNodeInfoWithoutSourceMap(*action) : NodeInfo<Action>(),
                                                          context,
-                                                         GetNamedTypesRegistry()).first;
+                                                         context.GetNamedTypesRegistry()).first;
 
     // Body
     payloadObject.set(SerializeKey::Body, sos::String(payloadBody));
@@ -539,7 +537,7 @@ sos::Object WrapPayload(const Payload& payload, const Action* action)
 
     /// Attributes
     if (!payload.attributes.empty()) {
-        content.push(WrapDataStructure(payload.attributes));
+        content.push(WrapDataStructure(payload.attributes, context));
     }
 
     /// Asset 'bodyExample'
@@ -594,7 +592,7 @@ sos::Object WrapParameter(const Parameter& parameter)
     return parameterObject;
 }
 
-sos::Object WrapTransactionExample(const TransactionExample& example, const Action& action)
+sos::Object WrapTransactionExample(const TransactionExample& example, const Action& action, ConversionContext& context)
 {
     sos::Object exampleObject;
 
@@ -606,16 +604,16 @@ sos::Object WrapTransactionExample(const TransactionExample& example, const Acti
 
     // Requests
     exampleObject.set(SerializeKey::Requests,
-                      WrapCollection<Request>()(example.requests, WrapPayload, &action));
+                      WrapCollection<Request>()(example.requests, WrapPayload, &action, context));
 
     // Responses
     exampleObject.set(SerializeKey::Responses,
-                      WrapCollection<Response>()(example.responses, WrapPayload, (Action *) NULL));
+                      WrapCollection<Response>()(example.responses, WrapPayload, (Action *) NULL, context));
 
     return exampleObject;
 }
 
-sos::Object WrapAction(const Action& action)
+sos::Object WrapAction(const Action& action, ConversionContext& context)
 {
     sos::Object actionObject;
 
@@ -647,19 +645,19 @@ sos::Object WrapAction(const Action& action)
     sos::Array content;
 
     if (!action.attributes.empty()) {
-        content.push(WrapDataStructure(action.attributes));
+        content.push(WrapDataStructure(action.attributes, context));
     }
 
     actionObject.set(SerializeKey::Content, content);
 
     // Transaction Examples
     actionObject.set(SerializeKey::Examples,
-                     WrapCollection<TransactionExample>()(action.examples, WrapTransactionExample, action));
+                     WrapCollection<TransactionExample>()(action.examples, WrapTransactionExample, action, context));
 
     return actionObject;
 }
 
-sos::Object WrapResource(const Resource& resource)
+sos::Object WrapResource(const Resource& resource, ConversionContext& context)
 {
     sos::Object resourceObject;
 
@@ -676,7 +674,7 @@ sos::Object WrapResource(const Resource& resource)
     resourceObject.set(SerializeKey::URITemplate, sos::String(resource.uriTemplate));
 
     // Model
-    sos::Object model = (resource.model.name.empty() ? sos::Object() : WrapPayload(resource.model, NULL));
+    sos::Object model = (resource.model.name.empty() ? sos::Object() : WrapPayload(resource.model, NULL, context));
     resourceObject.set(SerializeKey::Model, model);
 
     // Parameters
@@ -685,13 +683,13 @@ sos::Object WrapResource(const Resource& resource)
 
     // Actions
     resourceObject.set(SerializeKey::Actions,
-                       WrapCollection<Action>()(resource.actions, WrapAction));
+                       WrapCollection<Action>()(resource.actions, WrapAction, context));
 
     // Content
     sos::Array content;
 
     if (!resource.attributes.empty()) {
-        content.push(WrapDataStructure(resource.attributes));
+        content.push(WrapDataStructure(resource.attributes, context));
     }
 
     resourceObject.set(SerializeKey::Content, content);
@@ -699,7 +697,7 @@ sos::Object WrapResource(const Resource& resource)
     return resourceObject;
 }
 
-sos::Object WrapResourceGroup(const Element& resourceGroup)
+sos::Object WrapResourceGroup(const Element& resourceGroup, ConversionContext& context)
 {
     sos::Object resourceGroupObject;
 
@@ -715,7 +713,7 @@ sos::Object WrapResourceGroup(const Element& resourceGroup)
          ++it) {
 
         if (it->element == Element::ResourceElement) {
-            resources.push(WrapResource(it->content.resource));
+            resources.push(WrapResource(it->content.resource, context));
         }
         else if (it->element == Element::CopyElement) {
 
@@ -733,7 +731,7 @@ sos::Object WrapResourceGroup(const Element& resourceGroup)
     return resourceGroupObject;
 }
 
-sos::Object WrapElement(const Element& element)
+sos::Object WrapElement(const Element& element, ConversionContext& context)
 {
     sos::Object elementObject;
 
@@ -757,18 +755,18 @@ sos::Object WrapElement(const Element& element)
         case Element::CategoryElement:
         {
             elementObject.set(SerializeKey::Content,
-                              WrapCollection<Element>()(element.content.elements(), WrapElement));
+                              WrapCollection<Element>()(element.content.elements(), WrapElement, context));
             break;
         }
 
         case Element::DataStructureElement:
         {
-            return WrapDataStructure(element.content.dataStructure);
+            return WrapDataStructure(element.content.dataStructure, context);
         }
 
         case Element::ResourceElement:
         {
-            return WrapResource(element.content.resource);
+            return WrapResource(element.content.resource, context);
         }
 
         default:
@@ -783,7 +781,7 @@ bool IsElementResourceGroup(const Element& element)
     return element.element == Element::CategoryElement && element.category == Element::ResourceGroupCategory;
 }
 
-sos::Object WrapBlueprintAST(const Blueprint& blueprint)
+sos::Object WrapBlueprintAST(const Blueprint& blueprint, ConversionContext& context)
 {
     sos::Object blueprintObject;
 
@@ -805,16 +803,16 @@ sos::Object WrapBlueprintAST(const Blueprint& blueprint)
 
     // Resource Groups
     blueprintObject.set(SerializeKey::ResourceGroups,
-                        WrapCollection<Element>()(blueprint.content.elements(), WrapResourceGroup, IsElementResourceGroup, false));
+                        WrapCollectionIf<Element>()(blueprint.content.elements(), WrapResourceGroup, IsElementResourceGroup, context));
 
     // Content
     blueprintObject.set(SerializeKey::Content,
-                        WrapCollection<Element>()(blueprint.content.elements(), WrapElement));
+                        WrapCollection<Element>()(blueprint.content.elements(), WrapElement, context));
 
     return blueprintObject;
 }
 
-sos::Object drafter::WrapBlueprint(const snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const bool expandMSON)
+sos::Object drafter::WrapBlueprint(const snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, ConversionContext& context, const bool expandMSON)
 {
     sos::Object blueprintObject;
     snowcrash::Error error;
@@ -826,9 +824,8 @@ sos::Object drafter::WrapBlueprint(const snowcrash::ParseResult<snowcrash::Bluep
     try {
         ExpandMSON = expandMSON;
 
-        drafter::ConversionContext context;
         RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements()), context);
-        blueprintObject = WrapBlueprintAST(blueprint.node);
+        blueprintObject = WrapBlueprintAST(blueprint.node, context);
     }
     catch (std::exception& e) {
         error = snowcrash::Error(e.what(), snowcrash::MSONError);
@@ -837,7 +834,7 @@ sos::Object drafter::WrapBlueprint(const snowcrash::ParseResult<snowcrash::Bluep
         error = e;
     }
 
-    GetNamedTypesRegistry().clearAll(true);
+    context.GetNamedTypesRegistry().clearAll(true);
 
     if (error.code != snowcrash::Error::OK) {
         throw error;

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -18,6 +18,7 @@
 #include "SectionProcessor.h"
 
 #include "NamedTypesRegistry.h"
+#include "ConversionContext.h"
 
 using namespace drafter;
 
@@ -448,7 +449,8 @@ sos::Object WrapDataStructure(const DataStructure& dataStructure)
     sos::Object dataStructureObject;
 
 #if _WITH_REFRACT_
-    refract::IElement *element = DataStructureToRefract(MakeNodeInfoWithoutSourceMap(dataStructure), ExpandMSON);
+    ConversionContext context;
+    refract::IElement *element = DataStructureToRefract(MakeNodeInfoWithoutSourceMap(dataStructure), context, ExpandMSON);
     dataStructureObject = SerializeRefract(element, false);
 
     if (element) {
@@ -816,7 +818,8 @@ sos::Object drafter::WrapBlueprint(const snowcrash::ParseResult<snowcrash::Bluep
     try {
         ExpandMSON = expandMSON;
 
-        RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements()));
+        drafter::ConversionContext context;
+        RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements()), context);
         blueprintObject = WrapBlueprintAST(blueprint.node);
     }
     catch (std::exception& e) {

--- a/src/SerializeAST.cc
+++ b/src/SerializeAST.cc
@@ -518,13 +518,11 @@ sos::Object WrapPayload(const Payload& payload, const Action* action, Conversion
 
     snowcrash::Asset payloadBody = renderPayloadBody(MakeNodeInfoWithoutSourceMap(payload), 
                                                      action ? MakeNodeInfoWithoutSourceMap(*action) : NodeInfo<Action>(),
-                                                     context,
-                                                     context.GetNamedTypesRegistry()).first;
+                                                     context).first;
 
     snowcrash::Asset payloadSchema = renderPayloadSchema(MakeNodeInfoWithoutSourceMap(payload),
                                                          action ? MakeNodeInfoWithoutSourceMap(*action) : NodeInfo<Action>(),
-                                                         context,
-                                                         context.GetNamedTypesRegistry()).first;
+                                                         context).first;
 
     // Body
     payloadObject.set(SerializeKey::Body, sos::String(payloadBody));

--- a/src/SerializeAST.h
+++ b/src/SerializeAST.h
@@ -13,6 +13,8 @@
 
 namespace drafter {
 
+    class ConversionContext;
+
     /**
      * NOTE: depracated as entry point for serialization
      *
@@ -21,7 +23,7 @@ namespace drafter {
      * This function now works just as AST serialization wrapper
      * additionaly there is changed function interface 
      */
-    sos::Object WrapBlueprint(const snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const bool expandMSON);
+    sos::Object WrapBlueprint(const snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, ConversionContext& context, const bool expandMSON);
 }
 
 #endif

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -20,6 +20,7 @@
 #include "refract/ElementInserter.h"
 
 #include "NamedTypesRegistry.h"
+#include "ConversionContext.h"
 
 using namespace drafter;
 
@@ -94,7 +95,8 @@ namespace helper {
 }
 
 sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint,
-                                   const WrapperOptions& options)
+                                   const WrapperOptions& options,
+                                   ConversionContext& context)
 {
     snowcrash::Error error;
     refract::IElement* blueprintRefract = NULL;
@@ -104,8 +106,8 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
 
     if (blueprint.report.error.code == snowcrash::Error::OK) {
         try {
-            RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements()));
-            blueprintRefract = BlueprintToRefract(MakeNodeInfo(blueprint.node, blueprint.sourceMap));
+            RegisterNamedTypes(MakeNodeInfo(blueprint.node.content.elements(), blueprint.sourceMap.content.elements()), context);
+            blueprintRefract = BlueprintToRefract(MakeNodeInfo(blueprint.node, blueprint.sourceMap), context);
         }
         catch (std::exception& e) {
             error = snowcrash::Error(e.what(), snowcrash::MSONError);
@@ -150,9 +152,10 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
 }
 
 sos::Object drafter::WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint,
-                                const WrapperOptions& options)
+                                const WrapperOptions& options,
+                                ConversionContext& context)
 {
     return options.astType == RefractASTType
-        ? WrapParseResultRefract(blueprint, options)
+        ? WrapParseResultRefract(blueprint, options, context)
         : WrapParseResultAST(blueprint, options);
 }

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -153,9 +153,10 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
 }
 
 sos::Object drafter::WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint,
-                                const WrapperOptions& options,
-                                ConversionContext& context)
+                                const WrapperOptions& options)
 {
+    ConversionContext context;
+
     return options.astType == RefractASTType
         ? WrapParseResultRefract(blueprint, options, context)
         : WrapParseResultAST(blueprint, options, context);

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -46,7 +46,8 @@ sos::Object drafter::WrapAnnotation(const snowcrash::SourceAnnotation& annotatio
 }
 
 sos::Object WrapParseResultAST(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint,
-                               const WrapperOptions& options)
+                               const WrapperOptions& options,
+                               ConversionContext& context)
 {
     sos::Object object;
     snowcrash::Error error;
@@ -55,10 +56,10 @@ sos::Object WrapParseResultAST(snowcrash::ParseResult<snowcrash::Blueprint>& blu
 
     if (blueprint.report.error.code == snowcrash::Error::OK) {
         try {
-            object.set(SerializeKey::Ast, WrapBlueprint(blueprint, options.expandMSON));
+            object.set(SerializeKey::Ast, WrapBlueprint(blueprint, context, options.expandMSON));
 
             if (options.generateSourceMap) {
-                object.set(SerializeKey::Sourcemap, WrapBlueprintSourcemap(blueprint.sourceMap));
+                object.set(SerializeKey::Sourcemap, WrapBlueprintSourcemap(blueprint.sourceMap, context));
             }
         }
         catch (std::exception& e) {
@@ -116,7 +117,7 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
             error = e;
         }
 
-        GetNamedTypesRegistry().clearAll(true);
+        context.GetNamedTypesRegistry().clearAll(true);
 
         if (error.code != snowcrash::Error::OK) {
             blueprint.report.error = error;
@@ -157,5 +158,5 @@ sos::Object drafter::WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& bl
 {
     return options.astType == RefractASTType
         ? WrapParseResultRefract(blueprint, options, context)
-        : WrapParseResultAST(blueprint, options);
+        : WrapParseResultAST(blueprint, options, context);
 }

--- a/src/SerializeResult.h
+++ b/src/SerializeResult.h
@@ -18,10 +18,8 @@ namespace snowcrash {
 
 namespace drafter {
 
-    class ConversionContext;
-
     sos::Object WrapAnnotation(const snowcrash::SourceAnnotation& annotation);
-    sos::Object WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const WrapperOptions& options, ConversionContext& context);
+    sos::Object WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const WrapperOptions& options);
 }
 
 #endif // #ifndef DRAFTER_SERIALIZERESULT_H

--- a/src/SerializeResult.h
+++ b/src/SerializeResult.h
@@ -18,8 +18,10 @@ namespace snowcrash {
 
 namespace drafter {
 
+    class ConversionContext;
+
     sos::Object WrapAnnotation(const snowcrash::SourceAnnotation& annotation);
-    sos::Object WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const WrapperOptions& options);
+    sos::Object WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const WrapperOptions& options, ConversionContext& context);
 }
 
 #endif // #ifndef DRAFTER_SERIALIZERESULT_H

--- a/src/SerializeSourcemap.cc
+++ b/src/SerializeSourcemap.cc
@@ -7,6 +7,7 @@
 //
 
 #include "SerializeSourcemap.h"
+#include "ConversionContext.h"
 
 using namespace drafter;
 
@@ -420,7 +421,7 @@ bool IsElementResourceGroup(const SourceMap<Element>& element)
     return element.element == Element::CategoryElement && element.category == Element::ResourceGroupCategory;
 }
 
-sos::Object drafter::WrapBlueprintSourcemap(const SourceMap<Blueprint>& blueprint)
+sos::Object drafter::WrapBlueprintSourcemap(const SourceMap<Blueprint>& blueprint, ConversionContext& context)
 {
     sos::Object blueprintObject;
 
@@ -436,7 +437,7 @@ sos::Object drafter::WrapBlueprintSourcemap(const SourceMap<Blueprint>& blueprin
 
     // Resource Groups
     blueprintObject.set(SerializeKey::ResourceGroups,
-                        WrapCollection<Element>()(blueprint.content.elements().collection, WrapResourceGroupSourcemap, IsElementResourceGroup, false));
+                        WrapCollectionIf<Element>()(blueprint.content.elements().collection, WrapResourceGroupSourcemap, IsElementResourceGroup));
 
     // Content
     blueprintObject.set(SerializeKey::Content,

--- a/src/SerializeSourcemap.h
+++ b/src/SerializeSourcemap.h
@@ -13,7 +13,9 @@
 
 namespace drafter {
 
-    sos::Object WrapBlueprintSourcemap(const snowcrash::SourceMap<snowcrash::Blueprint>& blueprint);
+    class ConversionContext;
+
+    sos::Object WrapBlueprintSourcemap(const snowcrash::SourceMap<snowcrash::Blueprint>& blueprint, ConversionContext& context);
 }
 
 #endif

--- a/src/cdrafter.cc
+++ b/src/cdrafter.cc
@@ -50,10 +50,8 @@ SC_API int drafter_c_parse(const char* source,
         std::stringstream resultStream;
         drafter::WrapperOptions wrapperOptions(drafter::ASTType(astType), options & SC_EXPORT_SORUCEMAP_OPTION);
 
-        drafter::ConversionContext context;
-
         try {
-            serializer.process(drafter::WrapResult(blueprint, wrapperOptions, context), resultStream);
+            serializer.process(drafter::WrapResult(blueprint, wrapperOptions), resultStream);
         }
         catch (snowcrash::Error& e) {
             blueprint.report.error = e;

--- a/src/cdrafter.cc
+++ b/src/cdrafter.cc
@@ -17,6 +17,8 @@
 #include "SerializeSourcemap.h"
 #include "SerializeResult.h"
 
+#include "ConversionContext.h"
+
 #include <string.h>
 
 namespace sc = snowcrash;
@@ -48,8 +50,10 @@ SC_API int drafter_c_parse(const char* source,
         std::stringstream resultStream;
         drafter::WrapperOptions wrapperOptions(drafter::ASTType(astType), options & SC_EXPORT_SORUCEMAP_OPTION);
 
+        drafter::ConversionContext context;
+
         try {
-            serializer.process(drafter::WrapResult(blueprint, wrapperOptions), resultStream);
+            serializer.process(drafter::WrapResult(blueprint, wrapperOptions, context), resultStream);
         }
         catch (snowcrash::Error& e) {
             blueprint.report.error = e;

--- a/src/main.cc
+++ b/src/main.cc
@@ -19,6 +19,8 @@
 #include "config.h"
 #include "stream.h"
 
+#include "ConversionContext.h"
+
 namespace sc = snowcrash;
 
 /**
@@ -62,8 +64,10 @@ int main(int argc, const char *argv[])
     sos::Serialize* serializer = CreateSerializer(config.format);
     std::ostream *out = CreateStreamFromName<std::ostream>(config.output);
 
+    drafter::ConversionContext context;
+
     try {
-        sos::Object resultObject = drafter::WrapResult(blueprint, drafter::WrapperOptions(config.astType, config.sourceMap));
+        sos::Object resultObject = drafter::WrapResult(blueprint, drafter::WrapperOptions(config.astType, config.sourceMap), context);
 
         if (!config.validate) { // If not validate, we serialize
             Serialization(out, resultObject, serializer);

--- a/src/main.cc
+++ b/src/main.cc
@@ -64,10 +64,8 @@ int main(int argc, const char *argv[])
     sos::Serialize* serializer = CreateSerializer(config.format);
     std::ostream *out = CreateStreamFromName<std::ostream>(config.output);
 
-    drafter::ConversionContext context;
-
     try {
-        sos::Object resultObject = drafter::WrapResult(blueprint, drafter::WrapperOptions(config.astType, config.sourceMap), context);
+        sos::Object resultObject = drafter::WrapResult(blueprint, drafter::WrapperOptions(config.astType, config.sourceMap));
 
         if (!config.validate) { // If not validate, we serialize
             Serialization(out, resultObject, serializer);

--- a/test/draftertest.h
+++ b/test/draftertest.h
@@ -137,7 +137,7 @@ namespace draftertest {
             return ext::json;
         }
 
-        typedef sos::Object (*Wrapper)(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const drafter::WrapperOptions& options, drafter::ConversionContext& context);
+        typedef sos::Object (*Wrapper)(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const drafter::WrapperOptions& options);
 
         static bool handleResultJSON(const Wrapper wrapper, const std::string& basepath, const drafter::WrapperOptions& options, bool mustBeOk = false) {
             ITFixtureFiles fixture = ITFixtureFiles(basepath);
@@ -150,7 +150,7 @@ namespace draftertest {
             sos::SerializeJSON serializer;
             drafter::ConversionContext context;
 
-            serializer.process((*wrapper)(blueprint, options, context), outStream);
+            serializer.process((*wrapper)(blueprint, options), outStream);
             outStream << "\n";
 
             std::string actual = outStream.str();

--- a/test/draftertest.h
+++ b/test/draftertest.h
@@ -12,6 +12,8 @@
 #include "SerializeResult.h"
 #include "sosJSON.h"
 
+#include "ConversionContext.h"
+
 #define TEST_DRAFTER(description, category, name, tag,  wrapper, options, mustBeOk) TEST_CASE(description " " category " " name, "[" tag "][" category "]") { \
     REQUIRE(FixtureHelper::handleResultJSON(wrapper, "test/fixtures/" category "/" name, options, mustBeOk)); \
 }
@@ -135,7 +137,7 @@ namespace draftertest {
             return ext::json;
         }
 
-        typedef sos::Object (*Wrapper)(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const drafter::WrapperOptions& options);
+        typedef sos::Object (*Wrapper)(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const drafter::WrapperOptions& options, drafter::ConversionContext& context);
 
         static bool handleResultJSON(const Wrapper wrapper, const std::string& basepath, const drafter::WrapperOptions& options, bool mustBeOk = false) {
             ITFixtureFiles fixture = ITFixtureFiles(basepath);
@@ -146,8 +148,9 @@ namespace draftertest {
 
             std::stringstream outStream;
             sos::SerializeJSON serializer;
+            drafter::ConversionContext context;
 
-            serializer.process((*wrapper)(blueprint, options), outStream);
+            serializer.process((*wrapper)(blueprint, options, context), outStream);
             outStream << "\n";
 
             std::string actual = outStream.str();


### PR DESCRIPTION
This patch additionaly remove global access point `GetNamedTypeRegistry()` instead is `Registry` instance stored in `ConversionContext`

To be thread safe we need add `RefractElementFactory` into Context too.
It will be done in next pull request