### PR TITLE
(util) trivial logger, enabled via cmd line option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ tags
 .cproject
 .project
 .settings
+
+# log
+*.log

--- a/drafter.gyp
+++ b/drafter.gyp
@@ -289,6 +289,8 @@
         "src/utils/so/JsonIo.cc",
         "src/utils/so/YamlIo.h",
         "src/utils/so/YamlIo.cc",
+        "src/utils/log/Trivial.h",
+        "src/utils/log/Trivial.cc",
 
         # librefract parts - will be separated into other project
         "src/refract/Utils.h",

--- a/src/config.cc
+++ b/src/config.cc
@@ -24,6 +24,7 @@ namespace config
     static const std::string Validate = "validate";
     static const std::string Version = "version";
     static const std::string UseLineNumbers = "use-line-num";
+    static const std::string EnableLog = "enable-log";
 };
 
 void PrepareCommanLineParser(cmdline::parser& parser)
@@ -43,6 +44,7 @@ void PrepareCommanLineParser(cmdline::parser& parser)
     parser.add(config::Validate, 'l', "validate input only, do not output Parse Result");
     parser.add(
         config::UseLineNumbers, 'u', "use line and row number instead of character index when printing annotation");
+    parser.add(config::EnableLog, 'L', "enable logging");
 
     std::stringstream ss;
 
@@ -88,6 +90,7 @@ void ParseCommadLineOptions(int argc, const char* argv[], /* out */ Config& conf
     conf.format = parser.get<std::string>(config::Format) == "json" ? drafter::JSONFormat : drafter::YAMLFormat;
     conf.output = parser.get<std::string>(config::Output);
     conf.sourceMap = parser.exist(config::Sourcemap);
+    conf.enableLog = parser.exist(config::EnableLog);
 
     ValidateParsedCommandLine(parser, conf);
 }

--- a/src/config.h
+++ b/src/config.h
@@ -20,6 +20,7 @@ struct Config {
     drafter::SerializeFormat format;
     bool sourceMap;
     std::string output;
+    bool enableLog;
 };
 
 /**

--- a/src/main.cc
+++ b/src/main.cc
@@ -23,6 +23,8 @@
 
 #include "ConversionContext.h"
 
+#include "utils/log/Trivial.h"
+
 namespace sc = snowcrash;
 
 /**
@@ -51,6 +53,9 @@ void Serialization(std::ostream* stream, const sos::Object& object, sos::Seriali
 
 int ProcessRefract(const Config& config, std::unique_ptr<std::istream>& in, std::unique_ptr<std::ostream>& out)
 {
+    if(config.enableLog)
+        ENABLE_LOGGING;
+
     std::stringstream inputStream;
     inputStream << in->rdbuf();
 

--- a/src/utils/log/Trivial.cc
+++ b/src/utils/log/Trivial.cc
@@ -1,0 +1,38 @@
+//
+//  utils/log/Trivial.cc
+//  librefract
+//
+//  Created by Thomas Jandecka on 16/02/2018
+//  Copyright (c) 2018 Apiary Inc. All rights reserved.
+//
+
+#include "Trivial.h"
+
+using namespace drafter;
+using namespace utils;
+using namespace log;
+
+trivial_log& trivial_log::instance()
+{
+    static trivial_log instance_{"drafter.log"};
+    return instance_;
+}
+
+trivial_log::trivial_log(const char* file) : out_(file), enabled_(false) {
+}
+
+const char* log::severity_to_str(severity s)
+{
+    switch (s) {
+        case debug:
+            return "DEBUG";
+        case info:
+            return "INFO ";
+        case warning:
+            return "WARN ";
+        case error:
+            return "ERROR";
+        default:
+            return "";
+    }
+}

--- a/src/utils/log/Trivial.h
+++ b/src/utils/log/Trivial.h
@@ -1,0 +1,126 @@
+//
+//  utils/log/trivial_log.h
+//  librefract
+//
+//  Created by Thomas Jandecka on 16/02/2018
+//  Copyright (c) 2018 Apiary Inc. All rights reserved.
+//
+
+#ifndef DRAFTER_UTILS_LOG_TRIVIAL_H
+#define DRAFTER_UTILS_LOG_TRIVIAL_H
+
+#include <fstream>
+#include <mutex>
+#include <thread>
+
+#define ENABLE_LOGGING (drafter::utils::log::trivial_log::instance().enable())
+#define LOG(s)                                                                                                         \
+    (drafter::utils::log::trivial_entry<s>{ drafter::utils::log::trivial_log::instance(), __LINE__, __FILE__ })
+
+namespace drafter
+{
+    namespace utils
+    {
+        namespace log
+        {
+            enum severity
+            {
+                debug,
+                info,
+                warning,
+                error,
+            };
+
+            const char* severity_to_str(severity s);
+
+            class trivial_log
+            {
+                mutable std::mutex write_mtx_;
+                std::ofstream out_;
+                bool enabled_ = false;
+
+            public:
+                static trivial_log& instance();
+
+            private:
+                trivial_log(const char* out_path);
+
+            public:
+                std::mutex& mtx() const
+                {
+                    return write_mtx_;
+                }
+
+                std::ostream& out()
+                {
+                    return out_;
+                }
+
+                void enable()
+                {
+                    std::lock_guard<std::mutex> lock(write_mtx_);
+                    enabled_ = true;
+                }
+
+                bool enabled() const noexcept
+                {
+                    return enabled_;
+                }
+            };
+
+            template <severity SEVERITY>
+            class trivial_entry
+            {
+                trivial_log& log_;
+                std::lock_guard<std::mutex> log_lock_;
+
+            public:
+                trivial_entry(trivial_log& log, size_t line, const char* file) : log_(log), log_lock_(log_.mtx())
+                {
+                    if (log.enabled()) {
+                        log_.out() << '[' << severity_to_str(SEVERITY) << "]";
+                        log_.out() << '[' << std::this_thread::get_id() << "]";
+                        log_.out() << '[' << file << ':' << line << "] ";
+                    }
+                }
+
+                trivial_entry(const trivial_entry&) = delete;
+                trivial_entry(trivial_entry&&) = delete;
+
+                trivial_entry& operator=(const trivial_entry&) = delete;
+                trivial_entry& operator=(trivial_entry&&) = delete;
+
+                ~trivial_entry()
+                {
+                    if (log_.enabled())
+                        log_.out() << '\n'; // TODO @tjanc@ could throw
+                }
+
+                template <typename T>
+                trivial_entry& operator<<(T&& obj)
+                {
+                    if (log_.enabled())
+                        log_.out() << std::forward<T>(obj);
+                    return *this;
+                }
+            };
+
+#ifndef DEBUG
+            template <>
+            class trivial_entry<debug>
+            {
+            public:
+                constexpr trivial_entry(trivial_log& log, size_t line, const char* file) noexcept {}
+
+                template <typename T>
+                constexpr trivial_entry<debug>& operator<<(T&& obj) noexcept
+                {
+                    return *this;
+                }
+            };
+#endif
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
# Acceptance criteria
- logs into file `drafter.log`
- disabled by default, enabled via command line option
- severities: debug, info, warning, error
  - debug entries only logged when compiled with DEBUG

# Usage example
```
ENABLE_LOGGING; // called iff '--enable-log` or `-L` is given to drafter

// ...

LOG(debug) << "generating JSON Schema for " << e.element();
```