### PR TITLE
Bump minimum supported compiler versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Drafter Changelog
 
+## Master
+
+### Breaking
+
+* The following compiler versions are supported:
+
+  * Microsoft Visual C++ 2015 or higher
+  * GCC 5.3 or higher
+  * Clang 4.0 or higher
+
 ## 3.2.7
 
 ## Bug Fixes

--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ if (result) {
 ```
 
 ## Build
+
+### Compiler Support
+
+| Compiler | Minimum Supported Version |
+|----------|---------------------------|
+| Clang    | 4.0 |
+| GCC      | 5.3 |
+| MSVC++   | 2015 |
+
 1. Clone the repo + fetch the submodules:
 
     ```sh


### PR DESCRIPTION
Since we are near to releasing Drafter 4, this gives us another opportunity to make breaking changes in terms of supported compilers. I would propose we move to the following minimum versions:

| Compiler | Minimum Supported Version |
|----------|---------------------------|
| Clang    | 4.0 |
| GCC      | 5.3 |
| MSVC++   | 2015 |

This would allow us to make use of most [C++14 features and a few C++17 features](http://en.cppreference.com/w/cpp/compiler_support). I do not believe that supporting older compilers is as important as it once used to be, now that we have a pure JavaScript version of Drafter, the minimum compiler version doesn't add a barrier to using the API Blueprint parser and surrounding Node.JS tools such as Dredd as they can use the pure JavaScript version of Drafter.

The biggest requirement for the compilers would be supporting our development machines which are often the very latest compilers and also the platforms we use for parsing services. Here is the list of default compilers on various platforms:

| Platform | Compiler |
|--|--|
| Ubuntu 16.04 LTS | >= GCC 5.3.1 |
| CentOS 7 | GCC 4.8.5 |
| macOS (Xcode 8.3) | Clang 4 |
| Debian Stable (Stretch) | GCC 6 |
| ArchLinux | GCC 7.1.1 / Clang 4.0.1 |
| Gentoo | GCC 5.4 |
| Fedora 24-25 | GCC 6 |

I would like to have gone for GCC 6 to allow a lot of C++17, however I think Ubuntu 16.04 LTS support is important at the moment and therefore selected GCC 5.3 as the lowest supported version.