### PR TITLE
(fix) fixed VS build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,11 @@ image:
   - Visual Studio 2015
   - Visual Studio 2017
 
+environment:
+  matrix:
+    - VS_VERSION: 
+    - VS_VERSION: debug
+
 install:
   - set PATH=C:\Ruby25\bin;%PATH%
 

--- a/ext/snowcrash/test/test-ActionParser.cc
+++ b/ext/snowcrash/test/test-ActionParser.cc
@@ -554,7 +554,7 @@ TEST_CASE("Named Endpoint", "[named_endpoint]")
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 1);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(0).element == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.elements().at(0).content.resource;
     REQUIRE(resource.name == "My Named Endpoint");
     REQUIRE(resource.uriTemplate == "/test/endpoint");
     REQUIRE(resource.actions.size() == 1);
@@ -591,7 +591,7 @@ TEST_CASE("Named Endpoints Edge Cases", "[named_endpoint]")
     REQUIRE(blueprint.node.content.elements().at(2).content.elements().size() == 0);
 
     {
-        Resource resource = blueprint.node.content.elements().at(0).content.resource;
+        const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
         REQUIRE(resource.name == "Endpoint 1");
         REQUIRE(resource.uriTemplate == "/e1");
         REQUIRE(resource.actions.size() == 1);
@@ -601,7 +601,7 @@ TEST_CASE("Named Endpoints Edge Cases", "[named_endpoint]")
     }
 
     {
-        Resource resource = blueprint.node.content.elements().at(1).content.resource;
+        const Resource& resource = blueprint.node.content.elements().at(1).content.resource;
         REQUIRE(resource.name == "Endpoint 2");
         REQUIRE(resource.uriTemplate == "/e1");
         REQUIRE(resource.actions.size() == 1);
@@ -611,7 +611,7 @@ TEST_CASE("Named Endpoints Edge Cases", "[named_endpoint]")
     }
 
     {
-        Resource resource = blueprint.node.content.elements().at(2).content.resource;
+        const Resource& resource = blueprint.node.content.elements().at(2).content.resource;
         REQUIRE(resource.name == "Endpoint 3");
         REQUIRE(resource.uriTemplate == "/e1");
         REQUIRE(resource.actions.size() == 1);

--- a/ext/snowcrash/test/test-BlueprintParser.cc
+++ b/ext/snowcrash/test/test-BlueprintParser.cc
@@ -152,7 +152,7 @@ TEST_CASE("Parse API with Name and abbreviated resource", "[blueprint]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.uriTemplate == "/resource");
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions.front().examples.size() == 1);
@@ -442,7 +442,7 @@ TEST_CASE("Parsing unexpected blocks", "[blueprint]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.uriTemplate == "/");
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].method == "GET");
@@ -902,7 +902,7 @@ TEST_CASE(
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource r = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& r = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(r.name == "Post");
     REQUIRE(r.attributes.typeDefinition.baseType == mson::ImplicitObjectBaseType);
     REQUIRE(r.attributes.typeDefinition.typeSpecification.name.symbol.literal == "B");
@@ -1294,7 +1294,7 @@ TEST_CASE("Any named type data structure should be able to be overridden when re
     REQUIRE(blueprint.node.content.elements().at(1).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(1).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(1).content.resource;
     REQUIRE(resource.uriTemplate == "/sample");
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions.at(0).method == "GET");

--- a/ext/snowcrash/test/test-ParametersParser.cc
+++ b/ext/snowcrash/test/test-ParametersParser.cc
@@ -291,7 +291,7 @@ TEST_CASE("Percentage encoded characters in parameter name ", "[parameters][perc
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].parameters.size() == 1);

--- a/ext/snowcrash/test/test-ResourceGroupParser.cc
+++ b/ext/snowcrash/test/test-ResourceGroupParser.cc
@@ -155,7 +155,7 @@ TEST_CASE("Parse multiple resources with payloads", "[resource_group]")
     REQUIRE(resourceGroup.node.content.elements().size() == 2);
 
     REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
-    Resource resource1 = resourceGroup.node.content.elements().at(0).content.resource;
+    const Resource& resource1 = resourceGroup.node.content.elements().at(0).content.resource;
 
     REQUIRE(resource1.uriTemplate == "/1");
     REQUIRE(resource1.description.empty());
@@ -169,7 +169,7 @@ TEST_CASE("Parse multiple resources with payloads", "[resource_group]")
     REQUIRE(resource1.actions[0].examples[0].requests[0].body.empty());
     REQUIRE(resource1.actions[0].examples[0].responses.empty());
 
-    Resource resource2 = resourceGroup.node.content.elements().at(1).content.resource;
+    const Resource& resource2 = resourceGroup.node.content.elements().at(1).content.resource;
     REQUIRE(resource2.uriTemplate == "/2");
     REQUIRE(resource2.description.empty());
     REQUIRE(resource2.actions.size() == 1);
@@ -230,7 +230,7 @@ TEST_CASE("Parse resource with list in its description", "[resource_group]")
     REQUIRE(resourceGroup.node.content.elements().size() == 1);
     REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
 
-    Resource resource = resourceGroup.node.content.elements().at(0).content.resource;
+    const Resource& resource = resourceGroup.node.content.elements().at(0).content.resource;
     REQUIRE(resource.uriTemplate == "/1");
     REQUIRE(resource.description.empty());
     REQUIRE(resource.actions.size() == 1);
@@ -286,7 +286,7 @@ TEST_CASE("Make sure method followed by a group does not eat the group", "[resou
     REQUIRE(resourceGroup.node.content.elements().size() == 1);
     REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
 
-    Resource resource = resourceGroup.node.content.elements().at(0).content.resource;
+    const Resource& resource = resourceGroup.node.content.elements().at(0).content.resource;
     REQUIRE(resource.uriTemplate == "/1");
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].method == "POST");
@@ -316,7 +316,7 @@ TEST_CASE("Parse resource method abbreviation followed by a foreign method", "[r
     REQUIRE(resourceGroup.node.content.elements().size() == 1);
     REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
 
-    Resource resource = resourceGroup.node.content.elements().at(0).content.resource;
+    const Resource& resource = resourceGroup.node.content.elements().at(0).content.resource;
     REQUIRE(resource.name.empty());
     REQUIRE(resource.uriTemplate == "/resource");
     REQUIRE(resource.model.name.empty());
@@ -349,21 +349,25 @@ TEST_CASE("Parse resource method abbreviation followed by another", "[resource_g
     REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(resourceGroup.node.content.elements().at(1).element == Element::ResourceElement);
 
-    Resource resource = resourceGroup.node.content.elements().at(0).content.resource;
-    REQUIRE(resource.name.empty());
-    REQUIRE(resource.uriTemplate == "/resource");
-    REQUIRE(resource.model.name.empty());
-    REQUIRE(resource.model.body.empty());
-    REQUIRE(resource.actions.size() == 1);
-    REQUIRE(resource.actions[0].method == "GET");
+    {
+        const Resource& resource = resourceGroup.node.content.elements().at(0).content.resource;
+        REQUIRE(resource.name.empty());
+        REQUIRE(resource.uriTemplate == "/resource");
+        REQUIRE(resource.model.name.empty());
+        REQUIRE(resource.model.body.empty());
+        REQUIRE(resource.actions.size() == 1);
+        REQUIRE(resource.actions[0].method == "GET");
+    }
 
-    resource = resourceGroup.node.content.elements().at(1).content.resource;
-    REQUIRE(resource.name.empty());
-    REQUIRE(resource.uriTemplate == "/2");
-    REQUIRE(resource.model.name.empty());
-    REQUIRE(resource.model.body.empty());
-    REQUIRE(resource.actions.size() == 1);
-    REQUIRE(resource.actions[0].method == "POST");
+    {
+        const Resource& resource = resourceGroup.node.content.elements().at(1).content.resource;
+        REQUIRE(resource.name.empty());
+        REQUIRE(resource.uriTemplate == "/2");
+        REQUIRE(resource.model.name.empty());
+        REQUIRE(resource.model.body.empty());
+        REQUIRE(resource.actions.size() == 1);
+        REQUIRE(resource.actions[0].method == "POST");
+    }
 
     REQUIRE(resourceGroup.sourceMap.attributes.name.sourceMap.empty());
     REQUIRE(resourceGroup.sourceMap.content.elements().collection.size() == 2);
@@ -389,15 +393,19 @@ TEST_CASE("Resource followed by a complete action", "[resource_group][regression
     REQUIRE(resourceGroup.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(resourceGroup.node.content.elements().at(1).element == Element::ResourceElement);
 
-    Resource resource = resourceGroup.node.content.elements().at(0).content.resource;
-    REQUIRE(resource.name == "Resource");
-    REQUIRE(resource.uriTemplate == "/A");
+    {
+        const Resource& resource = resourceGroup.node.content.elements().at(0).content.resource;
+        REQUIRE(resource.name == "Resource");
+        REQUIRE(resource.uriTemplate == "/A");
+    }
 
-    resource = resourceGroup.node.content.elements().at(1).content.resource;
-    REQUIRE(resource.name.empty());
-    REQUIRE(resource.uriTemplate == "/B");
-    REQUIRE(resource.actions.size() == 1);
-    REQUIRE(resource.actions[0].method == "POST");
+    {
+        const Resource& resource = resourceGroup.node.content.elements().at(1).content.resource;
+        REQUIRE(resource.name.empty());
+        REQUIRE(resource.uriTemplate == "/B");
+        REQUIRE(resource.actions.size() == 1);
+        REQUIRE(resource.actions[0].method == "POST");
+    }
 
     SourceMap<Resource> resourceSM = resourceGroup.sourceMap.content.elements().collection[0].content.resource;
     SourceMapHelper::check(resourceSM.name.sourceMap, 0, 16);

--- a/ext/snowcrash/test/test-ResourceParser.cc
+++ b/ext/snowcrash/test/test-ResourceParser.cc
@@ -513,7 +513,7 @@ TEST_CASE("Parse named resource with lazy referencing", "[resource][model][issue
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.uriTemplate == "/1");
     REQUIRE(resource.name == "Resource 1");
 
@@ -580,7 +580,7 @@ TEST_CASE("Parse named resource with lazy referencing with both response and req
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.uriTemplate == "/items");
     REQUIRE(resource.name == "Collection of Items");
 

--- a/ext/snowcrash/test/test-SymbolIdentifier.cc
+++ b/ext/snowcrash/test/test-SymbolIdentifier.cc
@@ -26,7 +26,7 @@ TEST_CASE("Punctuation in identifiers", "[symbol_identifier]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.name == "Parcel's sticker @#!$%^&*=-?><,.~`\"'");
     REQUIRE(resource.uriTemplate == "/");
     REQUIRE(resource.actions.empty());
@@ -52,7 +52,7 @@ TEST_CASE("Non ASCII characters in identifiers", "[symbol_identifier]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.name == "\xD0\x9A\xD0\xB0\xD1\x82\xD0\xB5\xD0\xB3\xD0\xBE\xD1\x80\xD0\xB8\xD0\xB8");
     REQUIRE(resource.uriTemplate == "/");
     REQUIRE(resource.actions.empty());

--- a/ext/snowcrash/test/test-snowcrash.cc
+++ b/ext/snowcrash/test/test-snowcrash.cc
@@ -54,18 +54,18 @@ TEST_CASE("Parse simple blueprint", "[parser]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.uriTemplate == "/resource");
     REQUIRE(resource.actions.size() == 1);
 
-    Action& action = resource.actions[0];
+    const Action& action = resource.actions.at(0);
     REQUIRE(action.method == "GET");
     REQUIRE(action.description == "Resource **description**");
     REQUIRE(action.examples.size() == 1);
     REQUIRE(action.examples.front().requests.empty());
     REQUIRE(action.examples.front().responses.size() == 1);
 
-    Response& response = action.examples.front().responses[0];
+    const Response& response = action.examples.front().responses.at(0);
     REQUIRE(response.name == "200");
     REQUIRE(response.body == "Text\n\n{ ... }\n");
 }
@@ -120,7 +120,7 @@ TEST_CASE("Support description ending with an list item", "[parser][8]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description == "+ a description item");
     REQUIRE(resource.actions[0].examples.size() == 1);
@@ -145,7 +145,7 @@ TEST_CASE("Invalid ‘warning: empty body asset’ for certain status codes", "[
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].examples.size() == 1);
@@ -204,7 +204,7 @@ TEST_CASE("Parse adjacent asset blocks", "[parser][9]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].examples.size() == 1);
@@ -233,7 +233,7 @@ TEST_CASE("Parse adjacent asset list blocks", "[parser][9]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
@@ -265,7 +265,7 @@ TEST_CASE("Parse adjacent nested asset blocks", "[parser][9]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].description.empty());
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
@@ -391,7 +391,7 @@ TEST_CASE("Dangling block not recognized", "[parser][regression][186]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.name == "A");
     REQUIRE(resource.uriTemplate == "/a");
     REQUIRE(resource.model.body == "    { ... }\n\n");
@@ -421,7 +421,7 @@ TEST_CASE("Ignoring block recovery", "[parser][regression][188]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.name == "Note");
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].name == "Remove a Note");
@@ -454,7 +454,7 @@ TEST_CASE("Ignoring dangling model assets", "[parser][regression][196]")
     REQUIRE(blueprint.node.content.elements().at(1).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(1).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(1).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(1).content.resource;
     REQUIRE(resource.name.empty());
     REQUIRE(resource.uriTemplate == "/B");
     REQUIRE(resource.actions.size() == 1);
@@ -489,7 +489,7 @@ TEST_CASE("Ignoring local media type", "[parser][regression][195]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
@@ -536,7 +536,7 @@ TEST_CASE("Using local media type", "[parser][regression][195]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
@@ -579,7 +579,7 @@ TEST_CASE("Parse ill-formatted header", "[parser][198][regression]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].examples.size() == 1);
     REQUIRE(resource.actions[0].examples[0].responses.size() == 1);
@@ -616,7 +616,7 @@ TEST_CASE("Overshadow parameters", "[parser][201][regression][parameters]")
     REQUIRE(blueprint.node.content.elements().at(0).element == Element::ResourceElement);
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().size() == 0);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.resource;
     REQUIRE(resource.actions.size() == 1);
     REQUIRE(resource.actions[0].parameters.size() == 3);
 
@@ -676,7 +676,7 @@ TEST_CASE("Don't remove link references", "[parser][213]")
         == "This is [second example][id]\n\n[id]: http://b.com");
     REQUIRE(blueprint.node.content.elements().at(0).content.elements().at(1).element == Element::ResourceElement);
 
-    Resource resource = blueprint.node.content.elements().at(0).content.elements().at(1).content.resource;
+    const Resource& resource = blueprint.node.content.elements().at(0).content.elements().at(1).content.resource;
     REQUIRE(resource.uriTemplate == "/a");
     REQUIRE(resource.description == "This is [third example][id]\n\n[id]: http://c.com");
 }

--- a/test/utils/test-Variant.cc
+++ b/test/utils/test-Variant.cc
@@ -385,7 +385,9 @@ SCENARIO("variant construction", "[variant][init]")
 
         THEN("a Bar was move constructed")
         {
-            REQUIRE(Bar::record().move_constructor == 1);
+            // @tjanc@ we cannot guarantee move-ellision will work with the observed move constructor; there will be
+            // either one or two invocations based on that
+            REQUIRE((Bar::record().move_constructor == 1 || Bar::record().move_constructor == 2));
         }
 
         THEN("it was not default constructed")

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -203,6 +203,8 @@ echo   vcbuild.bat MSVC2013       : indicate target solution's version, could al
 goto success
 
 :fail
+REM print log if found
+if exist "drafter.log" tail.exe -n 100 "drafter.log"
 EXIT /B 1
 
 :success


### PR DESCRIPTION
- run debug builds on Appveyor
- if tests fail, Appveyor fails
- if tests fail, last 100 lines of `drafter.log` are dumped

Two bugs in tests surfaced:
- `test-Variant.cc`: too strict assert
- snowcrash tests: changed occurences of `Resource resource =` to `const Resource& resource =` due to invalid copy constructor of `snowcrash::Resource`; this suppresses issue #585 but does not fix it