### PR TITLE
(json-schema) primitive types, array, enum

### DIFF
--- a/drafter.gyp
+++ b/drafter.gyp
@@ -325,6 +325,8 @@
         "src/refract/JSONSchemaVisitor.h",
         "src/refract/JSONSchemaVisitor.cc",
         "src/refract/FilterVisitor.h",
+        "src/refract/JsonSchema.h",
+        "src/refract/JsonSchema.cc",
 
         "src/refract/Registry.h",
         "src/refract/Registry.cc",
@@ -400,6 +402,7 @@
         "test/utils/so/test-YamlIo.cc",
 
         "test/refract/test-Utils.cc",
+        "test/refract/test-JsonSchema.cc",
 
         "test/refract/dsd/test-Array.cc",
         "test/refract/dsd/test-Bool.cc",

--- a/src/refract/JsonSchema.cc
+++ b/src/refract/JsonSchema.cc
@@ -13,9 +13,8 @@
 #include "Element.h"
 #include "../ElementData.h"
 #include "Utils.h"
+#include "VisitorUtils.h"
 #include "../utils/log/Trivial.h"
-
-#include "VisitorUtils.h" // GetValue
 
 using namespace refract;
 using namespace schema;
@@ -24,19 +23,19 @@ using namespace drafter::utils::log;
 
 namespace
 { // API Elements tools
-    so::String instanciate(const StringElement& e)
+    so::String instantiate(const StringElement& e)
     {
         assert(!e.empty());
         return so::String{ e.get().get() };
     }
 
-    so::Number instanciate(const NumberElement& e)
+    so::Number instantiate(const NumberElement& e)
     {
         assert(!e.empty());
         return so::Number{ e.get().get() };
     }
 
-    so::Value instanciate(const BooleanElement& e)
+    so::Value instantiate(const BooleanElement& e)
     {
         assert(!e.empty());
         return e.get() ? //
@@ -44,26 +43,17 @@ namespace
             so::Value{ in_place_type<so::False>{} };
     }
 
-    bool has_fixed_attr(const IElement& e)
+    bool hasFixedAttr(const IElement& e)
     {
         return e.attributes().end() != e.attributes().find("fixed");
     }
 
-    bool has_fixed_type_attr(const IElement& e)
+    bool hasFixedTypeAttr(const IElement& e)
     {
         return e.attributes().end() != e.attributes().find("fixedType");
     }
 
-    template <typename T>
-    const T* get_if_default_attr(const T& e)
-    {
-        auto it = e.attributes().find("default");
-        if (e.attributes().end() != it)
-            return TypeQueryVisitor::as<const T>(it->second.get());
-        return nullptr;
-    }
-
-    const dsd::Array& get_enumerations(const EnumElement& e)
+    const dsd::Array& getEnumerations(const EnumElement& e)
     {
         auto resultIt = e.attributes().find("enumerations");
         assert(e.attributes().end() != resultIt);
@@ -74,217 +64,217 @@ namespace
 
         return enums->get();
     }
-}
+} // namespace
 
 namespace
 {
     using flags = std::bitset<1>;
-    constexpr std::size_t fixed_flag = 0;
-}
+    constexpr std::size_t FIXED_FLAG = 0;
+} // namespace
 
 namespace
 { // JSON Schema tools
-    so::Object& add_schema_version(so::Object& schema)
+    so::Object& addSchemaVersion(so::Object& schema)
     {
         schema.data.emplace_back("$schema", so::String{ "http://json-schema.org/draft-04/schema#" });
         return schema;
     }
 
-    so::Object& add_type(so::Object& schema, const char* type)
+    so::Object& addType(so::Object& schema, const char* type)
     {
         schema.data.emplace_back("type", so::String{ type });
         return schema;
     }
 
-    so::Object& add_items(so::Object& schema, so::Value value)
+    so::Object& addItems(so::Object& schema, so::Value value)
     {
         schema.data.emplace_back("items", std::move(value));
         return schema;
     }
 
     template <typename... Args>
-    so::Object& add_enum(so::Object& schema, Args&&... args)
+    so::Object& addEnum(so::Object& schema, Args&&... args)
     {
         schema.data.emplace_back("enum", so::Array{ so::Value{ std::forward<Args>(args) }... });
         return schema;
     }
-}
+} // namespace
 
 namespace
 {
-    so::Object& render_schema(so::Object& schema, const ObjectElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const ArrayElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const EnumElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const NullElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const StringElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const NumberElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const BooleanElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const MemberElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const ExtendElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const OptionElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const SelectElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const RefElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const HolderElement& e, flags options);
-    so::Object& render_schema(so::Object& schema, const IElement& e, flags options = 0);
+    so::Object& renderSchema(so::Object& schema, const ObjectElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const ArrayElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const EnumElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const NullElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const StringElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const NumberElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const BooleanElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const MemberElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const ExtendElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const OptionElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const SelectElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const RefElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const HolderElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, const IElement& e, flags options = 0);
 
-    so::Object make_schema(const IElement& e, flags options = 0);
+    so::Object makeSchema(const IElement& e, flags options = 0);
 
-    so::Object& render_schema(so::Object& schema, const ObjectElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const ObjectElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const ArrayElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const ArrayElement& e, flags options)
     {
-        add_type(schema, "array");
+        addType(schema, "array");
 
         // UPDATE OPTIONS
-        if (has_fixed_attr(e))
-            options.set(fixed_flag);
+        if (hasFixedAttr(e))
+            options.set(FIXED_FLAG);
 
-        if (has_fixed_type_attr(e)) { // array of any of types
+        if (hasFixedTypeAttr(e)) { // array of any of types
 
             if (e.empty() || e.get().empty())
-                add_enum(schema, so::Array{});
+                addEnum(schema, so::Array{});
 
             else if (e.get().size() == 1)
-                add_items(schema, make_schema(*e.get().begin()[0], options));
+                addItems(schema, makeSchema(*e.get().begin()[0], options));
 
             else {
                 so::Array items{};
                 for (const auto& entry : e.get())
-                    items.data.emplace_back(make_schema(*entry, options));
-                add_items(schema, so::Object{ std::make_pair("anyOf", std::move(items)) });
+                    items.data.emplace_back(makeSchema(*entry, options));
+                addItems(schema, so::Object{ std::make_pair("anyOf", std::move(items)) });
             }
 
-        } else if (options.test(fixed_flag)) { // tuple of constants/types
+        } else if (options.test(FIXED_FLAG)) { // tuple of constants/types
 
             if (e.empty() || e.get().empty())
-                add_enum(schema, so::Array{});
+                addEnum(schema, so::Array{});
             else {
                 so::Array items{};
                 for (const auto& item : e.get())
-                    items.data.emplace_back(make_schema(*item, options));
-                add_items(schema, std::move(items));
+                    items.data.emplace_back(makeSchema(*item, options));
+                addItems(schema, std::move(items));
             }
         }
 
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const EnumElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const EnumElement& e, flags options)
     {
-        if (has_fixed_attr(e))
-            options.set(fixed_flag);
+        if (hasFixedAttr(e))
+            options.set(FIXED_FLAG);
 
         so::Array anyOf{};
-        for (const auto& enumEntry : get_enumerations(e))
-            anyOf.data.emplace_back(make_schema(*enumEntry, options));
+        for (const auto& enumEntry : getEnumerations(e))
+            anyOf.data.emplace_back(makeSchema(*enumEntry, options));
 
         schema.data.emplace_back("anyOf", std::move(anyOf));
 
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const NullElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const NullElement& e, flags options)
     {
-        add_type(schema, "null");
+        addType(schema, "null");
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const StringElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const StringElement& e, flags options)
     {
-        add_type(schema, "string");
+        addType(schema, "string");
 
-        if (options.test(fixed_flag) || has_fixed_attr(e))
+        if (options.test(FIXED_FLAG) || hasFixedAttr(e))
             if (!e.empty())
-                add_enum(schema, instanciate(e));
+                addEnum(schema, instantiate(e));
 
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const NumberElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const NumberElement& e, flags options)
     {
-        add_type(schema, "number");
+        addType(schema, "number");
 
-        if (options.test(fixed_flag) || has_fixed_attr(e))
+        if (options.test(FIXED_FLAG) || hasFixedAttr(e))
             if (!e.empty())
-                add_enum(schema, instanciate(e));
+                addEnum(schema, instantiate(e));
 
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const BooleanElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const BooleanElement& e, flags options)
     {
-        add_type(schema, "boolean");
+        addType(schema, "boolean");
 
-        if (options.test(fixed_flag) || has_fixed_attr(e))
+        if (options.test(FIXED_FLAG) || hasFixedAttr(e))
             if (!e.empty())
-                add_enum(schema, instanciate(e));
+                addEnum(schema, instantiate(e));
 
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const MemberElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const MemberElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const ExtendElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const ExtendElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const OptionElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const OptionElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const SelectElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const SelectElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const RefElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const RefElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const HolderElement& e, flags options)
+    so::Object& renderSchema(so::Object& schema, const HolderElement& e, flags options)
     {
         LOG(error) << "HolderElement encountered when generating JSON schema";
         assert(false);
         return schema;
     }
 
-    so::Object& render_schema(so::Object& schema, const IElement& e, flags options /* = 0*/)
+    so::Object& renderSchema(so::Object& schema, const IElement& e, flags options /* = 0*/)
     {
         auto schemaPtr = &schema;
         refract::visit(e, [schemaPtr, options](const auto& el) { //
-            render_schema(*schemaPtr, el, options);
+            renderSchema(*schemaPtr, el, options);
         });
         return schema;
     }
 
-    so::Object make_schema(const IElement& e, flags options /* = 0*/)
+    so::Object makeSchema(const IElement& e, flags options /* = 0*/)
     {
         so::Object result{};
-        render_schema(result, e, options);
+        renderSchema(result, e, options);
         return result;
     }
-}
+} // namespace
 
 Schema schema::generateJsonSchema(const IElement& el)
 {
     so::Object result{};
-    add_schema_version(result);
-    render_schema(result, el);
+    addSchemaVersion(result);
+    renderSchema(result, el);
 
     return Schema{ std::move(result) };
 }

