### PR TITLE
Add fixed-type support for arrays and objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Master
 
+### Enhancements
+
+* Warn about reserved characters in Named type declaration.
+  [snowcrash#335](https://github.com/apiaryio/snowcrash/issues/335)
+* Add `fixed-type` keyword support.
+  [mson#66](https://github.com/apiaryio/mson/issues/66)
+
 ### Bug Fixes
 
 * Ensure that sample values are rendered in JSON Schema when using the `fixed`

--- a/features/fixtures/blueprint.apib
+++ b/features/fixtures/blueprint.apib
@@ -98,7 +98,7 @@ Format: 1A
 
 # Data Structures
 
-## <data structure name>
+## `<data structure name>`
 <data structure description>
 
 ### Properties

--- a/features/fixtures/refract.sourcemap.json
+++ b/features/fixtures/refract.sourcemap.json
@@ -1829,7 +1829,7 @@
                             "content": [
                               [
                                 1573,
-                                25
+                                27
                               ]
                             ]
                           }
@@ -1845,7 +1845,7 @@
                             "element": "sourceMap",
                             "content": [
                               [
-                                1598,
+                                1600,
                                 30
                               ]
                             ]
@@ -1870,7 +1870,7 @@
                                 "element": "sourceMap",
                                 "content": [
                                   [
-                                    1645,
+                                    1647,
                                     117
                                   ]
                                 ]
@@ -1887,7 +1887,7 @@
                                 "element": "sourceMap",
                                 "content": [
                                   [
-                                    1645,
+                                    1647,
                                     117
                                   ]
                                 ]

--- a/features/fixtures/refract.sourcemap.yaml
+++ b/features/fixtures/refract.sourcemap.yaml
@@ -1179,7 +1179,7 @@ content:
                           content:
                             -
                               - 1573
-                              - 25
+                              - 27
                     content: "<data structure name>"
                   description:
                     element: "string"
@@ -1189,7 +1189,7 @@ content:
                           element: "sourceMap"
                           content:
                             -
-                              - 1598
+                              - 1600
                               - 30
                     content: "<data structure description>\n\n"
                 content:
@@ -1206,7 +1206,7 @@ content:
                               element: "sourceMap"
                               content:
                                 -
-                                  - 1645
+                                  - 1647
                                   - 117
                         content: "<data structure property name>"
                       value:
@@ -1217,7 +1217,7 @@ content:
                               element: "sourceMap"
                               content:
                                 -
-                                  - 1645
+                                  - 1647
                                   - 117
                         content: "<data structure property value>"
   -

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -134,6 +134,9 @@ namespace drafter {
         if (ta & mson::FixedTypeAttribute) {
             attr->push_back(refract::IElement::Create(SerializeKey::Fixed));
         }
+        if (ta & mson::FixedTypeTypeAttribute) {
+            attr->push_back(refract::IElement::Create(SerializeKey::FixedType));
+        }
         if (ta & mson::NullableTypeAttribute) {
             attr->push_back(refract::IElement::Create(SerializeKey::Nullable));
         }

--- a/src/Serialize.cc
+++ b/src/Serialize.cc
@@ -88,6 +88,7 @@ const std::string SerializeKey::Samples = "samples";
 const std::string SerializeKey::TypeAttributes = "typeAttributes";
 const std::string SerializeKey::Optional = "optional";
 const std::string SerializeKey::Fixed = "fixed";
+const std::string SerializeKey::FixedType = "fixedType";
 const std::string SerializeKey::True = "true";
 const std::string SerializeKey::Generic = "generic";
 const std::string SerializeKey::Enum = "enum";

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -139,6 +139,7 @@ namespace drafter {
         // Refract MSON attribute "typeAttibute" values
         static const std::string Optional;
         static const std::string Fixed;
+        static const std::string FixedType;
 
         // Literal to Bool
         static const std::string True;

--- a/src/refract/JSONSchemaVisitor.h
+++ b/src/refract/JSONSchemaVisitor.h
@@ -21,6 +21,7 @@ namespace refract
         ObjectElement *pObj;
         ObjectElement *pDefs;
         bool fixed;
+        bool fixedType;
 
         void setSchemaType(const std::string& type);
         void addSchemaType(const std::string& type);
@@ -43,9 +44,11 @@ namespace refract
 
     public:
         JSONSchemaVisitor(ObjectElement *pDefinitions = NULL,
-                          bool fixit = false);
+                          bool _fixed = false,
+                          bool _fixedType = false);
         ~JSONSchemaVisitor();
-        void setFixed(bool fixit);
+        void setFixed(bool _fixed);
+        void setFixedType(bool _fixedType);
         void operator()(const IElement& e);
         void operator()(const MemberElement& e);
         void operator()(const ObjectElement& e);

--- a/test/fixtures/schema/array-fixed-type.apib
+++ b/test/fixtures/schema/array-fixed-type.apib
@@ -1,0 +1,10 @@
+# Resource [/example]
+
+## Action [GET]
+
++ Response 200 (application/json)
+
+    + Attributes
+        - tags (array, fixed-type)
+            - hello (string)
+            - 42 (number)

--- a/test/fixtures/schema/array-fixed-type.json
+++ b/test/fixtures/schema/array-fixed-type.json
@@ -1,0 +1,145 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": ""
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": "Resource"
+              },
+              "attributes": {
+                "href": "/example"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "Action"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "dataStructure",
+                              "content": [
+                                {
+                                  "element": "object",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "attributes": {
+                                        "typeAttributes": [
+                                          "fixedType"
+                                        ]
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "tags"
+                                        },
+                                        "value": {
+                                          "element": "array",
+                                          "content": [
+                                            {
+                                              "element": "string",
+                                              "content": "hello"
+                                            },
+                                            {
+                                              "element": "number",
+                                              "content": 42
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/json"
+                              },
+                              "content": "{\n  \"tags\": [\n    \"hello\",\n    42\n  ]\n}"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"string\"\n        },\n        {\n          \"type\": \"number\"\n        }\n      ]\n    }\n  }\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/schema/object-fixed-type-named-type.apib
+++ b/test/fixtures/schema/object-fixed-type-named-type.apib
@@ -1,0 +1,13 @@
+# Resource [/example]
+
+## Action [GET]
+
++ Response 200 (application/json)
+    + Attributes
+        - person (Person)
+
+# Data Structures
+
+# Person (object, fixed-type)
+- first_name
+- last_name

--- a/test/fixtures/schema/object-fixed-type-named-type.json
+++ b/test/fixtures/schema/object-fixed-type-named-type.json
@@ -1,0 +1,182 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": ""
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": "Resource"
+              },
+              "attributes": {
+                "href": "/example"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "Action"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "dataStructure",
+                              "content": [
+                                {
+                                  "element": "object",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "person"
+                                        },
+                                        "value": {
+                                          "element": "Person"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/json"
+                              },
+                              "content": "{\n  \"person\": {\n    \"first_name\": \"\",\n    \"last_name\": \"\"\n  }\n}"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"person\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"first_name\": {\n          \"type\": \"string\"\n        },\n        \"last_name\": {\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"additionalProperties\": false\n    }\n  }\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "dataStructures"
+            ]
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": [
+                {
+                  "element": "object",
+                  "meta": {
+                    "id": "Person"
+                  },
+                  "attributes": {
+                    "typeAttributes": [
+                      "fixedType"
+                    ]
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "first_name"
+                        },
+                        "value": {
+                          "element": "string"
+                        }
+                      }
+                    },
+                    {
+                      "element": "member",
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "last_name"
+                        },
+                        "value": {
+                          "element": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/schema/object-fixed-type-values.apib
+++ b/test/fixtures/schema/object-fixed-type-values.apib
@@ -1,0 +1,11 @@
+# Resource [/example]
+
+## Action [GET]
+
++ Response 200 (application/json)
+
+    + Attributes
+        - person (object, fixed-type)
+            - first_name: Andrew
+            - last_name: Smith
+

--- a/test/fixtures/schema/object-fixed-type-values.json
+++ b/test/fixtures/schema/object-fixed-type-values.json
@@ -1,0 +1,163 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": ""
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": "Resource"
+              },
+              "attributes": {
+                "href": "/example"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "Action"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "dataStructure",
+                              "content": [
+                                {
+                                  "element": "object",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "attributes": {
+                                        "typeAttributes": [
+                                          "fixedType"
+                                        ]
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "person"
+                                        },
+                                        "value": {
+                                          "element": "object",
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "first_name"
+                                                },
+                                                "value": {
+                                                  "element": "string",
+                                                  "content": "Andrew"
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "element": "member",
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "last_name"
+                                                },
+                                                "value": {
+                                                  "element": "string",
+                                                  "content": "Smith"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/json"
+                              },
+                              "content": "{\n  \"person\": {\n    \"first_name\": \"Andrew\",\n    \"last_name\": \"Smith\"\n  }\n}"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"person\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"first_name\": {\n          \"type\": \"string\"\n        },\n        \"last_name\": {\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"additionalProperties\": false\n    }\n  }\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/schema/object-fixed-type.apib
+++ b/test/fixtures/schema/object-fixed-type.apib
@@ -1,0 +1,10 @@
+# Resource [/example]
+
+## Action [GET]
+
++ Response 200 (application/json)
+
+    + Attributes
+        - person (object, fixed-type)
+            - first_name
+            - last_name

--- a/test/fixtures/schema/object-fixed-type.json
+++ b/test/fixtures/schema/object-fixed-type.json
@@ -1,0 +1,161 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": ""
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": "Resource"
+              },
+              "attributes": {
+                "href": "/example"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "Action"
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "dataStructure",
+                              "content": [
+                                {
+                                  "element": "object",
+                                  "content": [
+                                    {
+                                      "element": "member",
+                                      "attributes": {
+                                        "typeAttributes": [
+                                          "fixedType"
+                                        ]
+                                      },
+                                      "content": {
+                                        "key": {
+                                          "element": "string",
+                                          "content": "person"
+                                        },
+                                        "value": {
+                                          "element": "object",
+                                          "content": [
+                                            {
+                                              "element": "member",
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "first_name"
+                                                },
+                                                "value": {
+                                                  "element": "string"
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "element": "member",
+                                              "content": {
+                                                "key": {
+                                                  "element": "string",
+                                                  "content": "last_name"
+                                                },
+                                                "value": {
+                                                  "element": "string"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/json"
+                              },
+                              "content": "{\n  \"person\": {\n    \"first_name\": \"\",\n    \"last_name\": \"\"\n  }\n}"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"person\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"first_name\": {\n          \"type\": \"string\"\n        },\n        \"last_name\": {\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"additionalProperties\": false\n    }\n  }\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test-SchemaTest.cc
+++ b/test/test-SchemaTest.cc
@@ -55,6 +55,7 @@ TEST_REFRACT("schema", "array-fixed-inline");
 TEST_REFRACT("schema", "array-fixed-inline-samples");
 TEST_REFRACT("schema", "array-fixed-samples");
 TEST_REFRACT("schema", "array-fixed-types-only");
+TEST_REFRACT("schema", "array-fixed-type");
 
 //FIXME: Discuss it with hj, as current drafter seems legit
 //boutique version of schema
@@ -70,6 +71,9 @@ TEST_REFRACT("schema", "array-fixed-samples-complex");
 TEST_REFRACT("schema", "object-fixed");
 TEST_REFRACT("schema", "object-fixed-values");
 TEST_REFRACT("schema", "object-fixed-optional");
+TEST_REFRACT("schema", "object-fixed-type");
+TEST_REFRACT("schema", "object-fixed-type-named-type");
+TEST_REFRACT("schema", "object-fixed-type-values");
 TEST_REFRACT("schema", "object-complex");
 TEST_REFRACT("schema", "object-very-complex");
 


### PR DESCRIPTION
I do not know should fixed-type attribute work for other types (strings, enums & etc). If it should work - please describe me how. Also I've adjust tests for last revision of snowcrash library.

Based on https://github.com/apiaryio/mson/issues/66