### PR TITLE
fix(API Elements): Don't wrap default values in an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Correctly set the content type for custom JSON Schema.
   [#392](https://github.com/apiaryio/drafter/issues/392)
 
+* Default values were incorrectly wrapped in an array inside dataStructures for
+  API Elements output in Drafter. As per the API Elements specification this
+  isn't the correct behaviour and as such this no longer is the case.
+
 
 ## 3.1.1
 

--- a/features/fixtures/refract.json
+++ b/features/fixtures/refract.json
@@ -85,12 +85,7 @@
                                 }
                               ]
                             ],
-                            "default": [
-                              {
-                                "element": "string",
-                                "content": "<default value>"
-                              }
-                            ]
+                            "default": "<default value>"
                           },
                           "content": [
                             {
@@ -178,12 +173,7 @@
                                     }
                                   ]
                                 ],
-                                "default": [
-                                  {
-                                    "element": "string",
-                                    "content": "<default value>"
-                                  }
-                                ]
+                                "default": "<default value>"
                               },
                               "content": [
                                 {

--- a/features/fixtures/refract.sourcemap.json
+++ b/features/fixtures/refract.sourcemap.json
@@ -230,25 +230,23 @@
                                 }
                               ]
                             ],
-                            "default": [
-                              {
-                                "element": "string",
-                                "attributes": {
-                                  "sourceMap": [
-                                    {
-                                      "element": "sourceMap",
-                                      "content": [
-                                        [
-                                          516,
-                                          86
-                                        ]
+                            "default": {
+                              "element": "string",
+                              "attributes": {
+                                "sourceMap": [
+                                  {
+                                    "element": "sourceMap",
+                                    "content": [
+                                      [
+                                        516,
+                                        86
                                       ]
-                                    }
-                                  ]
-                                },
-                                "content": "<default value>"
-                              }
-                            ]
+                                    ]
+                                  }
+                                ]
+                              },
+                              "content": "<default value>"
+                            }
                           },
                           "content": [
                             {
@@ -491,25 +489,23 @@
                                     }
                                   ]
                                 ],
-                                "default": [
-                                  {
-                                    "element": "string",
-                                    "attributes": {
-                                      "sourceMap": [
-                                        {
-                                          "element": "sourceMap",
-                                          "content": [
-                                            [
-                                              823,
-                                              86
-                                            ]
+                                "default": {
+                                  "element": "string",
+                                  "attributes": {
+                                    "sourceMap": [
+                                      {
+                                        "element": "sourceMap",
+                                        "content": [
+                                          [
+                                            823,
+                                            86
                                           ]
-                                        }
-                                      ]
-                                    },
-                                    "content": "<default value>"
-                                  }
-                                ]
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  "content": "<default value>"
+                                }
                               },
                               "content": [
                                 {

--- a/features/fixtures/refract.sourcemap.yaml
+++ b/features/fixtures/refract.sourcemap.yaml
@@ -153,17 +153,16 @@ content:
                                           - 86
                                 content: "<example value>"
                           default:
-                            -
-                              element: "string"
-                              attributes:
-                                sourceMap:
-                                  -
-                                    element: "sourceMap"
-                                    content:
-                                      -
-                                        - 516
-                                        - 86
-                              content: "<default value>"
+                            element: "string"
+                            attributes:
+                              sourceMap:
+                                -
+                                  element: "sourceMap"
+                                  content:
+                                    -
+                                      - 516
+                                      - 86
+                            content: "<default value>"
                         content:
                           -
                             element: "string"
@@ -319,17 +318,16 @@ content:
                                               - 86
                                     content: "<example value>"
                               default:
-                                -
-                                  element: "string"
-                                  attributes:
-                                    sourceMap:
-                                      -
-                                        element: "sourceMap"
-                                        content:
-                                          -
-                                            - 823
-                                            - 86
-                                  content: "<default value>"
+                                element: "string"
+                                attributes:
+                                  sourceMap:
+                                    -
+                                      element: "sourceMap"
+                                      content:
+                                        -
+                                          - 823
+                                          - 86
+                                content: "<default value>"
                             content:
                               -
                                 element: "string"

--- a/features/fixtures/refract.yaml
+++ b/features/fixtures/refract.yaml
@@ -62,10 +62,7 @@ content:
                               -
                                 element: "string"
                                 content: "<example value>"
-                          default:
-                            -
-                              element: "string"
-                              content: "<default value>"
+                          default: "<default value>"
                         content:
                           -
                             element: "string"
@@ -124,10 +121,7 @@ content:
                                   -
                                     element: "string"
                                     content: "<example value>"
-                              default:
-                                -
-                                  element: "string"
-                                  content: "<default value>"
+                              default: "<default value>"
                             content:
                               -
                                 element: "string"

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -153,7 +153,7 @@ namespace drafter {
 
         // Add default value
         if (!parameter.node->defaultValue.empty()) {
-            element->attributes[SerializeKey::Default] = CreateArrayElement(LiteralToRefract<T>(MAKE_NODE_INFO(parameter, defaultValue), context), true);
+            element->attributes[SerializeKey::Default] = LiteralToRefract<T>(MAKE_NODE_INFO(parameter, defaultValue), context);
         }
 
         return element;

--- a/test/fixtures/api/resource-parameters.json
+++ b/test/fixtures/api/resource-parameters.json
@@ -55,12 +55,7 @@
                                 }
                               ]
                             ],
-                            "default": [
-                              {
-                                "element": "number",
-                                "content": 1
-                              }
-                            ]
+                            "default": 1
                           },
                           "content": [
                             {

--- a/test/fixtures/api/resource-parameters.sourcemap.json
+++ b/test/fixtures/api/resource-parameters.sourcemap.json
@@ -165,25 +165,23 @@
                                 }
                               ]
                             ],
-                            "default": [
-                              {
-                                "element": "number",
-                                "attributes": {
-                                  "sourceMap": [
-                                    {
-                                      "element": "sourceMap",
-                                      "content": [
-                                        [
-                                          158,
-                                          11
-                                        ]
+                            "default": {
+                              "element": "number",
+                              "attributes": {
+                                "sourceMap": [
+                                  {
+                                    "element": "sourceMap",
+                                    "content": [
+                                      [
+                                        158,
+                                        11
                                       ]
-                                    }
-                                  ]
-                                },
-                                "content": 1
-                              }
-                            ]
+                                    ]
+                                  }
+                                ]
+                              },
+                              "content": 1
+                            }
                           },
                           "content": [
                             {


### PR DESCRIPTION
As per the API Elements specification (http://api-elements.readthedocs.io/en/latest/element-definitions/#data-structure-base-api-element). The content of a the default value should not be an array.

> The type of of default attribute MUST match the type of element's content.

This is not a breaking change to our own uses:

- Attributes Kit supports the correct behaviour: https://github.com/apiaryio/attributes-kit/blob/87f5e500b9435d5660a6bd4254f747ffbb83eff3/src/Modules/SamplesPreprocessor/SamplesPreprocessor.js#L31-L43
- Metamorphoses **only** supports the correct behaviour. I am fixing this in Drafter because I realised it was broken when integrating with Metamorphoses: https://github.com/apiaryio/metamorphoses/blob/22b13a6a97aa5d29b711c6821715a88fe2714bda/src/adapters/refract/getUriParameters.coffee#L24