### PR TITLE
fix required attribute processing for json schema of oneOf

### DIFF
--- a/src/refract/JSONSchemaVisitor.cc
+++ b/src/refract/JSONSchemaVisitor.cc
@@ -346,67 +346,7 @@ namespace refract
             fixedType = true;
         }
 
-        for (std::vector<refract::IElement*>::const_iterator it = val.begin();
-             it != val.end();
-             ++it) {
-
-            if (!*it) {
-                continue;
-            }
-
-            TypeQueryVisitor type;
-            Visit(type, *(*it));
-
-            switch (type.get()) {
-                case TypeQueryVisitor::Member: {
-                    MemberElement *mr = static_cast<MemberElement*>(*it);
-                    if (IsTypeAttribute(*(*it), "required") ||
-                        IsTypeAttribute(*(*it), "fixed") ||
-                        ((fixed || fixedType) && !IsTypeAttribute(*(*it), "optional"))) {
-
-                        StringElement *str = TypeQueryVisitor::as<StringElement>(mr->value.first);
-                        if (str) {
-                            reqVals.push_back(IElement::Create(str->value));
-                        }
-                    }
-
-                    if (IsVariableProperty(*mr->value.first)) {
-                        varProps.push_back(mr);
-                    }
-                    else {
-                        JSONSchemaVisitor renderer(pDefs, fixed);
-                        Visit(renderer, *(*it));
-                        ObjectElement *o1 = TypeQueryVisitor::as<ObjectElement>(renderer.get());
-                        if (!o1->value.empty()) {
-                            MemberElement *m1 = TypeQueryVisitor::as<MemberElement>(o1->value[0]->clone());
-                            if (m1) {
-                                m1->renderType(IElement::rCompact);
-                                o->push_back(m1);
-                            }
-
-                        }
-                    }
-                }
-                break;
-
-                case TypeQueryVisitor::Select:
-                {
-                    SelectElement* sel = static_cast<SelectElement*>(*it);
-
-                    // FIXME: there is no valid solution for multiple "SelectElement" in one object.
-
-                    for (SelectElement::ValueType::const_iterator it = sel->value.begin() ; it != sel->value.end() ; ++it) {
-                        JSONSchemaVisitor v(pDefs);
-                        VisitBy(*(*it), v);
-                        oneOfMembers.push_back(v.getOwnership());
-                    }
-                }
-                break;
-
-                default:
-                    throw LogicError("Invalid member type of object in MSON definition");
-            }
-        }
+        processMembers(val.begin(), val.end(), reqVals, varProps, oneOfMembers, o);
 
         if (!varProps.empty()) {
             addVariableProps(varProps, o);
@@ -610,33 +550,11 @@ namespace refract
         ObjectElement* props = pObj;
         RefractElements members;
         ArrayElement::ValueType reqVals;
+        std::vector<MemberElement*> varProps; // TODO: Add variable properties processing
         RefractElements oneOfMembers;
         IncludeMembers(e, members);
 
-        for (OptionElement::ValueType::const_iterator it = members.begin() ; it != members.end() ; ++it) {
-            if (SelectElement* sel = TypeQueryVisitor::as<SelectElement>(*it)) {
-                for (SelectElement::ValueType::const_iterator it = sel->value.begin() ; it != sel->value.end() ; ++it) {
-                    JSONSchemaVisitor v(pDefs);
-                    VisitBy(*(*it), v);
-                    oneOfMembers.push_back(v.getOwnership());
-                }
-            }
-            else {
-                Visit(*this, *(*it));
-
-                if (MemberElement *mr = static_cast<MemberElement*>(*it)) {
-                    if (IsTypeAttribute(*(*it), "required") ||
-                        IsTypeAttribute(*(*it), "fixed") ||
-                        ((fixed || fixedType) && !IsTypeAttribute(*(*it), "optional"))) {
-
-                        StringElement *str = TypeQueryVisitor::as<StringElement>(mr->value.first);
-                        if (str) {
-                            reqVals.push_back(IElement::Create(str->value));
-                        }
-                    }
-                }
-            }
-        }
+        processMembers(members.begin(), members.end(), reqVals, varProps, oneOfMembers, props);
 
         pObj = new ObjectElement;
         pObj->renderType(IElement::rCompact);
@@ -687,5 +605,72 @@ namespace refract
         s.process(sv.value(), ss);
 
         return ss.str();
+    }
+
+    void JSONSchemaVisitor::processMembers(std::vector<refract::IElement*>::const_iterator begin,
+                                           std::vector<refract::IElement*>::const_iterator end,
+                                           ArrayElement::ValueType& reqVals,
+                                           std::vector<MemberElement*>& varProps,
+                                           RefractElements& oneOfMembers,
+                                           ObjectElement *o)
+    {
+        for (std::vector<refract::IElement*>::const_iterator it = begin; it != end; ++it) {
+            if (!*it) {
+                continue;
+            }
+
+            TypeQueryVisitor type;
+            Visit(type, *(*it));
+
+            switch (type.get()) {
+                case TypeQueryVisitor::Member: {
+                    MemberElement *mr = static_cast<MemberElement*>(*it);
+                    if (IsTypeAttribute(*(*it), "required") ||
+                        IsTypeAttribute(*(*it), "fixed") ||
+                        ((fixed || fixedType) && !IsTypeAttribute(*(*it), "optional"))) {
+
+                        StringElement *str = TypeQueryVisitor::as<StringElement>(mr->value.first);
+                        if (str) {
+                            reqVals.push_back(IElement::Create(str->value));
+                        }
+                    }
+
+                    if (IsVariableProperty(*mr->value.first)) {
+                        varProps.push_back(mr);
+                    }
+                    else {
+                        JSONSchemaVisitor renderer(pDefs, fixed);
+                        Visit(renderer, *(*it));
+                        ObjectElement *o1 = TypeQueryVisitor::as<ObjectElement>(renderer.get());
+                        if (!o1->value.empty()) {
+                            MemberElement *m1 = TypeQueryVisitor::as<MemberElement>(o1->value[0]->clone());
+                            if (m1) {
+                                m1->renderType(IElement::rCompact);
+                                o->push_back(m1);
+                            }
+
+                        }
+                    }
+                }
+                    break;
+
+                case TypeQueryVisitor::Select:
+                {
+                    SelectElement* sel = static_cast<SelectElement*>(*it);
+
+                    // FIXME: there is no valid solution for multiple "SelectElement" in one object.
+
+                    for (SelectElement::ValueType::const_iterator it = sel->value.begin() ; it != sel->value.end() ; ++it) {
+                        JSONSchemaVisitor v(pDefs);
+                        VisitBy(*(*it), v);
+                        oneOfMembers.push_back(v.getOwnership());
+                    }
+                }
+                    break;
+
+                default:
+                    throw LogicError("Invalid member type of object in MSON definition");
+            }
+        }
     }
 }

