### PR TITLE
Install drafter static library and headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PYTHON ?= python
 GYP ?= ./ext/snowcrash/tools/gyp/gyp
 DESTDIR ?= /usr/local
 BINDIR ?= $(DESTDIR)/bin
+LIBDIR ?= $(DESTDIR)/lib
+INCLUDEDIR ?= $(DESTDIR)/include
 
 # Default to verbose builds
 V ?= 1
@@ -33,7 +35,11 @@ test-capi: config.gypi $(BUILD_DIR)/Makefile
 
 install: drafter
 	mkdir -p $(BINDIR)
+	mkdir -p $(INCLUDEDIR)/drafter
+	mkdir -p $(LIBDIR)
 	cp -f $(BUILD_DIR)/out/$(BUILDTYPE)/drafter $(BINDIR)/drafter
+	cp -f src/drafter.h $(INCLUDEDIR)/drafter/drafter.h
+	cp -f $(BUILD_DIR)/out/$(BUILDTYPE)/*.a $(LIBDIR)/
 
 config.gypi: configure
 	$(PYTHON) ./configure


### PR DESCRIPTION
This PR makes `make install` copy over the `drafter.h` header along with the static libraries.

#### Current Problems

There are two problems I see at the moment that I'd like to solve before we merge this:

- The current static library is not ideal, since the `libdrafter.a ` static library does not encapsulate all of the drafter dependencies, and thus the user will have to link against them all (snowcrash, sundown, sos, markdownparser, etc). This also means we need to expose them all in the user's lib dir when installing.

    ```
    -ldrafter -lsos -lsnowcrash -lmarkdownparser -lsundown -lc++
    ```

    It would be great if we can encapsulate them all into `libdrafter.a`. I know how to do this, but not with gyp. These dependencies are implementation details and we should keep them like that.
- We're only building and installing a static library. I think we should install both dynamic and static libraries. Dynamic libraries offer lots more possibilities for our users in Python/Ruby etc, using FFI and similar technologies people in these scripting languages can load a dynamic lib drafter at run-time.

#### Usage

```c
#include <stdlib.h>
#include <stdio.h>
#include <drafter/drafter.h>

int main(int argc, const char *argv[]) {
	const char* blueprint =
	  "# My API\n"
	  "## GET /message\n"
	  "+ Response 200 (text/plain)\n"
	  "\n"
	  "      Hello World!\n";

	drafter_options options;
	options.format = DRAFTER_SERIALIZE_JSON;
	options.sourcemap = true;

	char* result = NULL;
	if (drafter_parse_blueprint_to(blueprint, &result, options) == 0) {
		printf("%s\n", result);
		free(result);
	}

	return 0;
}
```

```shell
$ clang test.c -I/usr/local/include -L/usr/local/lib -ldrafter -lsos -lsnowcrash -lmarkdownparser -lsundown -lc++ -o test
```