### PR TITLE
Fix macOS clang compilation error

### DIFF
--- a/src/refract/dsd/Traits.h
+++ b/src/refract/dsd/Traits.h
@@ -136,7 +136,7 @@ namespace refract
             ///
             /// @return iterator following the member removed
             ///
-            auto erase(const_iterator it)
+            const_iterator erase(const_iterator it)
             {
                 return self().erase(it, std::next(it));
             }


### PR DESCRIPTION
```
$ clang --version
Apple LLVM version 9.0.0 (clang-900.0.39.2)
Target: x86_64-apple-darwin16.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

```
../src/refract/dsd/Traits.h:141:31: error: function 'erase' with deduced return type cannot be used before it is defined
                return self().erase(it, std::next(it));
                              ^
../src/refract/dsd/Traits.h:40:51: note: in instantiation of member function 'refract::dsd::container_traits<refract::dsd::Enum, std::__1::vector<std::__1::unique_ptr<refract::IElement, std::__1::default_delete<refract::IElement> >, std::__1::allocator<std::__1::unique_ptr<refract::IElement, std::__1::default_delete<refract::IElement> > > > >::erase' requested here
            typename = decltype(std::declval<T>().erase(std::declval<T>().begin(), std::declval<T>().begin()))>
                                                  ^
../src/refract/dsd/Traits.h:41:24: note: in instantiation of default argument for 'supports_erase_test<refract::dsd::Enum>' required here
        std::true_type supports_erase_test(const T&);
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/refract/dsd/Traits.h:44:41: note: while substituting deduced template arguments into function template 'supports_erase_test' [with T = refract::dsd::Enum, $1 = (no value)]
        using supports_erase = decltype(supports_erase_test(std::declval<T>()));
                                        ^
../src/refract/dsd/Enum.cc:20:16: note: in instantiation of template type alias 'supports_erase' requested here
static_assert(!supports_erase<Enum>::value, "");
               ^
../src/refract/dsd/Traits.h:139:18: note: 'erase' declared here
            auto erase(const_iterator it)
                 ^
1 error generated.
```