### PR TITLE
Restore script to work without pyyaml

### DIFF
--- a/tools/refract-filter.py
+++ b/tools/refract-filter.py
@@ -14,18 +14,19 @@ except ImportError:
 VERSION = "0.1"
 
 
-def yaml_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
-    class OrderedLoader(Loader):
-        pass
+if yaml:
+    def yaml_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+        class OrderedLoader(Loader):
+            pass
 
-    def construct_mapping(loader, node):
-        loader.flatten_mapping(node)
-        return object_pairs_hook(loader.construct_pairs(node))
+        def construct_mapping(loader, node):
+            loader.flatten_mapping(node)
+            return object_pairs_hook(loader.construct_pairs(node))
 
-    OrderedLoader.add_constructor(
-        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-        construct_mapping)
-    return yaml.load(stream, OrderedLoader)
+        OrderedLoader.add_constructor(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+            construct_mapping)
+        return yaml.load(stream, OrderedLoader)
 
 
 def walk(node, cb):


### PR DESCRIPTION
As `yaml.Loader` etc is used in the arguments for the function, even due to our other checks for `if yaml` the script fails on invocation without first installing pyyaml. This PR fixes the script to work with JSON if you don't have pyyaml installed.

#### Before

```
$ ./tools/refract-filter.py test/fixtures/schema/array-fixed-inline-samples.json
Traceback (most recent call last):
  File "./tools/refract-filter.py", line 17, in <module>
    def yaml_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
AttributeError: 'NoneType' object has no attribute 'Loader'
```

#### After

```
$ ./tools/refract-filter.py test/fixtures/schema/array-fixed-inline-samples.json
{
  "address": [
    "city"
  ]
}
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "object",
  "properties": {
    "address": {
      "type": "array",
      "minItems": 3,
      "items": [
        {
          "type": "string"
        },
        {
          "type": "string",
          "enum": [
            "city"
          ]
        },
        {
          "type": "string"
        }
      ],
      "additionalItems": false
    }
  }
}
```