--- a/src/refract/JSONSchemaVisitor.cc
+++ b/src/refract/JSONSchemaVisitor.cc
@@ -609,6 +609,7 @@ namespace refract
     {
         ObjectElement* props = pObj;
         RefractElements members;
+        ArrayElement::ValueType reqVals;
         RefractElements oneOfMembers;
         IncludeMembers(e, members);
 
@@ -622,6 +623,18 @@ namespace refract
             }
             else {
                 Visit(*this, *(*it));
+
+                if (MemberElement *mr = static_cast<MemberElement*>(*it)) {
+                    if (IsTypeAttribute(*(*it), "required") ||
+                        IsTypeAttribute(*(*it), "fixed") ||
+                        ((fixed || fixedType) && !IsTypeAttribute(*(*it), "optional"))) {
+
+                        StringElement *str = TypeQueryVisitor::as<StringElement>(mr->value.first);
+                        if (str) {
+                            reqVals.push_back(IElement::Create(str->value));
+                        }
+                    }
+                }
             }
         }
 
@@ -629,6 +642,9 @@ namespace refract
         pObj->renderType(IElement::rCompact);
 
         addMember("properties", props);
+        if (!reqVals.empty()) {
+            addMember("required", new ArrayElement(reqVals, IElement::rCompact));
+        }
         if (!oneOfMembers.empty()) {
             addMember("oneOf", new ArrayElement(oneOfMembers, IElement::rCompact));
         }

