### PR TITLE
Compile with -O3

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -48,6 +48,7 @@
         }
       },
       'Release': {
+        'cflags': [ '-O3' ],
         'conditions': [
           ['target_arch=="x64"', {
             'msvs_configuration_platform': 'x64',


### PR DESCRIPTION
During performance testing of unrelated functionality, I've noticed the production build not to specify optimization flags. Some functions I expected to inline gave it away.

On an example running around `24s` in my environment, after introducing `-O3`, the run time decreased to `7s`.

Although the `O`-set of flags has different definitions in both GCC and clang, I suggest to go with `-O3` until we decide which optimizations applied by these aliases we want.  