### PR TITLE
Catch repository was moved to catch org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/apiaryio/sundown.git
 [submodule "test/vendor/Catch"]
 	path = test/vendor/Catch
-	url = https://github.com/philsquared/Catch.git
+	url = https://github.com/catchorg/Catch2.git
 [submodule "ext/sos"]
 	path = ext/sos
 	url = https://github.com/apiaryio/sos.git


### PR DESCRIPTION
Catch is now at v1.9.7 (latest v1 release)

This is causing problems (see #544)