--- a/src/refract/JSONSchemaVisitor.cc
+++ b/src/refract/JSONSchemaVisitor.cc
@@ -560,9 +560,11 @@ namespace refract
         pObj->renderType(IElement::rCompact);
 
         addMember("properties", props);
+
         if (!reqVals.empty()) {
             addMember("required", new ArrayElement(reqVals, IElement::rCompact));
         }
+
         if (!oneOfMembers.empty()) {
             addMember("oneOf", new ArrayElement(oneOfMembers, IElement::rCompact));
         }
@@ -625,11 +627,13 @@ namespace refract
             switch (type.get()) {
                 case TypeQueryVisitor::Member: {
                     MemberElement *mr = static_cast<MemberElement*>(*it);
+
                     if (IsTypeAttribute(*(*it), "required") ||
                         IsTypeAttribute(*(*it), "fixed") ||
                         ((fixed || fixedType) && !IsTypeAttribute(*(*it), "optional"))) {
 
                         StringElement *str = TypeQueryVisitor::as<StringElement>(mr->value.first);
+
                         if (str) {
                             reqVals.push_back(IElement::Create(str->value));
                         }
@@ -642,13 +646,14 @@ namespace refract
                         JSONSchemaVisitor renderer(pDefs, fixed);
                         Visit(renderer, *(*it));
                         ObjectElement *o1 = TypeQueryVisitor::as<ObjectElement>(renderer.get());
+
                         if (!o1->value.empty()) {
                             MemberElement *m1 = TypeQueryVisitor::as<MemberElement>(o1->value[0]->clone());
+
                             if (m1) {
                                 m1->renderType(IElement::rCompact);
                                 o->push_back(m1);
                             }
-
                         }
                     }
                 }

--- a/src/refract/JSONSchemaVisitor.h
+++ b/src/refract/JSONSchemaVisitor.h
@@ -43,6 +43,13 @@ namespace refract
 
         template<typename T> void primitiveType(const T& e);
 
+        void processMembers(std::vector<refract::IElement*>::const_iterator begin,
+                            std::vector<refract::IElement*>::const_iterator end,
+                            ArrayElement::ValueType& reqVals,
+                            std::vector<MemberElement*>& varProps,
+                            RefractElements& oneOfMembers,
+                            ObjectElement *o);
+
     public:
         JSONSchemaVisitor(ObjectElement *pDefinitions = NULL,
                           bool _fixed = false,

--- a/test/fixtures/oneof/required.apib
+++ b/test/fixtures/oneof/required.apib
@@ -1,0 +1,13 @@
+# GET /ab
+- response 200 (application/json)
+    - Attributes (Test)
+
+# Data Structures
+
+## Test (object)
+- One Of
+    - Properties
+        - foo: A (string, required)
+
+    - Properties
+        - bar: B (string)

--- a/test/fixtures/oneof/required.json
+++ b/test/fixtures/oneof/required.json
@@ -1,0 +1,185 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": ""
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": ""
+              },
+              "attributes": {
+                "href": "/ab"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": ""
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "dataStructure",
+                              "content": [
+                                {
+                                  "element": "Test"
+                                }
+                              ]
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/json"
+                              },
+                              "content": "{\n  \"foo\": \"A\"\n}"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {},\n  \"oneOf\": [\n    {\n      \"properties\": {\n        \"foo\": {\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"foo\"\n      ]\n    },\n    {\n      \"properties\": {\n        \"bar\": {\n          \"type\": \"string\"\n        }\n      }\n    }\n  ]\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "dataStructures"
+            ]
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": [
+                {
+                  "element": "object",
+                  "meta": {
+                    "id": "Test"
+                  },
+                  "content": [
+                    {
+                      "element": "select",
+                      "content": [
+                        {
+                          "element": "option",
+                          "content": [
+                            {
+                              "element": "member",
+                              "attributes": {
+                                "typeAttributes": [
+                                  "required"
+                                ]
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "foo"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "A"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "element": "option",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "bar"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "B"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/oneof/required2.apib
+++ b/test/fixtures/oneof/required2.apib
@@ -1,0 +1,12 @@
+# GET /ab
+- response 200 (application/json)
+    - Attributes (Test)
+
+# Data Structures
+
+## Test (object)
+- One Of
+    - Properties
+        - foo: A (string, required)
+
+    - bar: B (string, required)

--- a/test/fixtures/oneof/required2.json
+++ b/test/fixtures/oneof/required2.json
@@ -1,0 +1,190 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": ""
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": ""
+              },
+              "attributes": {
+                "href": "/ab"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": ""
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "dataStructure",
+                              "content": [
+                                {
+                                  "element": "Test"
+                                }
+                              ]
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/json"
+                              },
+                              "content": "{\n  \"foo\": \"A\"\n}"
+                            },
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBodySchema"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/schema+json"
+                              },
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {},\n  \"oneOf\": [\n    {\n      \"properties\": {\n        \"foo\": {\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"foo\"\n      ]\n    },\n    {\n      \"properties\": {\n        \"bar\": {\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"bar\"\n      ]\n    }\n  ]\n}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "dataStructures"
+            ]
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": [
+                {
+                  "element": "object",
+                  "meta": {
+                    "id": "Test"
+                  },
+                  "content": [
+                    {
+                      "element": "select",
+                      "content": [
+                        {
+                          "element": "option",
+                          "content": [
+                            {
+                              "element": "member",
+                              "attributes": {
+                                "typeAttributes": [
+                                  "required"
+                                ]
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "foo"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "A"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "element": "option",
+                          "content": [
+                            {
+                              "element": "member",
+                              "attributes": {
+                                "typeAttributes": [
+                                  "required"
+                                ]
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "bar"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "B"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test-OneOfTest.cc
+++ b/test/test-OneOfTest.cc
@@ -7,6 +7,7 @@ TEST_REFRACT("oneof", "simple");
 TEST_REFRACT("oneof", "object");
 TEST_REFRACT("oneof", "multi-properties");
 TEST_REFRACT("oneof", "expanded");
+TEST_REFRACT("oneof", "required");
 
 
 // FIXME: invalid JSON Schema

--- a/test/test-OneOfTest.cc
+++ b/test/test-OneOfTest.cc
@@ -8,6 +8,7 @@ TEST_REFRACT("oneof", "object");
 TEST_REFRACT("oneof", "multi-properties");
 TEST_REFRACT("oneof", "expanded");
 TEST_REFRACT("oneof", "required");
+TEST_REFRACT("oneof", "required2");
 
 
 // FIXME: invalid JSON Schema


### PR DESCRIPTION
This PR solves problem described in #452, but I think a bit of refactoring is required. It's possible to make it in separate PR or in this one.

Functions `void JSONSchemaVisitor::operator()(const OptionElement& e)` and `void JSONSchemaVisitor::operator()(const ObjectElement& e)` have a lot of common code (MemberElement & SelectElement processing, required attributes calculation) and I think this code a bit dirty: it's difficult to understand Select -> Option -> Select chain processing. This refactoring may take some time and it's difficult to estimate how much time it will be.

// UPDATE: refactoring complete