### PR TITLE
Some errors should not stop parsing.

### DIFF
--- a/src/ConversionContext.h
+++ b/src/ConversionContext.h
@@ -9,6 +9,7 @@
 #define DRAFTER_CONVERSIONCONTEXT_H
 
 #include "refract/Registry.h"
+#include "snowcrash.h"
 
 namespace drafter {
 
@@ -17,6 +18,7 @@ namespace drafter {
 
     public:
         const WrapperOptions& options;
+        std::vector<snowcrash::Warning> warnings;
 
         inline refract::Registry& GetNamedTypesRegistry() { return registry; }
 

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -323,13 +323,19 @@ namespace drafter {
         // ideal solution is add warning into collection
         // but there is no way how to do it
         // in current time we solve it by rethrow
-
         catch (snowcrash::Error& e) {
-            e.location = payload.sourceMap->sourceMap;
-            throw e;
+            context.warnings.push_back(
+                snowcrash::Warning("unable to render JSON/JSONSchema. " + e.message,
+                                   snowcrash::ApplicationError,
+                                   payload.sourceMap->sourceMap));
         }
         catch (refract::LogicError& e) {
-            throw snowcrash::Error(e.what(), snowcrash::ApplicationError, payload.sourceMap->sourceMap);
+            context.warnings.push_back(
+                snowcrash::Warning(std::string(
+                                       "unable to render JSON/JSONSchema. ").append(
+                                           e.what()),
+                                   snowcrash::ApplicationError,
+                                   payload.sourceMap->sourceMap));
         }
 
         RemoveEmptyElements(content);

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -737,7 +737,11 @@ namespace drafter {
 
             if (property.node->name.variable.values.size() > 1) {
                 // FIXME: is there example for multiple variables?
-                throw snowcrash::Error("multiple variables in property definition is not implemented", snowcrash::MSONError, sourceMap.sourceMap);
+                context.warnings.push_back(
+                    snowcrash::Warning(
+                        "multiple variables in property definition is not implemented",
+                        snowcrash::MSONError,
+                        sourceMap.sourceMap));
             }
 
             // variable containt type definition

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -131,6 +131,9 @@ sos::Object WrapParseResultRefract(snowcrash::ParseResult<snowcrash::Blueprint>&
     }
 
     snowcrash::Warnings& warnings = blueprint.report.warnings;
+    if (!context.warnings.empty()) {
+        warnings.insert(warnings.end(), context.warnings.begin(), context.warnings.end());
+    }
 
     if (!warnings.empty()) {
         std::transform(warnings.begin(), warnings.end(),


### PR DESCRIPTION
This probably is not a complete list but there is no way how to trigger
those I leave it as is with the infrastructure in place so we can add
them anytime later.

Couldn't come with a test cases as all the errors are impossible to
trigger if there is not a bug in snowcrash.