### PR TITLE
Fix memory leak while failing to open file

### DIFF
--- a/src/refract/ElementInserter.h
+++ b/src/refract/ElementInserter.h
@@ -19,9 +19,22 @@ namespace refract
     template <typename T>
     struct ElementInsertIterator : public std::iterator<std::output_iterator_tag, void, void, void, void> {
         T& element;
+
         ElementInsertIterator(T& element) : element(element) {}
 
+        ElementInsertIterator(const ElementInsertIterator& other) : element(other.element) {}
+
+        ElementInsertIterator& operator=(const ElementInsertIterator& other) {
+            element = other.element;
+            return *this;
+        }
+
         ElementInsertIterator& operator=(refract::IElement* e) {
+            element.push_back(e);
+            return *this;
+        }
+
+        ElementInsertIterator& operator=(const refract::IElement* e) {
             element.push_back(e);
             return *this;
         }

--- a/src/stream.h
+++ b/src/stream.h
@@ -137,6 +137,7 @@ T* CreateStreamFromName(const std::string& file)
 
     if (!stream->is_open()) {
       std::cerr << "fatal: unable to open file '" << file << "'\n";
+      delete stream;
       exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
I know we're exiting right away so it's not really a problem, but static analysers and such tools flag this as a leak.