### PR TITLE
Fix tarball generation to include tools/gyp in tarball

### DIFF
--- a/tools/make-tarball.sh
+++ b/tools/make-tarball.sh
@@ -29,11 +29,11 @@ $(pwd)/tools/make-tarball.sh checkout $TMPDIR/$DIR/
 (
   # Remove unnessecery files
   cd $TMPDIR/$DIR
-  rm -fr appveyor.yml circle.yml .npmignore tools/ package.json emcc/
+  rm -fr appveyor.yml circle.yml .npmignore tools/*.{sh,py} tools/homebrew package.json emcc/
 )
 
 (
   cd $TMPDIR
-  echo "Creating tarball"
+  echo "Creating tarball $TARBALL"
   env GZIP=-9 tar -czf $TARBALL $DIR
 )


### PR DESCRIPTION
In Drafter master (and 4 pre release) we moved gyp to be in tools/gyp (previously in ext) which causes problems with the generated release tar balls since gyp wouldn't be included.

This was discovered in https://github.com/apiaryio/drafter/issues/542#issuecomment-387804944. This fix makes it so that the tools/gyp directory is not deleted.