### PR TITLE
Don't disable thread safe static for macOS

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -131,7 +131,7 @@
           'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',       # !-fno-exceptions
           'GCC_ENABLE_CPP_RTTI': 'YES',             # !-fno-rtti
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
-          'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
+          'GCC_THREADSAFE_STATICS': 'YES',          # No -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
           'MACOSX_DEPLOYMENT_TARGET': '10.7',       # -mmacosx-version-min=10.7
           'USE_HEADERMAP': 'NO',


### PR DESCRIPTION
We're relying on this functionality in Protagonist as Protagonist async parsing uses separate threads and our internal logger is using static.