### PR TITLE
Use default/sample enum values over members when rendering JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 * Fixes rendering when One Of contains member sections with named types.
   [#360](https://github.com/apiaryio/drafter/issues/360)
 
+* Default and sample enum values will take precedence as the example value in
+  the rendered JSON structure over the enum members.
+
+
 ## 3.0.0
 
 ### Breaking

--- a/src/refract/RenderJSONVisitor.cc
+++ b/src/refract/RenderJSONVisitor.cc
@@ -149,7 +149,7 @@ namespace refract
 
         if (!enumValue) { // there is no enumValue injected from ExtendElement,try to pick value directly
 
-            const EnumElement::ValueType* val = GetValue<EnumElement>(e);
+            const EnumElement::ValueType* val = GetEnumValue(e);
             if (val && !val->empty()) {
                 enumValue = val->front()->clone();
             }

--- a/src/refract/VisitorUtils.h
+++ b/src/refract/VisitorUtils.h
@@ -125,6 +125,32 @@ namespace refract
         }
     };
 
+    struct GetEnumValue {
+        const EnumElement& element;
+
+        GetEnumValue(const EnumElement& e) : element(e) {}
+
+        operator const EnumElement::ValueType*() {
+            if (const EnumElement* s = GetSample(element)) {
+                return &s->value;
+            }
+
+            if (const EnumElement* d = GetDefault(element)) {
+                return &d->value;
+            }
+
+            if (!element.empty()) {
+                return &element.value;
+            }
+
+            if (element.empty() && IsTypeAttribute(element, "nullable")) {
+                return NULL;
+            }
+
+            return &element.value;
+        }
+    };
+
     // will be moved into different header (as part of drafter instead of refract)
     template <typename T>
     void CheckMixinParent(refract::IElement* element)

--- a/test/fixtures/render/enum-default.apib
+++ b/test/fixtures/render/enum-default.apib
@@ -1,0 +1,10 @@
+# GET /
+
++ Response 200 (application/json)
+    + Attributes
+        + enumField (enum)
+            + Members
+                + a
+                + b
+                + c
+            + Default: c

