### PR TITLE
Reference drafter-npm for Node JS parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ We love **Windows** too! Please refer to [Building on Windows](https://github.co
 ## Bindings
 Drafter bindings in other languages:
 
-- [Protagonist](https://github.com/apiaryio/protagonist) (Node.js)
+- [drafter-npm](https://github.com/apiaryio/drafter-npm) (Node.js)
 - [drafter.js](https://github.com/apiaryio/drafter.js) (Pure JavaScript)
 - [RedSnow](https://github.com/apiaryio/redsnow) (Ruby)
 


### PR DESCRIPTION
User's should prefer to use the new NPM drafter package from node instead of hitting Protagonist directly.

Depends on https://github.com/apiaryio/drafter-npm/pull/1