### PR TITLE
fix(API Elements): Don't double wrap samples in array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Correctly set the content type for custom JSON Schema.
   [#392](https://github.com/apiaryio/drafter/issues/392)
 
+* Sample values were wrapped inside an array inside another array for data
+  structures in API Elements output. This fixes the double wrapping of sample
+  values in arrays.
+
 
 ## 3.1.1
 

--- a/features/fixtures/refract.json
+++ b/features/fixtures/refract.json
@@ -78,12 +78,7 @@
                           "element": "enum",
                           "attributes": {
                             "samples": [
-                              [
-                                {
-                                  "element": "string",
-                                  "content": "<example value>"
-                                }
-                              ]
+                              "<example value>"
                             ],
                             "default": [
                               {
@@ -171,12 +166,7 @@
                               "element": "enum",
                               "attributes": {
                                 "samples": [
-                                  [
-                                    {
-                                      "element": "string",
-                                      "content": "<example value>"
-                                    }
-                                  ]
+                                  "<example value>"
                                 ],
                                 "default": [
                                   {

--- a/features/fixtures/refract.sourcemap.json
+++ b/features/fixtures/refract.sourcemap.json
@@ -210,25 +210,23 @@
                           "element": "enum",
                           "attributes": {
                             "samples": [
-                              [
-                                {
-                                  "element": "string",
-                                  "attributes": {
-                                    "sourceMap": [
-                                      {
-                                        "element": "sourceMap",
-                                        "content": [
-                                          [
-                                            516,
-                                            86
-                                          ]
+                              {
+                                "element": "string",
+                                "attributes": {
+                                  "sourceMap": [
+                                    {
+                                      "element": "sourceMap",
+                                      "content": [
+                                        [
+                                          516,
+                                          86
                                         ]
-                                      }
-                                    ]
-                                  },
-                                  "content": "<example value>"
-                                }
-                              ]
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "content": "<example value>"
+                              }
                             ],
                             "default": [
                               {
@@ -471,25 +469,23 @@
                               "element": "enum",
                               "attributes": {
                                 "samples": [
-                                  [
-                                    {
-                                      "element": "string",
-                                      "attributes": {
-                                        "sourceMap": [
-                                          {
-                                            "element": "sourceMap",
-                                            "content": [
-                                              [
-                                                823,
-                                                86
-                                              ]
+                                  {
+                                    "element": "string",
+                                    "attributes": {
+                                      "sourceMap": [
+                                        {
+                                          "element": "sourceMap",
+                                          "content": [
+                                            [
+                                              823,
+                                              86
                                             ]
-                                          }
-                                        ]
-                                      },
-                                      "content": "<example value>"
-                                    }
-                                  ]
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "content": "<example value>"
+                                  }
                                 ],
                                 "default": [
                                   {

--- a/features/fixtures/refract.sourcemap.yaml
+++ b/features/fixtures/refract.sourcemap.yaml
@@ -141,17 +141,16 @@ content:
                         attributes:
                           samples:
                             -
-                              -
-                                element: "string"
-                                attributes:
-                                  sourceMap:
-                                    -
-                                      element: "sourceMap"
-                                      content:
-                                        -
-                                          - 516
-                                          - 86
-                                content: "<example value>"
+                              element: "string"
+                              attributes:
+                                sourceMap:
+                                  -
+                                    element: "sourceMap"
+                                    content:
+                                      -
+                                        - 516
+                                        - 86
+                              content: "<example value>"
                           default:
                             -
                               element: "string"
@@ -307,17 +306,16 @@ content:
                             attributes:
                               samples:
                                 -
-                                  -
-                                    element: "string"
-                                    attributes:
-                                      sourceMap:
-                                        -
-                                          element: "sourceMap"
-                                          content:
-                                            -
-                                              - 823
-                                              - 86
-                                    content: "<example value>"
+                                  element: "string"
+                                  attributes:
+                                    sourceMap:
+                                      -
+                                        element: "sourceMap"
+                                        content:
+                                          -
+                                            - 823
+                                            - 86
+                                  content: "<example value>"
                               default:
                                 -
                                   element: "string"

--- a/features/fixtures/refract.yaml
+++ b/features/fixtures/refract.yaml
@@ -58,10 +58,7 @@ content:
                         element: "enum"
                         attributes:
                           samples:
-                            -
-                              -
-                                element: "string"
-                                content: "<example value>"
+                            - "<example value>"
                           default:
                             -
                               element: "string"
@@ -120,10 +117,7 @@ content:
                             element: "enum"
                             attributes:
                               samples:
-                                -
-                                  -
-                                    element: "string"
-                                    content: "<example value>"
+                                - "<example value>"
                               default:
                                 -
                                   element: "string"

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -147,7 +147,7 @@ namespace drafter {
         // Add sample value
         if (!parameter.node->exampleValue.empty()) {
             refract::ArrayElement* samples = new refract::ArrayElement;
-            samples->push_back(CreateArrayElement(LiteralToRefract<T>(MAKE_NODE_INFO(parameter, exampleValue), context), true));
+            samples->push_back(LiteralToRefract<T>(MAKE_NODE_INFO(parameter, exampleValue), context));
             element->attributes[SerializeKey::Samples] = samples;
         }
 

--- a/test/fixtures/api/resource-parameters.json
+++ b/test/fixtures/api/resource-parameters.json
@@ -48,12 +48,7 @@
                           "element": "enum",
                           "attributes": {
                             "samples": [
-                              [
-                                {
-                                  "element": "number",
-                                  "content": 23
-                                }
-                              ]
+                              23
                             ],
                             "default": [
                               {

--- a/test/fixtures/api/resource-parameters.sourcemap.json
+++ b/test/fixtures/api/resource-parameters.sourcemap.json
@@ -145,25 +145,23 @@
                           "element": "enum",
                           "attributes": {
                             "samples": [
-                              [
-                                {
-                                  "element": "number",
-                                  "attributes": {
-                                    "sourceMap": [
-                                      {
-                                        "element": "sourceMap",
-                                        "content": [
-                                          [
-                                            69,
-                                            47
-                                          ]
+                              {
+                                "element": "number",
+                                "attributes": {
+                                  "sourceMap": [
+                                    {
+                                      "element": "sourceMap",
+                                      "content": [
+                                        [
+                                          69,
+                                          47
                                         ]
-                                      }
-                                    ]
-                                  },
-                                  "content": 23
-                                }
-                              ]
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "content": 23
+                              }
                             ],
                             "default": [
                               {


### PR DESCRIPTION
I don't believe that these sample values should be double wrapped in arrays and I think this is a mistake.

API Elements (http://api-elements.readthedocs.io/en/latest/element-definitions/#properties_13) specifies that:

> The type of items in samples array attribute MUST match the type of element's content.