### PR TITLE
ConversionContext is a class not struct

### DIFF
--- a/src/SerializeResult.h
+++ b/src/SerializeResult.h
@@ -22,7 +22,7 @@ namespace refract {
 
 namespace drafter {
 
-    struct ConversionContext;
+    class ConversionContext;
 
     sos::Object WrapAnnotation(const snowcrash::SourceAnnotation& annotation);
     sos::Object WrapResult(snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, const WrapperOptions& options);


### PR DESCRIPTION
```
In file included from ../src/main.cc:22:
../src/ConversionContext.h:18:5: warning: 'ConversionContext' defined as a class here but previously declared as a struct
      [-Wmismatched-tags]
    class ConversionContext {
    ^
../src/SerializeResult.h:25:5: note: did you mean class here?
    struct ConversionContext;
    ^~~~~~
    class
```