### PR TITLE
Link to Drafter AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ brew install --HEAD \
   https://raw.github.com/apiaryio/drafter/master/tools/homebrew/drafter.rb
 ```
 
-[AUR package](https://aur.archlinux.org/packages/drafter-git/) for Arch Linux.
+[AUR package](https://aur.archlinux.org/packages/drafter/) for Arch Linux.
 
 Other systems refer to [build notes](#build).
 


### PR DESCRIPTION
drafter-git our package is outdated, incorrect and broken. It would be better to point to the stable non-git version.