### PR TITLE
(optim) avoided use of std::set in ElementComparator

### DIFF
--- a/src/ElementComparator.h
+++ b/src/ElementComparator.h
@@ -9,20 +9,20 @@
 #define DRAFTER_ELEMENTCOMPARATOR_H
 
 #include "refract/InfoElements.h"
-#include <set>
 #include <algorithm>
 #include <iterator>
+#include <type_traits>
 
 namespace drafter
 {
 
     namespace detail
     {
-
         struct SortedRef {
             using InfoRef = std::vector<std::reference_wrapper<const refract::InfoElements::value_type> >;
 
-            InfoRef operator()(const refract::InfoElements& infoElements, const std::set<std::string>& ignore) const
+            template <typename IgnorePredicate>
+            InfoRef operator()(const refract::InfoElements& infoElements, IgnorePredicate&& ignore) const
             {
                 InfoRef res;
 
@@ -32,7 +32,10 @@ namespace drafter
 
                 res.erase(std::remove_if(res.begin(),
                               res.end(),
-                              [&ignore](const auto& info) { return ignore.find(info.get().first) != ignore.end(); }),
+                              [ignoreKey = std::forward<IgnorePredicate>(ignore)](const auto& entry) //
+                              {                                                                      //
+                                  return ignoreKey(entry.get().first);                               //
+                              }),
                     res.end());
 
                 std::sort(res.begin(), res.end(), [](auto l, auto r) { return l.get().first < r.get().first; });
@@ -40,50 +43,74 @@ namespace drafter
                 return res;
             }
         };
-    };
 
-    using namespace refract;
+        struct IgnoreNone {
+            bool operator()(const std::string&) const noexcept
+            {
+                return false;
+            }
+        };
 
-    struct EmptyKeySet {
-        const std::set<std::string> operator()() const noexcept
+        template <typename IgnorePredicate>
+        class InfoElementsComparator
         {
-            return {};
-        }
-    };
+            IgnorePredicate ignore;
 
-    struct DefaultKeySet {
-        const std::set<std::string> operator()() const noexcept
+        public:
+            template <typename = typename std::enable_if< //
+                          std::is_default_constructible<IgnorePredicate>::value>::type>
+            InfoElementsComparator() : ignore{}
+            {
+            }
+
+            explicit InfoElementsComparator(IgnorePredicate ignoreKey) : ignore{ std::move(ignoreKey) } {}
+
+            bool operator()(const refract::InfoElements& rhs, const refract::InfoElements& lhs) const
+            {
+                const auto l = SortedRef()(lhs, ignore);
+                const auto r = SortedRef()(rhs, ignore);
+
+                return std::equal(l.begin(), l.end(), r.begin(), r.end(), [](const auto& l, const auto& r) {
+                    return l.get().first == r.get().first && *l.get().second.get() == *r.get().second.get();
+                });
+            }
+        };
+
+        struct IsSourceMap {
+            bool operator()(const std::string& key) const noexcept
+            {
+                return key == "sourceMap";
+            }
+        };
+
+        template <class IgnoreAttrs, class IgnoreMeta>
+        class ElementComparator
         {
-            return { "sourceMap" };
-        }
-    };
+            const refract::IElement& rhs;
 
-    template <class IgnoreKeys = EmptyKeySet>
-    struct InfoElementsComparator {
-        bool operator()(const InfoElements& rhs, const InfoElements& lhs) const
-        {
-            const auto l = detail::SortedRef()(lhs, IgnoreKeys()());
-            const auto r = detail::SortedRef()(rhs, IgnoreKeys()());
+        public:
+            explicit ElementComparator(const refract::IElement& rhs_) : rhs(rhs_) {}
 
-            return std::equal(l.begin(), l.end(), r.begin(), r.end(), [](const auto& l, const auto& r) {
-                return l.get().first == r.get().first && *l.get().second.get() == *r.get().second.get();
-            });
-        }
-    };
+        public:
+            template <typename ElementT>
+            bool operator()(const ElementT& lhs) const
+            {
+                return (lhs.empty() == rhs.empty()) && (lhs.element() == rhs.element())
+                    && (InfoElementsComparator<IgnoreAttrs>{}(rhs.attributes(), lhs.attributes()))
+                    && (InfoElementsComparator<IgnoreMeta>{}(rhs.meta(), lhs.meta()))
+                    && (lhs.empty() || (lhs.get() == dynamic_cast<const ElementT*>(&rhs)->get()));
+            }
+        };
+    } // namespace detail
 