--- a/src/refract/JsonSchema.cc
+++ b/src/refract/JsonSchema.cc
@@ -1,0 +1,290 @@
+//
+//  refract/JsonSchema.cc
+//  librefract
+//
+//  Created by Thomas Jandecka on 16/02/2018
+//  Copyright (c) 2018 Apiary Inc. All rights reserved.
+//
+
+#include "JsonSchema.h"
+
+#include <cassert>
+#include <bitset>
+#include "Element.h"
+#include "../ElementData.h"
+#include "Utils.h"
+#include "../utils/log/Trivial.h"
+
+#include "VisitorUtils.h" // GetValue
+
+using namespace refract;
+using namespace schema;
+using namespace drafter::utils;
+using namespace drafter::utils::log;
+
+namespace
+{ // API Elements tools
+    so::String instanciate(const StringElement& e)
+    {
+        assert(!e.empty());
+        return so::String{ e.get().get() };
+    }
+
+    so::Number instanciate(const NumberElement& e)
+    {
+        assert(!e.empty());
+        return so::Number{ e.get().get() };
+    }
+
+    so::Value instanciate(const BooleanElement& e)
+    {
+        assert(!e.empty());
+        return e.get() ? //
+            so::Value{ in_place_type<so::True>{} } :
+            so::Value{ in_place_type<so::False>{} };
+    }
+
+    bool has_fixed_attr(const IElement& e)
+    {
+        return e.attributes().end() != e.attributes().find("fixed");
+    }
+
+    bool has_fixed_type_attr(const IElement& e)
+    {
+        return e.attributes().end() != e.attributes().find("fixedType");
+    }
+
+    template <typename T>
+    const T* get_if_default_attr(const T& e)
+    {
+        auto it = e.attributes().find("default");
+        if (e.attributes().end() != it)
+            return TypeQueryVisitor::as<const T>(it->second.get());
+        return nullptr;
+    }
+
+    const dsd::Array& get_enumerations(const EnumElement& e)
+    {
+        auto resultIt = e.attributes().find("enumerations");
+        assert(e.attributes().end() != resultIt);
+
+        const auto enums = TypeQueryVisitor::as<const ArrayElement>(resultIt->second.get());
+        assert(enums);
+        assert(!enums->empty());
+
+        return enums->get();
+    }
+}
+
+namespace
+{
+    using flags = std::bitset<1>;
+    constexpr std::size_t fixed_flag = 0;
+}
+
+namespace
+{ // JSON Schema tools
+    so::Object& add_schema_version(so::Object& schema)
+    {
+        schema.data.emplace_back("$schema", so::String{ "http://json-schema.org/draft-04/schema#" });
+        return schema;
+    }
+
+    so::Object& add_type(so::Object& schema, const char* type)
+    {
+        schema.data.emplace_back("type", so::String{ type });
+        return schema;
+    }
+
+    so::Object& add_items(so::Object& schema, so::Value value)
+    {
+        schema.data.emplace_back("items", std::move(value));
+        return schema;
+    }
+
+    template <typename... Args>
+    so::Object& add_enum(so::Object& schema, Args&&... args)
+    {
+        schema.data.emplace_back("enum", so::Array{ so::Value{ std::forward<Args>(args) }... });
+        return schema;
+    }
+}
+
+namespace
+{
+    so::Object& render_schema(so::Object& schema, const ObjectElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const ArrayElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const EnumElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const NullElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const StringElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const NumberElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const BooleanElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const MemberElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const ExtendElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const OptionElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const SelectElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const RefElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const HolderElement& e, flags options);
+    so::Object& render_schema(so::Object& schema, const IElement& e, flags options = 0);
+
+    so::Object make_schema(const IElement& e, flags options = 0);
+
+    so::Object& render_schema(so::Object& schema, const ObjectElement& e, flags options)
+    {
+        assert(false); // TODO @tjanc@ not implemented
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const ArrayElement& e, flags options)
+    {
+        add_type(schema, "array");
+
+        // UPDATE OPTIONS
+        if (has_fixed_attr(e))
+            options.set(fixed_flag);
+
+        if (has_fixed_type_attr(e)) { // array of any of types
+
+            if (e.empty() || e.get().empty())
+                add_enum(schema, so::Array{});
+
+            else if (e.get().size() == 1)
+                add_items(schema, make_schema(*e.get().begin()[0], options));
+
+            else {
+                so::Array items{};
+                for (const auto& entry : e.get())
+                    items.data.emplace_back(make_schema(*entry, options));
+                add_items(schema, so::Object{ std::make_pair("anyOf", std::move(items)) });
+            }
+
+        } else if (options.test(fixed_flag)) { // tuple of constants/types
+
+            if (e.empty() || e.get().empty())
+                add_enum(schema, so::Array{});
+            else {
+                so::Array items{};
+                for (const auto& item : e.get())
+                    items.data.emplace_back(make_schema(*item, options));
+                add_items(schema, std::move(items));
+            }
+        }
+
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const EnumElement& e, flags options)
+    {
+        if (has_fixed_attr(e))
+            options.set(fixed_flag);
+
+        so::Array anyOf{};
+        for (const auto& enumEntry : get_enumerations(e))
+            anyOf.data.emplace_back(make_schema(*enumEntry, options));
+
+        schema.data.emplace_back("anyOf", std::move(anyOf));
+
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const NullElement& e, flags options)
+    {
+        add_type(schema, "null");
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const StringElement& e, flags options)
+    {
+        add_type(schema, "string");
+
+        if (options.test(fixed_flag) || has_fixed_attr(e))
+            if (!e.empty())
+                add_enum(schema, instanciate(e));
+
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const NumberElement& e, flags options)
+    {
+        add_type(schema, "number");
+
+        if (options.test(fixed_flag) || has_fixed_attr(e))
+            if (!e.empty())
+                add_enum(schema, instanciate(e));
+
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const BooleanElement& e, flags options)
+    {
+        add_type(schema, "boolean");
+
+        if (options.test(fixed_flag) || has_fixed_attr(e))
+            if (!e.empty())
+                add_enum(schema, instanciate(e));
+
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const MemberElement& e, flags options)
+    {
+        assert(false); // TODO @tjanc@ not implemented
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const ExtendElement& e, flags options)
+    {
+        assert(false); // TODO @tjanc@ not implemented
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const OptionElement& e, flags options)
+    {
+        assert(false); // TODO @tjanc@ not implemented
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const SelectElement& e, flags options)
+    {
+        assert(false); // TODO @tjanc@ not implemented
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const RefElement& e, flags options)
+    {
+        assert(false); // TODO @tjanc@ not implemented
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const HolderElement& e, flags options)
+    {
+        LOG(error) << "HolderElement encountered when generating JSON schema";
+        assert(false);
+        return schema;
+    }
+
+    so::Object& render_schema(so::Object& schema, const IElement& e, flags options /* = 0*/)
+    {
+        auto schemaPtr = &schema;
+        refract::visit(e, [schemaPtr, options](const auto& el) { //
+            render_schema(*schemaPtr, el, options);
+        });
+        return schema;
+    }
+
+    so::Object make_schema(const IElement& e, flags options /* = 0*/)
+    {
+        so::Object result{};
+        render_schema(result, e, options);
+        return result;
+    }
+}
+
+Schema schema::generateJsonSchema(const IElement& el)
+{
+    so::Object result{};
+    add_schema_version(result);
+    render_schema(result, el);
+
+    return Schema{ std::move(result) };
+}