--- a/test/fixtures/render/enum-default.ast.json
+++ b/test/fixtures/render/enum-default.ast.json
@@ -1,0 +1,209 @@
+{
+  "_version": "2.2",
+  "ast": {
+    "_version": "4.0",
+    "metadata": [],
+    "name": "",
+    "description": "",
+    "element": "category",
+    "resourceGroups": [
+      {
+        "name": "",
+        "description": "",
+        "resources": [
+          {
+            "element": "resource",
+            "name": "",
+            "description": "",
+            "uriTemplate": "/",
+            "model": {},
+            "parameters": [],
+            "actions": [
+              {
+                "name": "",
+                "description": "",
+                "method": "GET",
+                "parameters": [],
+                "attributes": {
+                  "relation": "",
+                  "uriTemplate": ""
+                },
+                "content": [],
+                "examples": [
+                  {
+                    "name": "",
+                    "description": "",
+                    "requests": [],
+                    "responses": [
+                      {
+                        "name": "200",
+                        "description": "",
+                        "headers": [
+                          {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": "{\n  \"enumField\": \"c\"\n}",
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"enumField\": {\n      \"type\": \"string\",\n      \"enum\": [\n        \"a\",\n        \"b\",\n        \"c\"\n      ],\n      \"default\": \"c\"\n    }\n  }\n}",
+                        "content": [
+                          {
+                            "element": "dataStructure",
+                            "content": [
+                              {
+                                "element": "object",
+                                "content": [
+                                  {
+                                    "element": "member",
+                                    "content": {
+                                      "key": {
+                                        "element": "string",
+                                        "content": "enumField"
+                                      },
+                                      "value": {
+                                        "element": "enum",
+                                        "attributes": {
+                                          "default": [
+                                            {
+                                              "element": "string",
+                                              "content": "c"
+                                            }
+                                          ]
+                                        },
+                                        "content": [
+                                          {
+                                            "element": "string",
+                                            "content": "a"
+                                          },
+                                          {
+                                            "element": "string",
+                                            "content": "b"
+                                          },
+                                          {
+                                            "element": "string",
+                                            "content": "c"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "content": []
+          }
+        ]
+      }
+    ],
+    "content": [
+      {
+        "element": "category",
+        "content": [
+          {
+            "element": "resource",
+            "name": "",
+            "description": "",
+            "uriTemplate": "/",
+            "model": {},
+            "parameters": [],
+            "actions": [
+              {
+                "name": "",
+                "description": "",
+                "method": "GET",
+                "parameters": [],
+                "attributes": {
+                  "relation": "",
+                  "uriTemplate": ""
+                },
+                "content": [],
+                "examples": [
+                  {
+                    "name": "",
+                    "description": "",
+                    "requests": [],
+                    "responses": [
+                      {
+                        "name": "200",
+                        "description": "",
+                        "headers": [
+                          {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": "{\n  \"enumField\": \"c\"\n}",
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"enumField\": {\n      \"type\": \"string\",\n      \"enum\": [\n        \"a\",\n        \"b\",\n        \"c\"\n      ],\n      \"default\": \"c\"\n    }\n  }\n}",
+                        "content": [
+                          {
+                            "element": "dataStructure",
+                            "content": [
+                              {
+                                "element": "object",
+                                "content": [
+                                  {
+                                    "element": "member",
+                                    "content": {
+                                      "key": {
+                                        "element": "string",
+                                        "content": "enumField"
+                                      },
+                                      "value": {
+                                        "element": "enum",
+                                        "attributes": {
+                                          "default": [
+                                            {
+                                              "element": "string",
+                                              "content": "c"
+                                            }
+                                          ]
+                                        },
+                                        "content": [
+                                          {
+                                            "element": "string",
+                                            "content": "a"
+                                          },
+                                          {
+                                            "element": "string",
+                                            "content": "b"
+                                          },
+                                          {
+                                            "element": "string",
+                                            "content": "c"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "content": []
+          }
+        ]
+      }
+    ]
+  },
+  "error": {
+    "code": 0,
+    "message": "",
+    "location": []
+  },
+  "warnings": []
+}

--- a/test/fixtures/render/enum-sample.apib
+++ b/test/fixtures/render/enum-sample.apib
@@ -1,0 +1,10 @@
+# GET /
+
++ Response 200 (application/json)
+    + Attributes
+        + enumField (enum)
+            + Members
+                + a
+                + b
+                + c
+            + Sample: c

--- a/test/fixtures/render/enum-sample.ast.json
+++ b/test/fixtures/render/enum-sample.ast.json
@@ -1,0 +1,213 @@
+{
+  "_version": "2.2",
+  "ast": {
+    "_version": "4.0",
+    "metadata": [],
+    "name": "",
+    "description": "",
+    "element": "category",
+    "resourceGroups": [
+      {
+        "name": "",
+        "description": "",
+        "resources": [
+          {
+            "element": "resource",
+            "name": "",
+            "description": "",
+            "uriTemplate": "/",
+            "model": {},
+            "parameters": [],
+            "actions": [
+              {
+                "name": "",
+                "description": "",
+                "method": "GET",
+                "parameters": [],
+                "attributes": {
+                  "relation": "",
+                  "uriTemplate": ""
+                },
+                "content": [],
+                "examples": [
+                  {
+                    "name": "",
+                    "description": "",
+                    "requests": [],
+                    "responses": [
+                      {
+                        "name": "200",
+                        "description": "",
+                        "headers": [
+                          {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": "{\n  \"enumField\": \"c\"\n}",
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"enumField\": {\n      \"type\": \"string\",\n      \"enum\": [\n        \"a\",\n        \"b\",\n        \"c\"\n      ]\n    }\n  }\n}",
+                        "content": [
+                          {
+                            "element": "dataStructure",
+                            "content": [
+                              {
+                                "element": "object",
+                                "content": [
+                                  {
+                                    "element": "member",
+                                    "content": {
+                                      "key": {
+                                        "element": "string",
+                                        "content": "enumField"
+                                      },
+                                      "value": {
+                                        "element": "enum",
+                                        "attributes": {
+                                          "samples": [
+                                            [
+                                              {
+                                                "element": "string",
+                                                "content": "c"
+                                              }
+                                            ]
+                                          ]
+                                        },
+                                        "content": [
+                                          {
+                                            "element": "string",
+                                            "content": "a"
+                                          },
+                                          {
+                                            "element": "string",
+                                            "content": "b"
+                                          },
+                                          {
+                                            "element": "string",
+                                            "content": "c"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "content": []
+          }
+        ]
+      }
+    ],
+    "content": [
+      {
+        "element": "category",
+        "content": [
+          {
+            "element": "resource",
+            "name": "",
+            "description": "",
+            "uriTemplate": "/",
+            "model": {},
+            "parameters": [],
+            "actions": [
+              {
+                "name": "",
+                "description": "",
+                "method": "GET",
+                "parameters": [],
+                "attributes": {
+                  "relation": "",
+                  "uriTemplate": ""
+                },
+                "content": [],
+                "examples": [
+                  {
+                    "name": "",
+                    "description": "",
+                    "requests": [],
+                    "responses": [
+                      {
+                        "name": "200",
+                        "description": "",
+                        "headers": [
+                          {
+                            "name": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": "{\n  \"enumField\": \"c\"\n}",
+                        "schema": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"enumField\": {\n      \"type\": \"string\",\n      \"enum\": [\n        \"a\",\n        \"b\",\n        \"c\"\n      ]\n    }\n  }\n}",
+                        "content": [
+                          {
+                            "element": "dataStructure",
+                            "content": [
+                              {
+                                "element": "object",
+                                "content": [
+                                  {
+                                    "element": "member",
+                                    "content": {
+                                      "key": {
+                                        "element": "string",
+                                        "content": "enumField"
+                                      },
+                                      "value": {
+                                        "element": "enum",
+                                        "attributes": {
+                                          "samples": [
+                                            [
+                                              {
+                                                "element": "string",
+                                                "content": "c"
+                                              }
+                                            ]
+                                          ]
+                                        },
+                                        "content": [
+                                          {
+                                            "element": "string",
+                                            "content": "a"
+                                          },
+                                          {
+                                            "element": "string",
+                                            "content": "b"
+                                          },
+                                          {
+                                            "element": "string",
+                                            "content": "c"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "content": []
+          }
+        ]
+      }
+    ]
+  },
+  "error": {
+    "code": 0,
+    "message": "",
+    "location": []
+  },
+  "warnings": []
+}

--- a/test/fixtures/schema/default-section.json
+++ b/test/fixtures/schema/default-section.json
@@ -118,7 +118,7 @@
                               "attributes": {
                                 "contentType": "application/json"
                               },
-                              "content": "{\n  \"list\": \"3\"\n}"
+                              "content": "{\n  \"list\": \"4\"\n}"
                             },
                             {
                               "element": "asset",

--- a/test/test-RenderTest.cc
+++ b/test/test-RenderTest.cc
@@ -34,6 +34,8 @@ TEST_AST("render", "nullable");
 TEST_AST("render", "override");
 TEST_AST("render", "action-request-attributes");
 TEST_AST("render", "object-array-string");
+TEST_AST("render", "enum-default");
+TEST_AST("render", "enum-sample");
 
 TEST_AST("render", "issue-246");
 TEST_AST("render", "issue-318");


### PR DESCRIPTION
The following precedence of enum examples with rendering will now be taken:

- Sample Values
- Default Values
- Values
- Nullable