### PR TITLE
Upgrade clang-format script

### DIFF
--- a/tools/clang-format-check.sh
+++ b/tools/clang-format-check.sh
@@ -2,10 +2,11 @@
 
 set -e
 
-clang-format -style=file -output-replacements-xml $(git ls-files | grep '\.cc\|\.h$') | grep -c "<replacement "
+function report_error () {
+  echo "There are some style issues. Please run clang-format on your files."
+  exit 1;
+}
 
-if [ $? -ne 1 ]
-then
-	echo "There are some style issues. Please run clang-format on your files."
-	exit 1;
-fi
+clang-format --version | cut -d ' '  -f 3 | grep -q "^5\." || (echo "Requires clang-format version 5" && exit 1)
+
+clang-format -style=file -output-replacements-xml $(git ls-files | grep -e '\.cc$\|\.h$' | grep -v 'ext/boost') | awk '/\<replacement /{exit 1}' || report_error


### PR DESCRIPTION
I've pulled out the commit from https://github.com/apiaryio/drafter/pull/576 so we can fix the rules in separate step (as there is large branch in progress).

* Check clang-format for version 5
* exclude boost headers from checking
* replace grep by awk because of error code