### PR TITLE
Enable array-restricted-to-type test fixture

### DIFF
--- a/test/fixtures/schema/array-restricted-to-type.json
+++ b/test/fixtures/schema/array-restricted-to-type.json
@@ -103,50 +103,48 @@
                           "content": [
                             {
                               "element": "dataStructure",
-                              "content": [
-                                {
-                                  "element": "object",
-                                  "content": [
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "tags"
-                                        },
-                                        "value": {
-                                          "element": "array",
-                                          "content": [
-                                            {
-                                              "element": "number",
-                                              "attributes": {
-                                                "typeAttributes": {
-                                                  "element": "array",
-                                                  "content": [
-                                                    {
-                                                      "element": "string",
-                                                      "content": "fixed"
-                                                    }
-                                                  ]
-                                                },
-                                                "samples": {
-                                                  "element": "array",
-                                                  "content": [
-                                                    {
-                                                      "element": "number",
-                                                      "content": 5
-                                                    }
-                                                  ]
-                                                }
+                              "content": {
+                                "element": "object",
+                                "content": [
+                                  {
+                                    "element": "member",
+                                    "content": {
+                                      "key": {
+                                        "element": "string",
+                                        "content": "tags"
+                                      },
+                                      "value": {
+                                        "element": "array",
+                                        "content": [
+                                          {
+                                            "element": "number",
+                                            "attributes": {
+                                              "typeAttributes": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "string",
+                                                    "content": "fixed"
+                                                  }
+                                                ]
+                                              },
+                                              "samples": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "number",
+                                                    "content": 5
+                                                  }
+                                                ]
                                               }
                                             }
-                                          ]
-                                        }
+                                          }
+                                        ]
                                       }
                                     }
-                                  ]
-                                }
-                              ]
+                                  }
+                                ]
+                              }
                             },
                             {
                               "element": "asset",

--- a/test/fixtures/schema/array-restricted-to-types-complex.json
+++ b/test/fixtures/schema/array-restricted-to-types-complex.json
@@ -103,65 +103,63 @@
                           "content": [
                             {
                               "element": "dataStructure",
-                              "content": [
-                                {
-                                  "element": "object",
-                                  "content": [
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "tags"
-                                        },
-                                        "value": {
-                                          "element": "array",
-                                          "content": [
-                                            {
-                                              "element": "string",
-                                              "attributes": {
-                                                "typeAttributes": {
-                                                  "element": "array",
-                                                  "content": [
-                                                    {
-                                                      "element": "string",
-                                                      "content": "fixed"
-                                                    }
-                                                  ]
-                                                },
-                                                "samples": {
-                                                  "element": "array",
-                                                  "content": [
-                                                    {
-                                                      "element": "string",
-                                                      "content": "hello"
-                                                    }
-                                                  ]
-                                                }
+                              "content": {
+                                "element": "object",
+                                "content": [
+                                  {
+                                    "element": "member",
+                                    "content": {
+                                      "key": {
+                                        "element": "string",
+                                        "content": "tags"
+                                      },
+                                      "value": {
+                                        "element": "array",
+                                        "content": [
+                                          {
+                                            "element": "string",
+                                            "attributes": {
+                                              "typeAttributes": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "string",
+                                                    "content": "fixed"
+                                                  }
+                                                ]
+                                              },
+                                              "samples": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "string",
+                                                    "content": "hello"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "element": "number",
+                                            "attributes": {
+                                              "typeAttributes": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "string",
+                                                    "content": "fixed"
+                                                  }
+                                                ]
                                               }
                                             },
-                                            {
-                                              "element": "number",
-                                              "attributes": {
-                                                "typeAttributes": {
-                                                  "element": "array",
-                                                  "content": [
-                                                    {
-                                                      "element": "string",
-                                                      "content": "fixed"
-                                                    }
-                                                  ]
-                                                }
-                                              },
-                                              "content": 42
-                                            }
-                                          ]
-                                        }
+                                            "content": 42
+                                          }
+                                        ]
                                       }
                                     }
-                                  ]
-                                }
-                              ]
+                                  }
+                                ]
+                              }
                             },
                             {
                               "element": "asset",

--- a/test/fixtures/schema/array-restricted-to-types.json
+++ b/test/fixtures/schema/array-restricted-to-types.json
@@ -103,55 +103,53 @@
                           "content": [
                             {
                               "element": "dataStructure",
-                              "content": [
-                                {
-                                  "element": "object",
-                                  "content": [
-                                    {
-                                      "element": "member",
-                                      "content": {
-                                        "key": {
-                                          "element": "string",
-                                          "content": "tags"
-                                        },
-                                        "value": {
-                                          "element": "array",
-                                          "content": [
-                                            {
-                                              "element": "string",
-                                              "attributes": {
-                                                "typeAttributes": {
-                                                  "element": "array",
-                                                  "content": [
-                                                    {
-                                                      "element": "string",
-                                                      "content": "fixed"
-                                                    }
-                                                  ]
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "element": "number",
-                                              "attributes": {
-                                                "typeAttributes": {
-                                                  "element": "array",
-                                                  "content": [
-                                                    {
-                                                      "element": "string",
-                                                      "content": "fixed"
-                                                    }
-                                                  ]
-                                                }
+                              "content": {
+                                "element": "object",
+                                "content": [
+                                  {
+                                    "element": "member",
+                                    "content": {
+                                      "key": {
+                                        "element": "string",
+                                        "content": "tags"
+                                      },
+                                      "value": {
+                                        "element": "array",
+                                        "content": [
+                                          {
+                                            "element": "string",
+                                            "attributes": {
+                                              "typeAttributes": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "string",
+                                                    "content": "fixed"
+                                                  }
+                                                ]
                                               }
                                             }
-                                          ]
-                                        }
+                                          },
+                                          {
+                                            "element": "number",
+                                            "attributes": {
+                                              "typeAttributes": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "string",
+                                                    "content": "fixed"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
                                       }
                                     }
-                                  ]
-                                }
-                              ]
+                                  }
+                                ]
+                              }
                             },
                             {
                               "element": "asset",

--- a/test/test-SchemaTest.cc
+++ b/test/test-SchemaTest.cc
@@ -65,11 +65,8 @@ TEST_REFRACT("schema", "array-fixed-type-object");
 //"content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"tags\": {\n      \"type\": \"array\",\n      \"items\": [\n        {\n          \"type\": \"string\",\n          \"enum\": [\n           \"hello\"\n          ]\n        },\n        {\n          \"type\": \"number\"\n        },\n        {\n          \"type\": \"object\",\n          \"properties\": {\n            \"name\": {\n              \"type\": \"string\"\n            },\n            \"color\": {\n              \"type\": \"string\",\n              \"enum\": [\"white\"]\n            },\n            \"description\": {\n              \"type\": \"string\"\n            }\n          },\n          \"additionalProperties\": false,\n          \"required\": [\"name\", \"color\", \"description\"]\n        },\n        {\n          \"type\": \"string\",\n          \"enum\": [\"world\"]\n        }\n      ]\n    }\n  },\n  \"required\": [\"tags\"]\n}"
 TEST_REFRACT("schema", "array-fixed-samples-complex");
 
-//FIXME: fixed bug #193
-//TEST_REFRACT("schema", "array-restricted-to-type");
-
-//FIXME: fixed bug #193
-//TEST_REFRACT("schema", "array-restricted-to-types-complex");
+TEST_REFRACT("schema", "array-restricted-to-type");
+TEST_REFRACT("schema", "array-restricted-to-types-complex");
 
 TEST_REFRACT("schema", "object-fixed");
 TEST_REFRACT("schema", "object-fixed-values");

--- a/test/test-SchemaTest.cc
+++ b/test/test-SchemaTest.cc
@@ -66,6 +66,7 @@ TEST_REFRACT("schema", "array-fixed-type-object");
 TEST_REFRACT("schema", "array-fixed-samples-complex");
 
 TEST_REFRACT("schema", "array-restricted-to-type");
+TEST_REFRACT("schema", "array-restricted-to-types");
 TEST_REFRACT("schema", "array-restricted-to-types-complex");
 
 TEST_REFRACT("schema", "object-fixed");


### PR DESCRIPTION
Since #193 was resolved, this fixture can be enabled (and updated to new serialisation).