### PR TITLE
Add -std=c++11 option to cflags

### DIFF
--- a/configure
+++ b/configure
@@ -165,7 +165,7 @@ output = {
   'include_dirs': [],
   'libraries': [],
   'defines': [],
-  'cflags': [],
+  'cflags': [ '-std=c++11' ],
 }
 
 configure_drafter(output)


### PR DESCRIPTION
This should be fixing #244 on gcc 5.x version. However I did not test it in other environments, it would probably be worth testing if it does not break builds with older gcc.

Build and tests pass and but it produces bambilion of warnings cause auto_ptr  seems to be deprecated in c++11. Drafter itself works like a charm.