--- a/src/refract/JsonSchema.h
+++ b/src/refract/JsonSchema.h
@@ -1,0 +1,34 @@
+//
+//  refract/JsonSchema.h
+//  librefract
+//
+//  Created by Thomas Jandecka on 16/02/2018
+//  Copyright (c) 2018 Apiary Inc. All rights reserved.
+//
+
+#ifndef REFRACT_JSON_SCHEMA_H
+#define REFRACT_JSON_SCHEMA_H
+
+#include "../utils/so/Value.h"
+
+#include "ElementIfc.h"
+
+namespace refract
+{
+    namespace schema
+    {
+
+        using PassSchema = drafter::utils::so::True;
+        using FailSchema = drafter::utils::so::False;
+
+        using Boolean = drafter::utils::variant< //
+            drafter::utils::so::True,
+            drafter::utils::so::False>;
+
+        using Schema = drafter::utils::so::Value;
+
+        Schema generateJsonSchema(const IElement& el);
+    }
+}
+
+#endif

--- a/test/refract/test-JsonSchema.cc
+++ b/test/refract/test-JsonSchema.cc
@@ -43,14 +43,14 @@ SCENARIO("JSON Schema serialization of NullElement", "[json-schema]")
         {
             auto result = schema::generateJsonSchema(*el);
 
-            THEN("the schema matches any boolean")
+            THEN("the schema matches (any) null value")
             {
                 REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"null"})");
             }
         }
     }
 
