### PR TITLE
Hold std::vector as member instead of base class in MemberElementCollection

### DIFF
--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -832,7 +832,7 @@ namespace drafter {
             // most safe is check it via refract::TypeQueryVisitor
             descriptionRef = (static_cast<refract::StringElement*>((*iterator)->value.second)->value);
             element->meta.push_back(*iterator);
-            value->meta.std::vector<refract::MemberElement*>::erase(iterator);
+            value->meta.erase(iterator);
             // FIXME: extract source map
         }
         else {

--- a/src/refract/Element.h
+++ b/src/refract/Element.h
@@ -67,16 +67,52 @@ namespace refract
 
     struct IElement
     {
-
-        struct MemberElementCollection : public std::vector<MemberElement*>
+        class MemberElementCollection final
         {
-            virtual const_iterator find(const std::string& name) const;
-            virtual iterator find(const std::string& name);
+            // FIXME raw pointer ownership
+            using Container = std::vector<MemberElement*>;
+            Container elements;
+
+           public:
+            using iterator = typename Container::iterator;
+            using const_iterator = typename Container::const_iterator;
+
+           public:
+            MemberElementCollection() = default;
+            ~MemberElementCollection();
+
+            MemberElementCollection(const MemberElementCollection&) = delete;
+            MemberElementCollection(MemberElementCollection&&) = default;
+
+            MemberElementCollection& operator=(const MemberElementCollection&) = delete;
+            MemberElementCollection& operator=(MemberElementCollection&&) = default;
+
+           public:
+            const_iterator begin() const noexcept { return elements.begin(); }
+            iterator begin() noexcept { return elements.begin(); }
+
+            const_iterator end() const noexcept { return elements.end(); }
+            iterator end() noexcept { return elements.end(); }
+
+            const_iterator find(const std::string& name) const;
+            iterator find(const std::string& name);
+
             MemberElement& operator[](const std::string& name);
-            MemberElement& operator[](const int index);
-            virtual void clone(const MemberElementCollection& other); /// < clone elements from `other` to `this`
-            virtual void erase(const std::string& key);
-            virtual ~MemberElementCollection();
+
+            /// clone elements from `other` to `this`
+            void clone(const MemberElementCollection& other);
+
+            // FIXME erase(const std::string) deletes pointer, whereas erase(iterator) does not
+            void erase(const std::string& key);
+            void erase(iterator it) { elements.erase(it); }
+
+            // FIXME pointers are not deleted
+            void clear() { elements.clear(); }
+
+            void push_back(MemberElement* e) { elements.push_back(e); }
+
+            bool empty() const noexcept { return elements.empty(); }
+            Container::size_type size() const noexcept { return elements.size(); }
         };
 
         MemberElementCollection meta;

--- a/src/refract/ElementInserter.h
+++ b/src/refract/ElementInserter.h
@@ -18,24 +18,22 @@ namespace refract
 
     template <typename T>
     struct ElementInsertIterator : public std::iterator<std::output_iterator_tag, void, void, void, void> {
-        T& element;
+        T* element;
 
-        ElementInsertIterator(T& element) : element(element) {}
+        ElementInsertIterator(T& element) : element(&element) {}
 
         ElementInsertIterator(const ElementInsertIterator& other) : element(other.element) {}
 
-        ElementInsertIterator& operator=(const ElementInsertIterator& other) {
-            element = other.element;
-            return *this;
-        }
+        ElementInsertIterator& operator=(const ElementInsertIterator& other) = default;
+        ElementInsertIterator& operator=(ElementInsertIterator&& other) = default;
 
         ElementInsertIterator& operator=(refract::IElement* e) {
-            element.push_back(e);
+            element->push_back(e);
             return *this;
         }
 
         ElementInsertIterator& operator=(const refract::IElement* e) {
-            element.push_back(e);
+            element->push_back(e);
             return *this;
         }
 
@@ -46,7 +44,6 @@ namespace refract
         ElementInsertIterator& operator*() {
             return *this;
         }
-        
     };
 
     template <typename T>


### PR DESCRIPTION
- std::vector is not meant to be derived from; it doesn't even have a virtual destructor. In the future, this could cause strange behaviour.
- Parts of the interface continues to be implemented sub-optimally or inconsistently; changing this was not in scope of the task, therefore FIXME comments were added where relevant