### PR TITLE
(json-schema) refs & named types in `definitions` 

### DIFF
--- a/src/refract/JsonSchema.cc
+++ b/src/refract/JsonSchema.cc
@@ -8,13 +8,13 @@
 
 #include "JsonSchema.h"
 
-#include <cassert>
-#include <bitset>
-#include "Element.h"
 #include "../ElementData.h"
 #include "Utils.h"
 #include "VisitorUtils.h"
 #include "../utils/log/Trivial.h"
+#include "Element.h"
+#include <bitset>
+#include <cassert>
 
 using namespace refract;
 using namespace schema;
@@ -102,89 +102,146 @@ namespace
 
 namespace
 {
-    so::Object& renderSchema(so::Object& schema, const ObjectElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const ArrayElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const EnumElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const NullElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const StringElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const NumberElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const BooleanElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const MemberElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const ExtendElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const OptionElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const SelectElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const RefElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const HolderElement& e, flags options);
-    so::Object& renderSchema(so::Object& schema, const IElement& e, flags options = 0);
+    so::Object& addRef(so::Object& schema, const std::string& type)
+    {
+        schema.data.emplace_back("$ref", so::String{ std::string{ "#/definitions/" } + type });
+        return schema;
+    }
 
-    so::Object makeSchema(const IElement& e, flags options = 0);
+    so::Object& addAdditionalItems(so::Object& schema, so::Value value)
+    {
+        schema.data.emplace_back("additionalItems", std::move(value));
+        return schema;
+    }
 
-    so::Object& renderSchema(so::Object& schema, const ObjectElement& e, flags options)
+    so::Object& addMinItems(so::Object& schema, unsigned value)
+    {
+        schema.data.emplace_back("minItems", so::Number{ static_cast<double>(value) });
+        return schema;
+    }
+
+    template <typename T>
+    so::Object& chooseTarget(so::Object& s, so::Object& defs, const T& e)
+    {
+        if (e.element() == T::ValueType::name)
+            return s;
+        else {
+            addRef(s, e.element());
+            defs.data.emplace_back(e.element(), so::Object{});
+            return get<so::Object>(defs.data.back().second);
+        }
+    }
+} // namespace
+
+namespace
+{
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const ObjectElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const ArrayElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const EnumElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const NullElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const StringElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const NumberElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const BooleanElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const MemberElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const ExtendElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const OptionElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const SelectElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const RefElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const HolderElement& e, flags options);
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const IElement& e, flags options = 0);
+
+    so::Object makeSchema(const IElement& e, so::Object& defs, flags options = 0);
+
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const ObjectElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
         return schema;
     }
 
