### PR TITLE
fix: Infinite loop issue

### DIFF
--- a/ext/snowcrash/ext/markdown-parser/markdownparser.xcodeproj/project.pbxproj
+++ b/ext/snowcrash/ext/markdown-parser/markdownparser.xcodeproj/project.pbxproj
@@ -319,7 +319,7 @@
 					CATCH_NO_EXCEPT,
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "./test/**";
+				USER_HEADER_SEARCH_PATHS = "../../../../test/**";
 			};
 			name = Debug;
 		};
@@ -329,7 +329,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				GCC_PREPROCESSOR_DEFINITIONS = CATCH_NO_EXCEPT;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "./test/**";
+				USER_HEADER_SEARCH_PATHS = "../../../../test/**";
 			};
 			name = Release;
 		};

--- a/ext/snowcrash/snowcrash.xcodeproj/project.pbxproj
+++ b/ext/snowcrash/snowcrash.xcodeproj/project.pbxproj
@@ -719,7 +719,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "./ext/markdown-parser/src/** ./ext/markdown-parser/ext/sundown/src/** ./test/**";
+				USER_HEADER_SEARCH_PATHS = "./ext/markdown-parser/src/** ./ext/markdown-parser/ext/sundown/src/** ../../test/**";
 			};
 			name = Debug;
 		};
@@ -727,7 +727,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "./ext/markdown-parser/src/** ./ext/markdown-parser/ext/sundown/src/** ./test/**";
+				USER_HEADER_SEARCH_PATHS = "./ext/markdown-parser/src/** ./ext/markdown-parser/ext/sundown/src/** ../../test/**";
 			};
 			name = Release;
 		};

--- a/ext/snowcrash/src/BlueprintParser.h
+++ b/ext/snowcrash/src/BlueprintParser.h
@@ -181,7 +181,8 @@ namespace snowcrash
 
                         contextSectionType = sectionType;
                         contextCur = cur;
-                    } else if (contextSectionType != DataStructureGroupSectionType) {
+                    } else if (contextSectionType != DataStructureGroupSectionType
+                        && SectionProcessor<Action>::sectionType(cur) == ActionSectionType) {
 
                         contextSectionType = UndefinedSectionType;
                     }
@@ -190,8 +191,7 @@ namespace snowcrash
                     if (contextSectionType == DataStructureGroupSectionType) {
 
                         if (sectionType != MSONSampleDefaultSectionType && sectionType != MSONPropertyMembersSectionType
-                            && sectionType != MSONValueMembersSectionType
-                            && sectionType != UndefinedSectionType
+                            && sectionType != MSONValueMembersSectionType && sectionType != UndefinedSectionType
                             && sectionType != DataStructureGroupSectionType) {
 
                             contextSectionType = UndefinedSectionType;

--- a/ext/snowcrash/test/test-BlueprintParser.cc
+++ b/ext/snowcrash/test/test-BlueprintParser.cc
@@ -1480,3 +1480,22 @@ TEST_CASE("Parse blueprint with escaped data structure reference", "[blueprint]"
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::CategoryElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
 }
+
+TEST_CASE("Parse blueprint with random header node after resource", "[blueprint]")
+{
+    mdp::ByteBuffer source
+        = "## Examples [/examples]\n"
+          "## X\n"
+          "+ Attributes (Examples)\n"
+          "# Data Structures\n"
+          "# Examples (object)\n"
+          "\n"
+          "# Y\n";
+
+    ParseResult<Blueprint> blueprint;
+    SectionParserHelper<Blueprint, BlueprintParser>::parse(
+        source, BlueprintSectionType, blueprint, ExportSourcemapOption, Models(), &blueprint);
+
+    REQUIRE(blueprint.report.error.code != Error::OK);
+    REQUIRE(blueprint.report.warnings.size() == 1);
+}

--- a/test/fixtures/render/issue-328-1.json
+++ b/test/fixtures/render/issue-328-1.json
@@ -30,11 +30,11 @@
                   "content": [
                     {
                       "element": "number",
-                      "content": 32
+                      "content": 30
                     },
                     {
                       "element": "number",
-                      "content": 15
+                      "content": 18
                     }
                   ]
                 }
@@ -43,7 +43,7 @@
           ]
         }
       },
-      "content": "base type 'C' is not defined in the document"
+      "content": "base type 'C' circularly referencing itself"
     }
   ]
 }

--- a/test/fixtures/render/issue-328-2.json
+++ b/test/fixtures/render/issue-328-2.json
@@ -2,92 +2,48 @@
   "element": "parseResult",
   "content": [
     {
-      "element": "category",
+      "element": "annotation",
       "meta": {
         "classes": {
           "element": "array",
           "content": [
             {
               "element": "string",
-              "content": "api"
+              "content": "error"
             }
           ]
-        },
-        "title": {
-          "element": "string",
-          "content": "API"
         }
       },
-      "content": [
-        {
-          "element": "category",
-          "meta": {
-            "classes": {
-              "element": "array",
-              "content": [
-                {
-                  "element": "string",
-                  "content": "resourceGroup"
-                }
-              ]
-            },
-            "title": {
-              "element": "string",
-              "content": ""
-            }
-          },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 4
+        },
+        "sourceMap": {
+          "element": "array",
           "content": [
             {
-              "element": "resource",
-              "meta": {
-                "title": {
-                  "element": "string",
-                  "content": "C"
-                }
-              },
-              "attributes": {
-                "href": {
-                  "element": "string",
-                  "content": "/c"
-                }
-              },
+              "element": "sourceMap",
               "content": [
                 {
-                  "element": "copy",
-                  "content": "### Add C(`[POST"
-                },
-                {
-                  "element": "dataStructure",
-                  "content": {
-                    "element": "C",
-                    "meta": {
-                      "id": {
-                        "element": "string",
-                        "content": "C"
-                      }
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "content": 35
+                    },
+                    {
+                      "element": "number",
+                      "content": 18
                     }
-                  }
+                  ]
                 }
               ]
             }
           ]
-        },
-        {
-          "element": "category",
-          "meta": {
-            "classes": {
-              "element": "array",
-              "content": [
-                {
-                  "element": "string",
-                  "content": "dataStructures"
-                }
-              ]
-            }
-          },
-          "content": []
         }
-      ]
+      },
+      "content": "base type 'C' circularly referencing itself"
     },
     {
       "element": "annotation",


### PR DESCRIPTION
Snowcrash should give out a circular reference error when an attirbutes
section is reference itself even when a description header node is present
before it.

This is actually a better fix for #328 than the one we did in #329 