### PR TITLE
Fix bug #539

### DIFF
--- a/src/utils/Utf8.h
+++ b/src/utils/Utf8.h
@@ -222,8 +222,6 @@ namespace drafter
                 input_iterator& operator=(const input_iterator& other) = default;
                 input_iterator& operator=(input_iterator&& other) = default;
 
-                input_iterator() noexcept = default;
-
                 friend void swap(input_iterator& lhs, input_iterator& rhs)
                 {
                     using std::swap;


### PR DESCRIPTION
Removed an unused and meaningless defaulted constructor.
Now compiles on Apple LLVM version 9.1.0.
Fixes #539