-    GIVEN("A BooleanElement with content")
+    GIVEN("A NullElement with content")
     {
         auto el = make_element<NullElement>();
 
@@ -58,7 +58,7 @@ SCENARIO("JSON Schema serialization of NullElement", "[json-schema]")
         {
             auto result = schema::generateJsonSchema(*el);
 
-            THEN("the schema matches any number")
+            THEN("the schema matches (any) null value")
             {
                 REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"null"})");
             }
@@ -92,7 +92,7 @@ SCENARIO("JSON Schema serialization of BooleanElement", "[json-schema]")
         {
             auto result = schema::generateJsonSchema(*el);
 
-            THEN("the schema matches any number")
+            THEN("the schema matches any boolean")
             {
                 REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"boolean"})");
             }
@@ -107,7 +107,7 @@ SCENARIO("JSON Schema serialization of BooleanElement", "[json-schema]")
         {
             auto result = schema::generateJsonSchema(*el);
 
-            THEN("the schema matches any number")
+            THEN("the schema matches any boolean")
             {
                 REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"boolean"})");
             }
@@ -123,7 +123,7 @@ SCENARIO("JSON Schema serialization of BooleanElement", "[json-schema]")
         {
             auto result = schema::generateJsonSchema(*el);
 
-            THEN("the schema matches the number 42")
+            THEN("the schema matches true")
             {
                 REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"boolean","enum":[true]})");
             }