-    so::Object& renderSchema(so::Object& schema, const ArrayElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const ArrayElement& e, flags options)
     {
-        addType(schema, "array");
+        constexpr const char* TYPE_NAME = "array";
 
-        // UPDATE OPTIONS
         if (hasFixedAttr(e))
             options.set(FIXED_FLAG);
 
         if (hasFixedTypeAttr(e)) { // array of any of types
 
-            if (e.empty() || e.get().empty())
+            if (e.empty() || e.get().empty()) {
+                auto& schema = chooseTarget(s, defs, e);
+                addType(schema, TYPE_NAME);
                 addEnum(schema, so::Array{});
 
-            else if (e.get().size() == 1)
-                addItems(schema, makeSchema(*e.get().begin()[0], options));
+            } else if (e.get().size() == 1) {
+                auto item_schema = makeSchema(*e.get().begin()[0], defs, options);
+                auto& schema = chooseTarget(s, defs, e);
+                addType(schema, TYPE_NAME);
+                addItems(schema, std::move(item_schema));
 
-            else {
+            } else {
                 so::Array items{};
                 for (const auto& entry : e.get())
-                    items.data.emplace_back(makeSchema(*entry, options));
+                    items.data.emplace_back(makeSchema(*entry, defs, options));
+                auto& schema = chooseTarget(s, defs, e);
+                addType(schema, TYPE_NAME);
                 addItems(schema, so::Object{ std::make_pair("anyOf", std::move(items)) });
             }
 
-        } else if (options.test(FIXED_FLAG)) { // tuple of constants/types
+        } else if (options.test(FIXED_FLAG)) { // tuple of N constants/types
 
-            if (e.empty() || e.get().empty())
+            if (e.empty() || e.get().empty()) {
+                auto& schema = chooseTarget(s, defs, e);
+                addType(schema, TYPE_NAME);
                 addEnum(schema, so::Array{});
-            else {
+
+            } else {
                 so::Array items{};
                 for (const auto& item : e.get())
-                    items.data.emplace_back(makeSchema(*item, options));
-                addItems(schema, std::move(items));
+                    items.data.emplace_back(makeSchema(*item, defs, options));
+
+                auto& schema = chooseTarget(s, defs, e);
+                addType(schema, TYPE_NAME);
+                addMinItems(schema, items.data.size());  // minimum of N entries
+                addItems(schema, std::move(items));      // schemas of tuple entries
+                addAdditionalItems(schema, so::False{}); // no more entries
             }
+        } else {
+            auto& schema = chooseTarget(s, defs, e);
+            addType(schema, TYPE_NAME);
         }
 
-        return schema;
+        return s;
     }
 
-    so::Object& renderSchema(so::Object& schema, const EnumElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const EnumElement& e, flags options)
     {
         if (hasFixedAttr(e))
             options.set(FIXED_FLAG);
 
         so::Array anyOf{};
         for (const auto& enumEntry : getEnumerations(e))
-            anyOf.data.emplace_back(makeSchema(*enumEntry, options));
+            anyOf.data.emplace_back(makeSchema(*enumEntry, defs, options));
 
+        // write to a definitions entry iff element e is a named type
+        auto& schema = chooseTarget(s, defs, e);
         schema.data.emplace_back("anyOf", std::move(anyOf));
-
         return schema;
     }
 
-    so::Object& renderSchema(so::Object& schema, const NullElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const NullElement& e, flags options)
     {
+        // write to a definitions entry iff element e is a named type
+        auto& schema = chooseTarget(s, defs, e);
+
         addType(schema, "null");
         return schema;
     }
 
-    so::Object& renderSchema(so::Object& schema, const StringElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const StringElement& e, flags options)
     {
+        // write to a definitions entry iff element e is a named type
+        auto& schema = chooseTarget(s, defs, e);
+
         addType(schema, "string");
 
         if (options.test(FIXED_FLAG) || hasFixedAttr(e))
@@ -194,8 +251,11 @@ namespace
         return schema;
     }
 
-    so::Object& renderSchema(so::Object& schema, const NumberElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const NumberElement& e, flags options)
     {
+        // write to a definitions entry iff element e is a named type
+        auto& schema = chooseTarget(s, defs, e);
+
         addType(schema, "number");
 
         if (options.test(FIXED_FLAG) || hasFixedAttr(e))
@@ -205,8 +265,11 @@ namespace
         return schema;
     }
 
-    so::Object& renderSchema(so::Object& schema, const BooleanElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const BooleanElement& e, flags options)
     {
+        // write to a definitions entry iff element e is a named type
+        auto& schema = chooseTarget(s, defs, e);
+
         addType(schema, "boolean");
 
         if (options.test(FIXED_FLAG) || hasFixedAttr(e))
@@ -216,65 +279,71 @@ namespace
         return schema;
     }
 
-    so::Object& renderSchema(so::Object& schema, const MemberElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const MemberElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
-        return schema;
+        return s;
     }
 
-    so::Object& renderSchema(so::Object& schema, const ExtendElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const ExtendElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
-        return schema;
+        return s;
     }
 
-    so::Object& renderSchema(so::Object& schema, const OptionElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const OptionElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
-        return schema;
+        return s;
     }
 
-    so::Object& renderSchema(so::Object& schema, const SelectElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const SelectElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
-        return schema;
+        return s;
     }
 
-    so::Object& renderSchema(so::Object& schema, const RefElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object& defs, const RefElement& e, flags options)
     {
         assert(false); // TODO @tjanc@ not implemented
-        return schema;
+        return s;
     }
 
-    so::Object& renderSchema(so::Object& schema, const HolderElement& e, flags options)
+    so::Object& renderSchema(so::Object& s, so::Object&, const HolderElement&, flags)
     {
         LOG(error) << "HolderElement encountered when generating JSON schema";
         assert(false);
-        return schema;
+        return s;
     }
 
-    so::Object& renderSchema(so::Object& schema, const IElement& e, flags options /* = 0*/)
+    so::Object& renderSchema(so::Object& schema, so::Object& defs, const IElement& e, flags options /* = 0*/)
     {
         auto schemaPtr = &schema;
-        refract::visit(e, [schemaPtr, options](const auto& el) { //
-            renderSchema(*schemaPtr, el, options);
+        auto defsPtr = &defs;
+        refract::visit(e, [schemaPtr, defsPtr, options](const auto& el) { //
+            renderSchema(*schemaPtr, *defsPtr, el, options);
         });
         return schema;
     }
 
-    so::Object makeSchema(const IElement& e, flags options /* = 0*/)
+    so::Object makeSchema(const IElement& e, so::Object& defs, flags options /* = 0*/)
     {
         so::Object result{};
-        renderSchema(result, e, options);
+        renderSchema(result, defs, e, options);
         return result;
     }
 } // namespace
 
-Schema schema::generateJsonSchema(const IElement& el)
+so::Object schema::generateJsonSchema(const IElement& el)
 {
     so::Object result{};
     addSchemaVersion(result);
-    renderSchema(result, el);
 
-    return Schema{ std::move(result) };
+    so::Object defs{};
+    renderSchema(result, defs, el);
+
+    if (defs.data.size() > 0)
+        result.data.insert(result.data.begin() + 1, std::make_pair("definitions", std::move(defs)));
+
+    return result;
 }

--- a/src/refract/JsonSchema.h
+++ b/src/refract/JsonSchema.h
@@ -17,17 +17,7 @@ namespace refract
 {
     namespace schema
     {
-
-        using PassSchema = drafter::utils::so::True;
-        using FailSchema = drafter::utils::so::False;
-
-        using Boolean = drafter::utils::variant< //
-            drafter::utils::so::True,
-            drafter::utils::so::False>;
-
-        using Schema = drafter::utils::so::Value;
-
-        Schema generateJsonSchema(const IElement& el);
+        drafter::utils::so::Object generateJsonSchema(const IElement& el);
     }
 }
 

--- a/test/refract/test-JsonSchema.cc
+++ b/test/refract/test-JsonSchema.cc
@@ -31,7 +31,7 @@ namespace
         so::serialize_json(ss, v, so::packed{});
         return ss.str();
     }
-}
+} // namespace
 
 SCENARIO("JSON Schema serialization of NullElement", "[json-schema]")
 {
@@ -102,7 +102,7 @@ SCENARIO("JSON Schema serialization of BooleanElement", "[json-schema]")
     GIVEN("An empty BooleanElement with fixed attribute true")
     {
         auto el = make_empty<BooleanElement>();
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -133,7 +133,7 @@ SCENARIO("JSON Schema serialization of BooleanElement", "[json-schema]")
     GIVEN("A BooleanElement with content and fixed attribute true")
     {
         auto el = from_primitive(true);
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -150,7 +150,7 @@ SCENARIO("JSON Schema serialization of BooleanElement", "[json-schema]")
     {
         auto el = from_primitive(true);
         el->element("Bar");
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -184,7 +184,7 @@ SCENARIO("JSON Schema serialization of NumberElement", "[json-schema]")
     GIVEN("An empty NumberElement with fixed attribute true")
     {
         auto el = make_empty<NumberElement>();
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -215,7 +215,7 @@ SCENARIO("JSON Schema serialization of NumberElement", "[json-schema]")
     GIVEN("A NumberElement with content and fixed attribute true")
     {
         auto el = from_primitive(42.0);
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -232,7 +232,7 @@ SCENARIO("JSON Schema serialization of NumberElement", "[json-schema]")
     {
         auto el = from_primitive(42.0);
         el->element("Baz");
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -266,7 +266,7 @@ SCENARIO("JSON Schema serialization of StringElement", "[json-schema]")
     GIVEN("An empty StringElement with fixed attribute true")
     {
         auto el = make_empty<StringElement>();
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -297,7 +297,7 @@ SCENARIO("JSON Schema serialization of StringElement", "[json-schema]")
     GIVEN("A StringElement with content and fixed attribute true")
     {
         auto el = from_primitive("foo");
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -314,7 +314,7 @@ SCENARIO("JSON Schema serialization of StringElement", "[json-schema]")
     {
         auto el = from_primitive("foo");
         el->element("Flip");
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -348,7 +348,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
     GIVEN("An empty ArrayElement with fixed attribute true")
     {
         auto el = make_empty<ArrayElement>();
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -364,7 +364,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
     GIVEN("An empty ArrayElement with fixedType attribute true")
     {
         auto el = make_empty<ArrayElement>();
-        el->attributes().set("fixedType", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixedType")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -395,7 +395,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
     GIVEN("An ArrayElement with empty string as content and fixed attribute true")
     {
         auto el = make_element<ArrayElement>(make_empty<StringElement>());
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -411,7 +411,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
     GIVEN("An ArrayElement with empty string as content and fixedType attribute true")
     {
         auto el = make_element<ArrayElement>(make_empty<StringElement>());
-        el->attributes().set("fixedType", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixedType")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -442,7 +442,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
     GIVEN("An ArrayElement with fixed string as content and fixed attribute true")
     {
         auto el = make_element<ArrayElement>(from_primitive("Hello world!"));
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -458,7 +458,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
     GIVEN("An ArrayElement with fixed string as content and fixedType attribute true")
     {
         auto el = make_element<ArrayElement>(from_primitive("Hello world!"));
-        el->attributes().set("fixedType", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixedType")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -500,7 +500,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
                 make_empty<StringElement>(),  //
                 from_primitive(true)));
 
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -524,7 +524,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
                 from_primitive("short string"), //
                 from_primitive(true)));
 
-        el->attributes().set("fixedType", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixedType")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -550,7 +550,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
             std::move(flap));
 
         el->element("Flop");
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -588,7 +588,7 @@ SCENARIO("JSON Schema serialization of EnumElement", "[json-schema]")
     {
         auto el = make_empty<EnumElement>();
         el->attributes().set("enumerations", make_element<ArrayElement>());
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -633,7 +633,7 @@ SCENARIO("JSON Schema serialization of EnumElement", "[json-schema]")
                 make_element<ArrayElement>(      //
                     make_empty<StringElement>(), //
                     from_primitive(true))));
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -662,7 +662,7 @@ SCENARIO("JSON Schema serialization of EnumElement", "[json-schema]")
                     make_empty<NumberElement>(),    //
                     std::move(a)));
         }
-        el->attributes().set("fixed", from_primitive(true));
+        el->attributes().set("typeAttributes", make_element<ArrayElement>(from_primitive("fixed")));
 
         WHEN("a JSON Schema is generated from it")
         {
@@ -728,7 +728,7 @@ namespace
         LOG(warning) << renderJsonSchema(el);
         return result;
     }
-}
+} // namespace
 
 SCENARIO("Test JSON Schema generation performance", "[json-schema-perf][.]")
 {


### PR DESCRIPTION
+ schemas of named types render into the `definitions` property
+ schemas of named types are referenced via `$ref` properties
+ array element with fixed attributed renders minItems and
additionalItems
+ minor fixes (spelling, unused typedefs etc.)