### PR TITLE
Fix issue #519

### DIFF
--- a/src/refract/JsonValue.cc
+++ b/src/refract/JsonValue.cc
@@ -219,16 +219,26 @@ namespace
 
         so::Array result{};
         if (e.empty()) {
+            if (options.test(FIXED_TYPE_FLAG))
+                LOG(warning) << "empty fixedType ArrayElement in backend";
+
             auto alt = renderSampleOrDefault(e, inherit_flags(options));
             if (alt.first)
                 return std::move(alt.second);
-        } else
+        } else {
+            if (options.test(FIXED_TYPE_FLAG)) {
+                auto alt = renderSampleOrDefault(e, inherit_flags(options));
+                if (alt.first)
+                    return std::move(alt.second);
+            }
+
             for (const auto& entry : e.get()) {
                 assert(entry);
                 renderItem(result, *entry, inherit_or_pass_flags(options, *entry));
                 if (options.test(FIXED_TYPE_FLAG))
                     break;
             }
+        }
 
         return so::Value{ result };
     }

--- a/test/fixtures/render/issue-519.apib
+++ b/test/fixtures/render/issue-519.apib
@@ -1,0 +1,18 @@
+# API
+
+## GET /users
+
++ Response 200 (application/json)
+    + Attributes
+        + users (array[User], fixed-type)
+            + Sample
+                + (User)
+                    + username: doe
+                + (User)
+                    + username: tim
+
+## Data Structures
+
+### User
+
++ username: kyle

--- a/test/fixtures/render/issue-519.json
+++ b/test/fixtures/render/issue-519.json
@@ -1,0 +1,266 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "API"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "meta": {
+            "title": {
+              "element": "string",
+              "content": ""
+            }
+          },
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/users"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": ""
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "object",
+                            "content": [
+                              {
+                                "element": "member",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixedType"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "users"
+                                  },
+                                  "value": {
+                                    "element": "array",
+                                    "attributes": {
+                                      "samples": {
+                                        "element": "array",
+                                        "content": [
+                                          {
+                                            "element": "array",
+                                            "content": [
+                                              {
+                                                "element": "User",
+                                                "content": [
+                                                  {
+                                                    "element": "member",
+                                                    "content": {
+                                                      "key": {
+                                                        "element": "string",
+                                                        "content": "username"
+                                                      },
+                                                      "value": {
+                                                        "element": "string",
+                                                        "content": "doe"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "element": "User",
+                                                "content": [
+                                                  {
+                                                    "element": "member",
+                                                    "content": {
+                                                      "key": {
+                                                        "element": "string",
+                                                        "content": "username"
+                                                      },
+                                                      "value": {
+                                                        "element": "string",
+                                                        "content": "tim"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "content": [
+                                      {
+                                        "element": "User"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{\n  \"users\": [\n    {\n      \"username\": \"doe\"\n    },\n    {\n      \"username\": \"tim\"\n    }\n  ]\n}"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBodySchema"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/schema+json"
+                            }
+                          },
+                          "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"users\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"anyOf\": [\n          {\n            \"type\": \"object\",\n            \"properties\": {\n              \"username\": {\n                \"type\": \"string\"\n              }\n            }\n          }\n        ]\n      }\n    }\n  }\n}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "dataStructures"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "content": "User"
+                  }
+                },
+                "content": [
+                  {
+                    "element": "member",
+                    "content": {
+                      "key": {
+                        "element": "string",
+                        "content": "username"
+                      },
+                      "value": {
+                        "element": "string",
+                        "content": "kyle"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test-RenderTest.cc
+++ b/test/test-RenderTest.cc
@@ -53,3 +53,4 @@ TEST_REFRACT("render", "fixed-named-type");
 TEST_REFRACT("render", "mixin-override");
 
 TEST_REFRACT("render", "issue-547");
+TEST_REFRACT("render", "issue-519");


### PR DESCRIPTION
## Context
1. A `fixedType` Array element should be treated as the type of lists of _any of_ the elements in its content.
2. An Enum element should be treated as the type of _any of_ the elements in its `enumerations` attribute.

One could argue both _any of_ combinators are expected to behave similarly.

## Current behaviour
In (1) the JSON value rendering precedence is **content** - **sample** - **default**.
In (2) the JSON value rendering precedence is **content** - **sample** - **default** - **enumerations**.

This is unified only syntactically. In (1) what seems to be _content_ actually is a `fixedType`'d Array element's way to define its `enumerations`.

## Fix
Issue #519 comes with this suggestion:
In (1) the JSON value rendering precedence SHOULD BE **sample** - **default** - **content**.

This PR does just this, it changes the precedence of value source for `fixedType` Array elements in the JSON value renderer.