@@ -357,7 +357,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
         }
     }
 
-    GIVEN("An ArrayElement with fixed string as content")
+    GIVEN("An ArrayElement with string as content")
     {
         auto el = make_element<ArrayElement>(from_primitive("Hello world!"));
 

--- a/test/refract/test-JsonSchema.cc
+++ b/test/refract/test-JsonSchema.cc
@@ -1,0 +1,706 @@
+//
+//  test/refract/test-JsonSchema.cc
+//  test-librefract
+//
+//  Created by Thomas Jandecka on 17/02/2018
+//  Copyright (c) 2018 Apiary Inc. All rights reserved.
+//
+
+#include "catch.hpp"
+
+#include "refract/JsonSchema.h"
+#include "refract/Element.h"
+#include "refract/JSONSchemaVisitor.h"
+#include "utils/so/JsonIo.h"
+#include "utils/log/Trivial.h"
+
+#include <chrono>
+#include <sstream>
+
+using namespace drafter::utils;
+using namespace drafter::utils::log;
+using namespace so;
+using namespace std::chrono;
+using namespace refract;
+
+namespace
+{
+    std::string to_string(const so::Value& v)
+    {
+        std::ostringstream ss{};
+        so::serialize_json(ss, v, so::packed{});
+        return ss.str();
+    }
+}
+
+SCENARIO("JSON Schema serialization of NullElement", "[json-schema]")
+{
+    GIVEN("An empty NullElement")
+    {
+        auto el = make_empty<NullElement>();
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any boolean")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"null"})");
+            }
+        }
+    }
+
+    GIVEN("A BooleanElement with content")
+    {
+        auto el = make_element<NullElement>();
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any number")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"null"})");
+            }
+        }
+    }
+}
+
+SCENARIO("JSON Schema serialization of BooleanElement", "[json-schema]")
+{
+    GIVEN("An empty BooleanElement")
+    {
+        auto el = make_empty<BooleanElement>();
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any boolean")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"boolean"})");
+            }
+        }
+    }
+
+    GIVEN("An empty BooleanElement with fixed attribute true")
+    {
+        auto el = make_empty<BooleanElement>();
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any number")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"boolean"})");
+            }
+        }
+    }
+
+    GIVEN("A BooleanElement with content")
+    {
+        auto el = from_primitive(true);
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any number")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"boolean"})");
+            }
+        }
+    }
+
+    GIVEN("A BooleanElement with content and fixed attribute true")
+    {
+        auto el = from_primitive(true);
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches the number 42")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"boolean","enum":[true]})");
+            }
+        }
+    }
+}
+
+SCENARIO("JSON Schema serialization of NumberElement", "[json-schema]")
+{
+    GIVEN("An empty NumberElement")
+    {
+        auto el = make_empty<NumberElement>();
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any number")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"number"})");
+            }
+        }
+    }
+
+    GIVEN("An empty NumberElement with fixed attribute true")
+    {
+        auto el = make_empty<NumberElement>();
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any number")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"number"})");
+            }
+        }
+    }
+
+    GIVEN("A NumberElement with content")
+    {
+        auto el = from_primitive(42.0);
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any number")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"number"})");
+            }
+        }
+    }
+
+    GIVEN("A NumberElement with content and fixed attribute true")
+    {
+        auto el = from_primitive(42.0);
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches the number 42")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"number","enum":[42]})");
+            }
+        }
+    }
+}
+
+SCENARIO("JSON Schema serialization of StringElement", "[json-schema]")
+{
+    GIVEN("An empty StringElement")
+    {
+        auto el = make_empty<StringElement>();
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any string")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"string"})");
+            }
+        }
+    }
+
+    GIVEN("An empty StringElement with fixed attribute true")
+    {
+        auto el = make_empty<StringElement>();
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any string")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"string"})");
+            }
+        }
+    }
+
+    GIVEN("A StringElement with content")
+    {
+        auto el = from_primitive("this will be ignored");
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any string")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"string"})");
+            }
+        }
+    }
+
+    GIVEN("A StringElement with content and fixed attribute true")
+    {
+        auto el = from_primitive("foo");
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches the string \"foo\"")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"string","enum":["foo"]})");
+            }
+        }
+    }
+}
+
+SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
+{
+    GIVEN("An empty ArrayElement")
+    {
+        auto el = make_empty<ArrayElement>();
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any array")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array"})");
+            }
+        }
+    }
+
+    GIVEN("An empty ArrayElement with fixed attribute true")
+    {
+        auto el = make_empty<ArrayElement>();
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches an empty array")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array","enum":[[]]})");
+            }
+        }
+    }
+
+    GIVEN("An empty ArrayElement with fixedType attribute true")
+    {
+        auto el = make_empty<ArrayElement>();
+        el->attributes().set("fixedType", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches an empty array")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array","enum":[[]]})");
+            }
+        }
+    }
+
+    GIVEN("An ArrayElement with empty string as content")
+    {
+        auto el = make_element<ArrayElement>(make_empty<StringElement>());
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any array")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array"})");
+            }
+        }
+    }
+
+    GIVEN("An ArrayElement with empty string as content and fixed attribute true")
+    {
+        auto el = make_element<ArrayElement>(make_empty<StringElement>());
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches arrays of a single entry that is a string")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array","items":[{"type":"string"}]})");
+            }
+        }
+    }
+
+    GIVEN("A ArrayElement with empty string as content and fixedType attribute true")
+    {
+        auto el = make_element<ArrayElement>(make_empty<StringElement>());
+        el->attributes().set("fixedType", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches arrays of strings")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array","items":{"type":"string"}})");
+            }
+        }
+    }
+
+    GIVEN("An ArrayElement with fixed string as content")
+    {
+        auto el = make_element<ArrayElement>(from_primitive("Hello world!"));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any array")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array"})");
+            }
+        }
+    }
+
+    GIVEN("An ArrayElement with fixed string as content and fixed attribute true")
+    {
+        auto el = make_element<ArrayElement>(from_primitive("Hello world!"));
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches [\"Hello world!\"] literals")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array","items":[{"type":"string","enum":["Hello world!"]}]})");
+            }
+        }
+    }
+
+    GIVEN("A ArrayElement with fixed string as content and fixedType attribute true")
+    {
+        auto el = make_element<ArrayElement>(from_primitive("Hello world!"));
+        el->attributes().set("fixedType", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches arrays of strings")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array","items":{"type":"string"}})");
+            }
+        }
+    }
+
+    GIVEN("An ArrayElement with some content")
+    {
+        auto el = make_element<ArrayElement>(   //
+            from_primitive("Hello world!"),     //
+            from_primitive(42.0),               //
+            make_element<ArrayElement>(         //
+                from_primitive("short string"), //
+                from_primitive(true)));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches any array")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array"})");
+            }
+        }
+    }
+
+    GIVEN("An ArrayElement with some content and fixed attribute true")
+    {
+        auto el = make_element<ArrayElement>( //
+            from_primitive("Hello world!"),   //
+            make_empty<NumberElement>(),      //
+            make_element<ArrayElement>(       //
+                make_empty<StringElement>(),  //
+                from_primitive(true)));
+
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN(
+                "the schema matches arrays of size 3 containing \"Hello world!\", a number and arrays of size 2 "
+                "containing a string and true")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array","items":[{"type":"string","enum":["Hello world!"]},{"type":"number"},{"type":"array","items":[{"type":"string"},{"type":"boolean","enum":[true]}]}]})");
+            }
+        }
+    }
+
+    GIVEN("A ArrayElement with some content and fixedType attribute true")
+    {
+        auto el = make_element<ArrayElement>(   //
+            from_primitive("Hello world!"),     //
+            from_primitive(42.0),               //
+            make_element<ArrayElement>(         //
+                from_primitive("short string"), //
+                from_primitive(true)));
+
+        el->attributes().set("fixedType", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches arrays of any size where elements match any of types string, number, array")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","type":"array","items":{"anyOf":[{"type":"string"},{"type":"number"},{"type":"array"}]}})");
+            }
+        }
+    }
+}
+
+SCENARIO("JSON Schema serialization of EnumElement", "[json-schema]")
+{
+    GIVEN("An empty EnumElement")
+    {
+        auto el = make_empty<EnumElement>();
+        el->attributes().set("enumerations", make_element<ArrayElement>());
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches nothing")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","anyOf":[]})");
+            }
+        }
+    }
+
+    GIVEN("An empty EnumElement with fixed attribute true")
+    {
+        auto el = make_empty<EnumElement>();
+        el->attributes().set("enumerations", make_element<ArrayElement>());
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches nothing")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","anyOf":[]})");
+            }
+        }
+    }
+
+    GIVEN("An empty EnumElement with non-empty enumerations")
+    {
+        auto el = make_empty<EnumElement>();
+        el->attributes().set("enumerations",
+            make_element<ArrayElement>(          //
+                from_primitive("Hello world!"),  //
+                make_empty<NumberElement>(),     //
+                make_element<ArrayElement>(      //
+                    make_empty<StringElement>(), //
+                    from_primitive(true))));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches a string, a number and arrays")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","anyOf":[{"type":"string"},{"type":"number"},{"type":"array"}]})");
+            }
+        }
+    }
+
+    GIVEN("An empty EnumElement with non-empty enumerations and fixed attribute true")
+    {
+        auto el = make_empty<EnumElement>();
+        el->attributes().set("enumerations",
+            make_element<ArrayElement>(          //
+                from_primitive("Hello world!"),  //
+                make_empty<NumberElement>(),     //
+                make_element<ArrayElement>(      //
+                    make_empty<StringElement>(), //
+                    from_primitive(true))));
+        el->attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = schema::generateJsonSchema(*el);
+
+            THEN("the schema matches \"Hello world!\", a number and arrays of size 2 containing a string and true")
+            {
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-04/schema#","anyOf":[{"type":"string","enum":["Hello world!"]},{"type":"number"},{"type":"array","items":[{"type":"string"},{"type":"boolean","enum":[true]}]}]})");
+            }
+        }
+    }
+}
+
+namespace
+{
+    constexpr int run_count = 100000;
+
+    std::string to_long_string(const so::Value& v)
+    {
+        std::ostringstream ss{};
+        so::serialize_json(ss, v);
+        return ss.str();
+    }
+
+    decltype(auto) run_json_schema(const IElement& el)
+    {
+        using namespace std::literals;
+
+        using clock = std::chrono::steady_clock;
+        using result_type = clock::duration;
+
+        result_type result = 0s;
+
+        std::ostringstream ss;
+        for (int i = run_count; i > 0; --i) {
+            const auto start = clock::now();
+            serialize_json(ss, schema::generateJsonSchema(el));
+            const auto end = clock::now();
+            REQUIRE(!ss.str().empty());
+            ss.str("");
+            result += end - start;
+        }
+        LOG(warning) << to_long_string(schema::generateJsonSchema(el));
+        return result;
+    }
+
+    decltype(auto) run_json_schema_legacy(const IElement& el)
+    {
+        using namespace std::literals;
+
+        using clock = std::chrono::steady_clock;
+        using result_type = clock::duration;
+
+        result_type result = 0s;
+
+        for (int i = run_count; i > 0; --i) {
+            const auto start = clock::now();
+            auto str = renderJsonSchema(el);
+            const auto end = clock::now();
+            REQUIRE(!str.empty());
+            result += end - start;
+        }
+        LOG(warning) << renderJsonSchema(el);
+        return result;
+    }
+}
+
+SCENARIO("Test JSON Schema generation performance", "[json-schema-perf][.]")
+{
+    ENABLE_LOGGING;
+
+    GIVEN("A StringElement")
+    {
+        StringElement el{ dsd::String{
+            "something never printed, yet not easily copied because it is too long for SSO!" } };
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = run_json_schema(el);
+            WARN("rendering time (us): " << duration_cast<microseconds>(result).count());
+        }
+
+        WHEN("a JSON Schema is generated from it (legacy)")
+        {
+            auto result = run_json_schema_legacy(el);
+            WARN("rendering time (us): " << duration_cast<microseconds>(result).count());
+        }
+    }
+
+    GIVEN("A StringElement; explicitely fixed; value in content")
+    {
+        StringElement el{ dsd::String{ "foo-bar" } };
+        el.attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = run_json_schema(el);
+            WARN("rendering time (us): " << duration_cast<microseconds>(result).count());
+        }
+
+        WHEN("a JSON Schema is generated from it (legacy)")
+        {
+            auto result = run_json_schema_legacy(el);
+            WARN("rendering time (us): " << duration_cast<microseconds>(result).count());
+        }
+    }
+
+    GIVEN("A BooleanElement")
+    {
+        BooleanElement el{ dsd::Boolean{ true } };
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = run_json_schema(el);
+            WARN("rendering time (us): " << duration_cast<microseconds>(result).count());
+        }
+
+        WHEN("a JSON Schema is generated from it (legacy)")
+        {
+            auto result = run_json_schema_legacy(el);
+            WARN("rendering time (us): " << duration_cast<microseconds>(result).count());
+        }
+    }
+
+    GIVEN("A NumberElement")
+    {
+        NumberElement el{ dsd::Number{ 42 } };
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = run_json_schema(el);
+            WARN("rendering time (us): " << duration_cast<microseconds>(result).count());
+        }
+
+        WHEN("a JSON Schema is generated from it (legacy)")
+        {
+            auto result = run_json_schema_legacy(el);
+            WARN("rendering time (us): " << duration_cast<microseconds>(result).count());
+        }
+    }
+
+    GIVEN("An ArrayElement")
+    {
+        ArrayElement el{ dsd::Array{ //
+            from_primitive("Hello you uncomfortable world with strings easily exceeding 40 characters"),
+            from_primitive(42.0),
+            make_element<ArrayElement>( //
+                from_primitive("short string"),
+                from_primitive(true)) } };
+
+        el.attributes().set("fixed", from_primitive(true));
+
+        WHEN("a JSON Schema is generated from it")
+        {
+            auto result = run_json_schema(el);
+            WARN("rendering time (us): " << duration_cast<microseconds>(result).count());
+        }
+
+        WHEN("a JSON Schema is generated from it (legacy)")
+        {
+            auto result = run_json_schema_legacy(el);
+            WARN("rendering time (us): " << duration_cast<microseconds>(result).count());
+        }
+    }
+}


### PR DESCRIPTION
Implements a subset of JSON schema generation from API Elements,
  + NullElement,
  + BooleanElement,
  + StringElement,
  + ArrayElement,
  + EnumElement,

without any support for named types.

Note that `fixed` and `fixedType` apply to some of the above elements. `optional`, `required` and `nullable` do not. `samples` and `default` are generally irrelevant when generating schemas.

This PR does not change production code paths.