### PR TITLE
Fix url protocol of submodule /test/vendor/catch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/apiaryio/snowcrash.git
 [submodule "test/vendor/Catch"]
 	path = test/vendor/Catch
-	url = git://github.com/philsquared/Catch.git
+	url = https://github.com/philsquared/Catch.git
 [submodule "ext/sos"]
 	path = ext/sos
 	url = https://github.com/apiaryio/sos.git


### PR DESCRIPTION
git clone --recursive did not work, caused by a submodule reference using git:// instead of https://.