-    template <class IgnoreAttrs = DefaultKeySet, class IgnoreMeta = EmptyKeySet>
-    struct ElementComparator {
-        const IElement& rhs;
-
-        template <typename ElementT>
-        bool operator()(const ElementT& lhs) const
-        {
-            return (lhs.empty() == rhs.empty()) && (lhs.element() == rhs.element())
-                && (InfoElementsComparator<IgnoreAttrs>{}(rhs.attributes(), lhs.attributes()))
-                && (InfoElementsComparator<IgnoreMeta>{}(rhs.meta(), lhs.meta()))
-                && (lhs.empty() || (lhs.get() == dynamic_cast<const ElementT*>(&rhs)->get()));
-        }
-    };
+    template <typename IgnoreAttrs = detail::IsSourceMap, typename IgnoreMeta = detail::IgnoreNone>
+    bool Equal(const refract::IElement& lhs,
+        const refract::IElement& rhs,
+        IgnoreAttrs&& ignoreAttrs = {},
+        IgnoreMeta&& ignoreMeta = {})
+    {
+        return visit(lhs, detail::ElementComparator<IgnoreAttrs, IgnoreMeta>{ rhs });
+    }
 } // namespace drafter
 
 #endif // ifndef DRAFTER_ELEMENTCOMPARATOR_H

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -755,9 +755,7 @@ namespace
                                          ConversionContext& context,
                                          const auto& sourceMap,
                                          const bool reportDuplicity) {
-                if (std::find_if(enums.begin(),
-                        enums.end(),
-                        [&info](auto& enm) { return visit(*info, ElementComparator<>{ *enm }); })
+                if (std::find_if(enums.begin(), enums.end(), [&info](auto& enm) { return Equal(*info, *enm); })
                     == enums.end()) {
 
                     enums.push_back(std::move(info));
@@ -786,7 +784,6 @@ namespace
                     if (IsLiteral(*info.get())) {
                         AppendInfoElement<ArrayElement>(info->attributes(), "typeAttributes", dsd::String{ "fixed" });
                     }
-
                 });
                 auto enumsElement = make_element<ArrayElement>(enums);
                 element.attributes().set(SerializeKey::Enumerations, std::move(enumsElement));
@@ -1303,7 +1300,7 @@ namespace
 
         return std::move(element);
     }
-}
+} // namespace
 
 std::unique_ptr<IElement> drafter::MSONToRefract(
     const NodeInfo<snowcrash::DataStructure>& dataStructure, ConversionContext& context)

--- a/src/refract/JSONSchemaVisitor.cc
+++ b/src/refract/JSONSchemaVisitor.cc
@@ -75,7 +75,7 @@ namespace
             return el->empty();
         });
     }
-}
+} // namespace
 
 JSONSchemaVisitor::JSONSchemaVisitor(ObjectElement& pDefinitions, bool _fixed /*= false*/, bool _fixedType /*= false*/)
     : pObj(make_element<ObjectElement>()), pDefs(pDefinitions), fixed(_fixed), fixedType(_fixedType)
@@ -425,13 +425,14 @@ void JSONSchemaVisitor::operator()(const ArrayElement& e)
 
 namespace
 {
-    struct IgnoredAtributes {
-        const std::set<std::string> operator()() const noexcept
+    struct IsIgnoredAttribute {
+        bool operator()(const std::string& key) const noexcept
         {
-            return { "sourceMap", "typeAttributes" };
+            return key == "sourceMap" //
+                || key == "typeAttributes";
         }
     };
-};
+}; // namespace
 
 void JSONSchemaVisitor::operator()(const EnumElement& e)
 {
@@ -455,7 +456,7 @@ void JSONSchemaVisitor::operator()(const EnumElement& e)
                     // NOTE: this ignore full set of 'typeAttributes' while compare attributes
                     // instead ingnore only `typeAttribute.fixed`
                     // it is not exactly what should happen, but i is "good enough" solution
-                    [&v](auto& el) { return visit(*el, drafter::ElementComparator<IgnoredAtributes>{ *v }); })
+                    [&v](auto& el) { return drafter::Equal<IsIgnoredAttribute>(*el, *v); })
                 == elms.end()) {
                 elms.push_back(v);
             }

--- a/test/test-ElementComparator.cc
+++ b/test/test-ElementComparator.cc
@@ -3,6 +3,7 @@
 #include "refract/Element.h"
 
 using namespace drafter;
+using namespace refract;
 using S = refract::StringElement;
 using N = refract::NumberElement;
 
@@ -19,7 +20,7 @@ SCENARIO("Compare equality of elements", "[Element][comparator][equal]")
         {
             THEN("it is recognized as equal")
             {
-                REQUIRE(true == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(true == Equal(*first, *second));
             }
         }
     }
@@ -34,7 +35,7 @@ SCENARIO("Compare equality of elements", "[Element][comparator][equal]")
         {
             THEN("it is recognized as non-equal")
             {
-                REQUIRE(false == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(false == Equal(*first, *second));
             }
         }
     }
@@ -49,7 +50,7 @@ SCENARIO("Compare equality of elements", "[Element][comparator][equal]")
         {
             THEN("it is recognized as equal")
             {
-                REQUIRE(true == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(true == Equal(*first, *second));
             }
         }
     }
