### PR TITLE
fix(integration tests): Respect GENERATE env variable

### DIFF
--- a/features/step_definitions/file_content_step.rb
+++ b/features/step_definitions/file_content_step.rb
@@ -2,6 +2,10 @@ Then /^the output should contain the content of file "(.*)"$/ do |filename|
   expected = nil
   in_current_dir do
     expected = File.read(filename)
+
+    if ENV['GENERATE'] == '1'
+      File.write(filename, all_output)
+    end
   end
 
   assert_partial_output(expected, all_output)


### PR DESCRIPTION
This makes the cucumber integration tests respect the `GENERATE` env variable to save new ASTs. This is the same behaviour as the main tests: https://github.com/apiaryio/drafter/blob/master/test/draftertest.h#L166