### PR TITLE
Allow 4 make jobs concurrently

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ aliases:
           name: Build
           command: |
             ./configure
-            make
+            make -j4
       - run:
           name: Test
-          command: make test
+          command: make test -j4
 
   - &test-clang-base
     <<: *test-base
@@ -118,7 +118,7 @@ jobs:
 
       - run:
           name: Build
-          command: ./configure && make
+          command: ./configure && make -j4
 
       - run:
           name: Integration Test
@@ -138,8 +138,8 @@ jobs:
           name: Build
           command: |
             ./configure
-            make
-            make test
+            make -j4
+            make test -j4
 
       - run:
           name: Memory Test


### PR DESCRIPTION
This nearly halfs the entire CI time on Circle CI.

Before:

<img width="234" alt="screen shot 2018-07-22 at 21 56 11" src="https://user-images.githubusercontent.com/44164/43050034-27971546-8dfa-11e8-99bf-73a4efcbaabc.png">

After:

<img width="225" alt="screen shot 2018-07-22 at 21 56 18" src="https://user-images.githubusercontent.com/44164/43050035-2a658b0e-8dfa-11e8-8acf-bf5ab1da8d92.png">