@@ -64,7 +65,7 @@ SCENARIO("Compare equality of elements", "[Element][comparator][equal]")
         {
             THEN("it is recognized as non-equal")
             {
-                REQUIRE(false == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(false == Equal(*first, *second));
             }
         }
     }
@@ -80,7 +81,7 @@ SCENARIO("Compare equality of elements", "[Element][comparator][equal]")
         {
             THEN("it is recognized as non-equal")
             {
-                REQUIRE(false == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(false == Equal(*first, *second));
             }
         }
     }
@@ -97,7 +98,7 @@ SCENARIO("Compare equality of elements", "[Element][comparator][equal]")
         {
             THEN("it is recognized as non-equal")
             {
-                REQUIRE(false == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(false == Equal(*first, *second));
             }
         }
     }
@@ -115,7 +116,7 @@ SCENARIO("Compare equality of elements", "[Element][comparator][equal]")
         {
             THEN("it is recognized as equal")
             {
-                REQUIRE(true == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(true == Equal(*first, *second));
             }
         }
     }
@@ -133,7 +134,7 @@ SCENARIO("Compare equality of elements", "[Element][comparator][equal]")
         {
             THEN("it is recognized as non-equal")
             {
-                REQUIRE(false == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(false == Equal(*first, *second));
             }
         }
     }
@@ -154,7 +155,7 @@ SCENARIO("Compare equality of elements with sourceMaps", "[Element][comparator][
         {
             THEN("it is recognized as equal")
             {
-                REQUIRE(true == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(true == Equal(*first, *second));
             }
         }
     }
@@ -171,7 +172,7 @@ SCENARIO("Compare equality of elements with sourceMaps", "[Element][comparator][
         {
             THEN("it is recognized as equal")
             {
-                REQUIRE(true == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(true == Equal(*first, *second));
             }
         }
     }
@@ -188,7 +189,7 @@ SCENARIO("Compare equality of elements with sourceMaps", "[Element][comparator][
         {
             THEN("it is recognized as equal")
             {
-                REQUIRE(true == visit(*first, ElementComparator<>{ *second }));
+                REQUIRE(true == Equal(*first, *second));
             }
         }
     }
@@ -197,8 +198,10 @@ SCENARIO("Compare equality of elements with sourceMaps", "[Element][comparator][
 SCENARIO("Compare equality of elements with custom keywordlist", "[Element][comparator][equal]")
 {
     struct IgnoreFooAndBarAttribute {
-        const std::set<std::string> operator()() const noexcept {
-            return { "foo", "bar" };
+        bool operator()(const std::string& key) const noexcept
+        {
+            return key == "foo" //
+                || key == "bar";
         }
     };
 
@@ -215,7 +218,7 @@ SCENARIO("Compare equality of elements with custom keywordlist", "[Element][comp
         {
             THEN("it is recognized as equal")
             {
-                REQUIRE(true == visit(*first, ElementComparator<IgnoreFooAndBarAttribute>{ *second }));
+                REQUIRE(true == Equal<IgnoreFooAndBarAttribute>(*first, *second));
             }
         }
     }
@@ -233,7 +236,7 @@ SCENARIO("Compare equality of elements with custom keywordlist", "[Element][comp
         {
             THEN("it is recognized as equal")
             {
-                REQUIRE(true == visit(*first, ElementComparator<IgnoreFooAndBarAttribute>{ *second }));
+                REQUIRE(true == Equal<IgnoreFooAndBarAttribute>(*first, *second));
             }
         }
     }
@@ -251,7 +254,7 @@ SCENARIO("Compare equality of elements with custom keywordlist", "[Element][comp
         {
             THEN("it is recognized as equal")
             {
-                REQUIRE(true == visit(*first, ElementComparator<IgnoreFooAndBarAttribute>{ *second }));
+                REQUIRE(true == Equal<IgnoreFooAndBarAttribute>(*first, *second));
             }
         }
     }
@@ -270,7 +273,7 @@ SCENARIO("Compare equality of elements with custom keywordlist", "[Element][comp
         {
             THEN("it is recognized as equal")
             {
-                REQUIRE(true == visit(*first, ElementComparator<IgnoreFooAndBarAttribute>{ *second }));
+                REQUIRE(true == Equal<IgnoreFooAndBarAttribute>(*first, *second));
             }
         }
     }
@@ -289,7 +292,7 @@ SCENARIO("Compare equality of elements with custom keywordlist", "[Element][comp
         {
             THEN("it is recognized as non equal")
             {
-                REQUIRE(false == visit(*first, ElementComparator<IgnoreFooAndBarAttribute>{ *second }));
+                REQUIRE(false == Equal<IgnoreFooAndBarAttribute>(*first, *second));
             }
         }
     }


### PR DESCRIPTION
- predicates are now passed to ElementComparator instead of std::set
generators
- (cosmetic) introduced `Equal`