### PR TITLE
Simple refactoring - remove restful parameter from `RefractElementFromValue()`

### DIFF
--- a/test/fixtures/schema/array-restricted-to-type.json
+++ b/test/fixtures/schema/array-restricted-to-type.json
@@ -119,21 +119,21 @@
                                           {
                                             "element": "number",
                                             "attributes": {
-                                              "typeAttributes": {
-                                                "element": "array",
-                                                "content": [
-                                                  {
-                                                    "element": "string",
-                                                    "content": "fixed"
-                                                  }
-                                                ]
-                                              },
                                               "samples": {
                                                 "element": "array",
                                                 "content": [
                                                   {
                                                     "element": "number",
                                                     "content": 5
+                                                  }
+                                                ]
+                                              },
+                                              "typeAttributes": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "string",
+                                                    "content": "fixed"
                                                   }
                                                 ]
                                               }

--- a/test/fixtures/schema/array-restricted-to-types-complex.json
+++ b/test/fixtures/schema/array-restricted-to-types-complex.json
@@ -119,21 +119,21 @@
                                           {
                                             "element": "string",
                                             "attributes": {
-                                              "typeAttributes": {
-                                                "element": "array",
-                                                "content": [
-                                                  {
-                                                    "element": "string",
-                                                    "content": "fixed"
-                                                  }
-                                                ]
-                                              },
                                               "samples": {
                                                 "element": "array",
                                                 "content": [
                                                   {
                                                     "element": "string",
                                                     "content": "hello"
+                                                  }
+                                                ]
+                                              },
+                                              "typeAttributes": {
+                                                "element": "array",
+                                                "content": [
+                                                  {
+                                                    "element": "string",
+                                                    "content": "fixed"
                                                   }
                                                 ]
                                               }


### PR DESCRIPTION
I found this refactoring while work on Enum implementation. 
I don't like to be part of Enum PR so i push it for merge

In tests there is just changed order of attributes in output