### PR TITLE
Initial CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+message(STATUS "Testing dependencies ${BUILD_TESTING_DEPENDENCIES}.")
+
+set(CMAKE_PREFIX_PATH "/prefix")
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE)
+set(as_subproject
+    markdown-parser
+    snowcrash
+    Sundown
+    cmdline
+    Drafter
+    Catch2
+    dtl
+    BoostContainer)
+
+macro(find_package)
+    if(NOT "${ARGV0}" IN_LIST as_subproject)
+        _find_package(${ARGV})
+    endif()
+endmacro()
+
+# add external dependencies living in `ext`
+add_subdirectory(ext/snowcrash/ext/markdown-parser/ext/sundown EXCLUDE_FROM_ALL)
+add_subdirectory(ext/cmdline EXCLUDE_FROM_ALL)
+add_subdirectory(ext/boost_1_66_0 EXCLUDE_FROM_ALL)
+
+message(STATUS "Setting up tests for production...")
+set(BUILD_TESTING ON)
+add_subdirectory(test/vendor/Catch EXCLUDE_FROM_ALL)
+add_subdirectory(test/vendor/dtl EXCLUDE_FROM_ALL)
+include(CTest)
+include(test/vendor/Catch/contrib/Catch.cmake)
+enable_testing()
+
+# targets developed in this super project
+add_subdirectory(ext/snowcrash/ext/markdown-parser EXCLUDE_FROM_ALL)
+add_subdirectory(ext/snowcrash EXCLUDE_FROM_ALL)
+
+# drafter
+add_subdirectory(src)
+if(${BUILD_TESTING})
+    add_subdirectory(test)
+endif()
+
+
+add_dependencies(drafter-test markdown-parser-test snowcrash-test)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,9 @@ add_subdirectory(ext/snowcrash EXCLUDE_FROM_ALL)
 add_subdirectory(src)
 if(${BUILD_TESTING})
     add_subdirectory(test)
+    add_custom_target(drafter-test-suite ALL)
+    add_dependencies(drafter-test-suite drafter-test markdown-parser-test snowcrash-test)
 endif()
 
 
-add_dependencies(drafter-test markdown-parser-test snowcrash-test)
 

--- a/drafter.gyp
+++ b/drafter.gyp
@@ -69,7 +69,7 @@
       'target_name': 'test-libmarkdownparser',
       'type': 'executable',
       'include_dirs': [
-        'test/vendor/Catch/include',
+        'test/vendor/Catch/single_include',
       ],
       'sources': [
         'ext/snowcrash/ext/markdown-parser/test/test-ByteBuffer.cc',
@@ -165,7 +165,7 @@
       'target_name': 'test-libsnowcrash',
       'type': 'executable',
       'include_dirs': [
-        'test/vendor/Catch/include',
+        'test/vendor/Catch/single_include',
       ],
       'sources': [
         'ext/snowcrash/test/test-ActionParser.cc',
@@ -361,7 +361,7 @@
       'target_name': 'test-libdrafter',
       'type': 'executable',
       'include_dirs': [
-        'test/vendor/Catch/include',
+        'test/vendor/Catch/single_include',
         'test/vendor/dtl/dtl',
         'src/refract',
       ],

--- a/ext/boost_1_66_0/BoostContainerConfig.cmake
+++ b/ext/boost_1_66_0/BoostContainerConfig.cmake
@@ -1,0 +1,2 @@
+include(CMakeFindDependencyMacro)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostContainerTargets.cmake")

--- a/ext/boost_1_66_0/CMakeLists.txt
+++ b/ext/boost_1_66_0/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(BoostContainer VERSION 1.66 LANGUAGES CXX)
+
+add_library(container INTERFACE)
+
+target_include_directories(container INTERFACE 
+    $<BUILD_INTERFACE:${BoostContainer_BINARY_DIR}>
+    $<BUILD_INTERFACE:${BoostContainer_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:>
+    )
+
+target_link_libraries(container INTERFACE)
+
+install(EXPORT container-targets
+    FILE BoostContainerTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS container EXPORT container-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostContainerConfigVersion.cmake"
+    VERSION ${BoostContainer_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostContainerConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostContainerConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+
+add_library(Boost::container ALIAS container)

--- a/ext/snowcrash/CMakeLists.txt
+++ b/ext/snowcrash/CMakeLists.txt
@@ -1,0 +1,93 @@
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+project(snowcrash VERSION 0.1 LANGUAGES CXX)
+
+set(snowcrash_SOURCES
+      src/Blueprint.cc
+      src/BlueprintSourcemap.cc
+      src/HeadersParser.cc
+      src/HTTP.cc
+      src/MSON.cc
+      src/MSONOneOfParser.cc
+      src/MSONSourcemap.cc
+      src/MSONTypeSectionParser.cc
+      src/MSONValueMemberParser.cc
+      src/Section.cc
+      src/Signature.cc
+      src/snowcrash.cc
+      src/UriTemplateParser.cc
+    )
+
+if(MSVC)
+    set(snowcrash_SOURCES ${snowcrash_SOURCES} src/win/RegexMatch.cc)
+else()
+    set(snowcrash_SOURCES ${snowcrash_SOURCES} src/posix/RegexMatch.cc)
+endif()
+
+add_library(snowcrash SHARED ${snowcrash_SOURCES})
+add_library(snowcrash-static STATIC ${snowcrash_SOURCES})
+add_library(snowcrash-pic STATIC ${snowcrash_SOURCES})
+set_property(TARGET snowcrash-pic PROPERTY POSITION_INDEPENDENT_CODE 1)
+
+if(UNIX)
+    set_target_properties(snowcrash-static PROPERTIES OUTPUT_NAME snowcrash)
+endif()
+
+find_package(markdown-parser 1.0 REQUIRED)
+
+target_link_libraries(snowcrash PUBLIC markdown-parser::markdown-parser-pic)
+target_link_libraries(snowcrash-static PUBLIC markdown-parser::markdown-parser-static)
+target_link_libraries(snowcrash-pic PUBLIC markdown-parser::markdown-parser-pic)
+
+target_include_directories(snowcrash PUBLIC
+    $<BUILD_INTERFACE:${snowcrash_BINARY_DIR}/src>
+    $<BUILD_INTERFACE:${snowcrash_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:src>
+    )
+
+target_include_directories(snowcrash-static PUBLIC
+    $<BUILD_INTERFACE:${snowcrash_BINARY_DIR}/src>
+    $<BUILD_INTERFACE:${snowcrash_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:src>
+    )
+
+target_include_directories(snowcrash-pic PUBLIC
+    $<BUILD_INTERFACE:${snowcrash_BINARY_DIR}/src>
+    $<BUILD_INTERFACE:${snowcrash_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:src>
+    )
+
+install(TARGETS snowcrash snowcrash-static snowcrash-pic EXPORT snowcrash-targets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+    )
+
+install(EXPORT snowcrash-targets
+    FILE snowcrash-targets.cmake
+    NAMESPACE snowcrash::
+    DESTINATION lib/cmake/snowcrash
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("snowcrash-config-version.cmake"
+    VERSION ${snowcrash_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "snowcrash-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/snowcrash-config-version.cmake"
+    DESTINATION
+        lib/cmake/snowcrash
+    )
+
+add_library(snowcrash::snowcrash ALIAS snowcrash)
+add_library(snowcrash::snowcrash-static ALIAS snowcrash-static)
+add_library(snowcrash::snowcrash-pic ALIAS snowcrash-pic)
+
+
+if(BUILD_TESTING)
+    include(snowcrash-tests.cmake)
+endif()

--- a/ext/snowcrash/ext/markdown-parser/CMakeLists.txt
+++ b/ext/snowcrash/ext/markdown-parser/CMakeLists.txt
@@ -1,0 +1,126 @@
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+project(markdown-parser VERSION 0.1 LANGUAGES CXX)
+
+set(MARKDOWN_PARSER_SOURCES
+    src/ByteBuffer.cc
+    src/MarkdownNode.cc
+    src/MarkdownParser.cc
+    )
+
+set(MARKDOWN_PARSER_COMPILE_FEATURES
+    cxx_alias_templates
+    cxx_alignas
+    cxx_alignof
+    cxx_attribute_deprecated
+    cxx_auto_type
+    cxx_constexpr
+    cxx_contextual_conversions
+    cxx_decltype
+    cxx_decltype_auto
+    cxx_defaulted_functions
+    cxx_defaulted_move_initializers
+    cxx_delegating_constructors
+    cxx_deleted_functions
+    cxx_digit_separators
+    cxx_explicit_conversions
+    cxx_final
+    cxx_generalized_initializers
+    cxx_generic_lambdas
+    cxx_inheriting_constructors
+    cxx_lambdas
+    cxx_lambda_init_captures
+    cxx_noexcept
+    cxx_nonstatic_member_init
+    cxx_nullptr
+    cxx_override
+    cxx_range_for
+    cxx_raw_string_literals
+    cxx_return_type_deduction
+    cxx_rvalue_references
+    cxx_sizeof_member
+    cxx_static_assert
+    cxx_strong_enums
+    cxx_thread_local
+    cxx_trailing_return_types
+    cxx_unicode_literals
+    cxx_uniform_initialization
+    cxx_unrestricted_unions
+    cxx_user_literals
+    cxx_variable_templates
+    cxx_variadic_macros
+    cxx_variadic_templates
+    cxx_template_template_parameters
+    )
+
+add_library(markdown-parser SHARED ${MARKDOWN_PARSER_SOURCES})
+add_library(markdown-parser-static STATIC ${MARKDOWN_PARSER_SOURCES})
+add_library(markdown-parser-pic STATIC ${MARKDOWN_PARSER_SOURCES})
+set_property(TARGET markdown-parser-pic PROPERTY POSITION_INDEPENDENT_CODE 1)
+
+if(UNIX)
+    set_target_properties(markdown-parser-static PROPERTIES OUTPUT_NAME markdown-parser)
+endif()
+
+find_package(Sundown 1.0 REQUIRED)
+
+target_link_libraries(markdown-parser PUBLIC Apiary::sundown-pic)
+target_link_libraries(markdown-parser-static PUBLIC Apiary::sundown-static)
+target_link_libraries(markdown-parser-pic PUBLIC Apiary::sundown-pic)
+
+target_include_directories(markdown-parser PUBLIC
+    $<BUILD_INTERFACE:${markdown-parser_BINARY_DIR}/src>
+    $<BUILD_INTERFACE:${markdown-parser_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:src>
+    )
+
+target_include_directories(markdown-parser-static PUBLIC
+    $<BUILD_INTERFACE:${markdown-parser_BINARY_DIR}/src>
+    $<BUILD_INTERFACE:${markdown-parser_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:src>
+    )
+
+target_include_directories(markdown-parser-pic PUBLIC
+    $<BUILD_INTERFACE:${markdown-parser_BINARY_DIR}/src>
+    $<BUILD_INTERFACE:${markdown-parser_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:src>
+    )
+
+target_compile_features(markdown-parser PUBLIC ${MARKDOWN_PARSER_COMPILE_FEATURES})
+target_compile_features(markdown-parser-static PUBLIC ${MARKDOWN_PARSER_COMPILE_FEATURES})
+target_compile_features(markdown-parser-pic PUBLIC ${MARKDOWN_PARSER_COMPILE_FEATURES})
+
+install(TARGETS markdown-parser markdown-parser-static markdown-parser-pic EXPORT markdown-parser-targets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+    )
+
+install(EXPORT markdown-parser-targets
+    FILE markdown-parser-targets.cmake
+    NAMESPACE markdown-parser::
+    DESTINATION lib/cmake/markdown-parser
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("markdown-parser-config-version.cmake"
+    VERSION ${markdown-parser_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+
+install(
+    FILES
+        "markdown-parser-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/markdown-parser-config-version.cmake"
+    DESTINATION
+        lib/cmake/markdown-parser
+    )
+
+add_library(markdown-parser::markdown-parser ALIAS markdown-parser)
+add_library(markdown-parser::markdown-parser-static ALIAS markdown-parser-static)
+add_library(markdown-parser::markdown-parser-pic ALIAS markdown-parser-pic)
+
+if(BUILD_TESTING)
+    include(markdown-parser-tests.cmake)
+endif()

--- a/ext/snowcrash/ext/markdown-parser/markdown-parser-config.cmake
+++ b/ext/snowcrash/ext/markdown-parser/markdown-parser-config.cmake
@@ -1,0 +1,3 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Sundown 1.0)
+include("${CMAKE_CURRENT_LIST_DIR}/markdown-parser-targets.cmake")

--- a/ext/snowcrash/ext/markdown-parser/markdown-parser-tests.cmake
+++ b/ext/snowcrash/ext/markdown-parser/markdown-parser-tests.cmake
@@ -8,7 +8,7 @@ add_executable(markdown-parser-test
     test/test-MarkdownParser.cc
     )
 
-catch_discover_tests(markdown-parser-test)
+add_test(MardownParserTest markdown-parser-test)
 
 target_link_libraries(markdown-parser-test
     PRIVATE

--- a/ext/snowcrash/ext/markdown-parser/markdown-parser-tests.cmake
+++ b/ext/snowcrash/ext/markdown-parser/markdown-parser-tests.cmake
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+find_package(Catch2 1.0 REQUIRED)
+
+add_executable(markdown-parser-test
+    test/test-ByteBuffer.cc
+    test/test-libmarkdownparser.cc
+    test/test-MarkdownParser.cc
+    )
+
+catch_discover_tests(markdown-parser-test)
+
+target_link_libraries(markdown-parser-test
+    PRIVATE
+        Catch2::Catch2
+        markdown-parser::markdown-parser-static
+    )
+

--- a/ext/snowcrash/ext/markdown-parser/test/test-ByteBuffer.cc
+++ b/ext/snowcrash/ext/markdown-parser/test/test-ByteBuffer.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 #include "MarkdownParser.h"
 
 using namespace mdp;

--- a/ext/snowcrash/ext/markdown-parser/test/test-MarkdownParser.cc
+++ b/ext/snowcrash/ext/markdown-parser/test/test-MarkdownParser.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 #include "MarkdownParser.h"
 
 using namespace mdp;

--- a/ext/snowcrash/ext/markdown-parser/test/test-libmarkdownparser.cc
+++ b/ext/snowcrash/ext/markdown-parser/test/test-libmarkdownparser.cc
@@ -7,4 +7,4 @@
 //
 
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include <catch2/catch.hpp>

--- a/ext/snowcrash/snowcrash-config.cmake
+++ b/ext/snowcrash/snowcrash-config.cmake
@@ -1,0 +1,3 @@
+include(CMakeFindDependencyMacro)
+find_dependency(markdown-parser 1.0)
+include("${CMAKE_CURRENT_LIST_DIR}/snowcrash-targets.cmake")

--- a/ext/snowcrash/snowcrash-tests.cmake
+++ b/ext/snowcrash/snowcrash-tests.cmake
@@ -42,7 +42,7 @@ add_executable(snowcrash-test-performance
     test/performance/perf-snowcrash.cc
     )
 
-catch_discover_tests(snowcrash-test)
+add_test(SnowcrashTest snowcrash-test)
 
 target_link_libraries(snowcrash-test
     PRIVATE

--- a/ext/snowcrash/snowcrash-tests.cmake
+++ b/ext/snowcrash/snowcrash-tests.cmake
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+find_package(Catch2 1.0 REQUIRED)
+
+add_executable(snowcrash-test
+    test/test-Blueprint.cc
+    test/test-MSONUtility.cc
+    test/test-MSONNamedTypeParser.cc
+    test/test-ModelTable.cc
+    test/test-Signature.cc
+    test/test-ParametersParser.cc
+    test/test-StringUtility.cc
+    test/test-snowcrash.cc
+    test/test-MSONOneOfParser.cc
+    test/test-Indentation.cc
+    test/test-UriTemplateParser.cc
+    test/test-PayloadParser.cc
+    test/test-SymbolIdentifier.cc
+    test/test-RegexMatch.cc
+    test/test-HeadersParser.cc
+    test/test-MSONValueMemberParser.cc
+    test/test-DataStructureGroupParser.cc
+    test/test-MSONPropertyMemberParser.cc
+    test/test-ParameterParser.cc
+    test/test-MSONTypeSectionParser.cc
+    test/test-MSONParameterParser.cc
+    test/test-RelationParser.cc
+    test/test-SectionParser.cc
+    test/test-MSONMixinParser.cc
+    test/test-ValuesParser.cc
+    test/test-BlueprintUtility.cc
+    test/test-Warnings.cc
+    test/test-ResourceParser.cc
+    test/test-ResourceGroupParser.cc
+    test/test-BlueprintParser.cc
+    test/test-AssetParser.cc
+    test/test-ActionParser.cc
+    test/test-AttributesParser.cc
+    )
+
+add_executable(snowcrash-test-performance
+    test/performance/perf-snowcrash.cc
+    )
+
+catch_discover_tests(snowcrash-test)
+
+target_link_libraries(snowcrash-test
+    PRIVATE
+        Catch2::Catch2
+        snowcrash::snowcrash-static
+        markdown-parser::markdown-parser-static
+    )
+
+target_link_libraries(snowcrash-test-performance
+    PRIVATE
+        snowcrash::snowcrash
+    )
+
+file(
+    COPY
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/performance/
+    DESTINATION
+        ${CMAKE_CURRENT_BINARY_DIR}/test/performance/
+    )
+

--- a/ext/snowcrash/test/snowcrashtest.h
+++ b/ext/snowcrash/test/snowcrashtest.h
@@ -9,7 +9,7 @@
 #ifndef SNOWCRASH_SNOWCRASHTEST_H
 #define SNOWCRASH_SNOWCRASHTEST_H
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 #include "MarkdownParser.h"
 #include "SectionParser.h"
 

--- a/ext/snowcrash/test/test-Blueprint.cc
+++ b/ext/snowcrash/test/test-Blueprint.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 #include "Blueprint.h"
 
 using namespace snowcrash;

--- a/ext/snowcrash/test/test-RegexMatch.cc
+++ b/ext/snowcrash/test/test-RegexMatch.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 #include "RegexMatch.h"
 
 using namespace snowcrash;

--- a/ext/snowcrash/test/test-UriTemplateParser.cc
+++ b/ext/snowcrash/test/test-UriTemplateParser.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 #include "UriTemplateParser.h"
 
 using namespace snowcrash;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,206 @@
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(Drafter VERSION 4.0 LANGUAGES CXX)
+
+set(DRAFTER_SOURCES
+    utils/so/Value.cc
+    utils/so/JsonIo.cc
+    utils/so/YamlIo.cc
+    utils/log/Trivial.cc
+    refract/dsd/Bool.cc
+    refract/dsd/Member.cc
+    refract/dsd/Object.cc
+    refract/dsd/Ref.cc
+    refract/dsd/Extend.cc
+    refract/dsd/Holder.cc
+    refract/dsd/Array.cc
+    refract/dsd/Select.cc
+    refract/dsd/Null.cc
+    refract/dsd/Enum.cc
+    refract/dsd/String.cc
+    refract/dsd/Number.cc
+    refract/dsd/Option.cc
+    refract/Utils.cc
+    refract/ElementUtils.cc
+    refract/ComparableVisitor.cc
+    refract/JsonValue.cc
+    refract/JsonUtils.cc
+    refract/SerializeSo.cc
+    refract/Query.cc
+    refract/InfoElements.cc
+    refract/TypeQueryVisitor.cc
+    refract/JsonSchema.cc
+    refract/PrintVisitor.cc
+    refract/Registry.cc
+    refract/IsExpandableVisitor.cc
+    refract/VisitorUtils.cc
+    refract/ExpandVisitor.cc
+    refract/Element.cc
+    Serialize.cc
+    SerializeResult.cc
+    RefractAPI.cc
+    drafter.cc
+    RefractSourceMap.cc
+    NamedTypesRegistry.cc
+    RefractDataStructure.cc
+    Render.cc
+    ConversionContext.cc
+    RefractElementFactory.cc
+    )
+
+set(DRAFTER_COMPILE_FEATURES
+    cxx_alias_templates
+    cxx_alignas
+    cxx_alignof
+    cxx_attribute_deprecated
+    cxx_auto_type
+    cxx_constexpr
+    cxx_contextual_conversions
+    cxx_decltype
+    cxx_decltype_auto
+    cxx_defaulted_functions
+    cxx_defaulted_move_initializers
+    cxx_delegating_constructors
+    cxx_deleted_functions
+    cxx_digit_separators
+    cxx_explicit_conversions
+    cxx_final
+    cxx_generalized_initializers
+    cxx_generic_lambdas
+    cxx_inheriting_constructors
+    cxx_lambdas
+    cxx_lambda_init_captures
+    cxx_noexcept
+    cxx_nonstatic_member_init
+    cxx_nullptr
+    cxx_override
+    cxx_range_for
+    cxx_raw_string_literals
+    cxx_return_type_deduction
+    cxx_rvalue_references
+    cxx_sizeof_member
+    cxx_static_assert
+    cxx_strong_enums
+    cxx_thread_local
+    cxx_trailing_return_types
+    cxx_unicode_literals
+    cxx_uniform_initialization
+    cxx_unrestricted_unions
+    cxx_user_literals
+    cxx_variable_templates
+    cxx_variadic_macros
+    cxx_variadic_templates
+    cxx_template_template_parameters
+    )
+
+# libdrafter
+add_library(drafter SHARED ${DRAFTER_SOURCES})
+add_library(drafter-static STATIC ${DRAFTER_SOURCES})
+add_library(drafter-pic STATIC ${DRAFTER_SOURCES})
+set_property(TARGET drafter-pic PROPERTY POSITION_INDEPENDENT_CODE 1)
+
+set_target_properties(drafter PROPERTIES PUBLIC_HEADER "drafter.h")
+
+# production dependencies
+find_package(snowcrash 1.0 REQUIRED)
+find_package(BoostContainer 1.66 REQUIRED)
+find_package(cmdline 1.0 REQUIRED)
+
+target_link_libraries(drafter
+    PRIVATE
+        snowcrash::snowcrash-pic
+        Boost::container
+    )
+
+target_link_libraries(drafter-pic
+    PRIVATE
+        snowcrash::snowcrash-pic
+        Boost::container
+    )
+
+target_link_libraries(drafter-static
+    PRIVATE
+        snowcrash::snowcrash-static
+        Boost::container
+    )
+
+target_include_directories(drafter PUBLIC
+    $<BUILD_INTERFACE:${Drafter_BINARY_DIR}>
+    $<BUILD_INTERFACE:${Drafter_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:>
+    )
+
+target_include_directories(drafter-static PUBLIC
+    $<BUILD_INTERFACE:${Drafter_BINARY_DIR}>
+    $<BUILD_INTERFACE:${Drafter_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:>
+    )
+
+target_include_directories(drafter-pic PUBLIC
+    $<BUILD_INTERFACE:${Drafter_BINARY_DIR}>
+    $<BUILD_INTERFACE:${Drafter_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:>
+    )
+
+
+target_compile_definitions(drafter PRIVATE BUILDING_DRAFTER=1)
+target_compile_definitions(drafter-static PRIVATE BUILDING_DRAFTER=1)
+target_compile_definitions(drafter-pic PRIVATE BUILDING_DRAFTER=1)
+
+target_compile_definitions(drafter PUBLIC DRAFTER_BUILD_SHARED=1)
+
+target_compile_features(drafter PUBLIC ${DRAFTER_COMPILE_FEATURES})
+target_compile_features(drafter-static PUBLIC ${DRAFTER_COMPILE_FEATURES})
+target_compile_features(drafter-pic PUBLIC ${DRAFTER_COMPILE_FEATURES})
+
+# drafter-cli
+add_executable(drafter-cli
+    main.cc
+    reporting.cc
+    config.cc
+    )
+
+target_link_libraries(drafter-cli
+    PRIVATE
+        snowcrash::snowcrash-static
+        drafter::drafter-static
+        cmdline::cmdline
+    )
+
+set_target_properties(drafter-cli PROPERTIES OUTPUT_NAME drafter)
+if(UNIX)
+        set_target_properties(drafter-static PROPERTIES OUTPUT_NAME drafter)
+endif()
+
+install(TARGETS drafter drafter-static drafter-pic drafter-cli EXPORT drafter-targets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+    PUBLIC_HEADER DESTINATION include
+    )
+
+install(EXPORT drafter-targets
+    FILE drafter-targets.cmake
+    NAMESPACE drafter::
+    DESTINATION lib/cmake/drafter
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("drafter-config-version.cmake"
+    VERSION ${drafter_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+
+install(
+    FILES
+        "drafter-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/drafter-config-version.cmake"
+    DESTINATION
+        lib/cmake/drafter
+    )
+
+add_library(drafter::drafter ALIAS drafter)
+add_library(drafter::drafter-static ALIAS drafter-static)
+add_library(drafter::drafter-pic ALIAS drafter-pic)
+

--- a/src/drafter-config.cmake
+++ b/src/drafter-config.cmake
@@ -1,0 +1,7 @@
+include(CMakeFindDependencyMacro)
+find_dependency(snowcrash 1.0)
+find_dependency(BoostContainer 1.66)
+find_dependency(cmdline 1.0)
+find_dependency(dtl 1.0)
+find_dependency(Catch2 1.0)
+include("${CMAKE_CURRENT_LIST_DIR}/drafter-targets.cmake")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+find_package(Catch2 1.0 REQUIRED)
+
+add_executable(drafter-test
+    utils/test-Utf8.cc
+    utils/so/test-YamlIo.cc
+    utils/so/test-JsonIo.cc
+    utils/test-Variant.cc
+    test-RefractAPITest.cc
+    test-ElementComparator.cc
+    refract/dsd/test-Option.cc
+    refract/dsd/test-Object.cc
+    refract/dsd/test-Select.cc
+    refract/dsd/test-Extend.cc
+    refract/dsd/test-String.cc
+    refract/dsd/test-Holder.cc
+    refract/dsd/test-Element.cc
+    refract/dsd/test-Array.cc
+    refract/dsd/test-Number.cc
+    refract/dsd/test-Ref.cc
+    refract/dsd/test-InfoElements.cc
+    refract/dsd/test-Null.cc
+    refract/dsd/test-Bool.cc
+    refract/dsd/test-Member.cc
+    refract/dsd/test-Enum.cc
+    refract/test-InfoElementsUtils.cc
+    refract/test-Utils.cc
+    refract/test-JsonSchema.cc
+    refract/test-JsonValue.cc
+    test-VisitorUtils.cc
+    test-SyntaxIssuesTest.cc
+    test-ApplyVisitorTest.cc
+    test-ElementDataTest.cc
+    test-RefractDataStructureTest.cc
+    test-ElementInfoUtils.cc
+    test-drafter.cc
+    test-ExtendElementTest.cc
+    test-ElementFactoryTest.cc
+    test-SchemaTest.cc
+    test-OneOfTest.cc
+    test-RefractParseResultTest.cc
+    test-RefractSourceMapTest.cc
+    test-CircularReferenceTest.cc
+    test-RenderTest.cc
+    test-Serialize.cc
+    )
+
+target_link_libraries(drafter-test
+    PRIVATE
+        Catch2::Catch2
+        dtl::dtl
+        drafter::drafter-static
+        snowcrash::snowcrash-static
+        Boost::container
+    )
+
+catch_discover_tests(drafter-test)
+
+file(
+    COPY
+        ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/
+    DESTINATION
+        ${CMAKE_CURRENT_BINARY_DIR}/test/fixtures/
+    )
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,7 +55,7 @@ target_link_libraries(drafter-test
         Boost::container
     )
 
-catch_discover_tests(drafter-test)
+add_test(DrafterTest drafter-test)
 
 file(
     COPY

--- a/test/draftertest.h
+++ b/test/draftertest.h
@@ -176,7 +176,6 @@ namespace draftertest
             std::string actual = outStream.str();
             std::string expected;
             std::string extension = getFixtureExtension(options);
-            bool matches = false;
 
             INFO("Filename: \x1b[35m" << basepath << extension << "\x1b[0m");
             expected = fixture.get(extension);

--- a/test/draftertest.h
+++ b/test/draftertest.h
@@ -1,7 +1,7 @@
 #ifndef DRAFTER_DRAFTERTEST_H
 #define DRAFTER_DRAFTERTEST_H
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 #include "dtl.hpp"
 
 #include "RefractAPI.h"

--- a/test/refract/dsd/test-Array.cc
+++ b/test/refract/dsd/test-Array.cc
@@ -113,13 +113,10 @@ SCENARIO("`Array` is inserted to and erased from", "[ElementData][Array]")
             WHEN("another three ElementMocks are inserted at begin two at end")
             {
                 auto mock2 = std::make_unique<test::ElementMock>();
-                auto mock2ptr = mock.get();
 
                 auto mock3 = std::make_unique<test::ElementMock>();
-                auto mock3ptr = mock.get();
 
                 auto mock4 = std::make_unique<test::ElementMock>();
-                auto mock4ptr = mock.get();
 
                 array.insert(array.begin(), std::move(mock2));
                 array.insert(array.begin(), std::move(mock3));
@@ -129,7 +126,6 @@ SCENARIO("`Array` is inserted to and erased from", "[ElementData][Array]")
                 auto mock5ptr = mock.get();
 
                 auto mock6 = std::make_unique<test::ElementMock>();
-                auto mock6ptr = mock.get();
 
                 array.insert(array.begin(), std::move(mock5));
                 array.insert(array.begin(), std::move(mock6));

--- a/test/refract/dsd/test-Array.cc
+++ b/test/refract/dsd/test-Array.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Array.h"
 #include "refract/Element.h"

--- a/test/refract/dsd/test-Bool.cc
+++ b/test/refract/dsd/test-Bool.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Bool.h"
 

--- a/test/refract/dsd/test-Element.cc
+++ b/test/refract/dsd/test-Element.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/Element.h"
 #include "ElementMock.h"

--- a/test/refract/dsd/test-Enum.cc
+++ b/test/refract/dsd/test-Enum.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Enum.h"
 #include "ElementMock.h"

--- a/test/refract/dsd/test-Extend.cc
+++ b/test/refract/dsd/test-Extend.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Extend.h"
 #include "refract/Element.h"

--- a/test/refract/dsd/test-Extend.cc
+++ b/test/refract/dsd/test-Extend.cc
@@ -114,13 +114,8 @@ SCENARIO("`Extend` is inserted to and erased from", "[ElementData][Extend]")
             WHEN("another three ElementMocks are inserted at begin two at end")
             {
                 auto mock2 = std::make_unique<test::ElementMock>();
-                auto mock2ptr = mock.get();
-
                 auto mock3 = std::make_unique<test::ElementMock>();
-                auto mock3ptr = mock.get();
-
                 auto mock4 = std::make_unique<test::ElementMock>();
-                auto mock4ptr = mock.get();
 
                 extend.insert(extend.begin(), std::move(mock2));
                 extend.insert(extend.begin(), std::move(mock3));
@@ -130,7 +125,6 @@ SCENARIO("`Extend` is inserted to and erased from", "[ElementData][Extend]")
                 auto mock5ptr = mock.get();
 
                 auto mock6 = std::make_unique<test::ElementMock>();
-                auto mock6ptr = mock.get();
 
                 extend.insert(extend.begin(), std::move(mock5));
                 extend.insert(extend.begin(), std::move(mock6));

--- a/test/refract/dsd/test-Holder.cc
+++ b/test/refract/dsd/test-Holder.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Holder.h"
 #include "ElementMock.h"

--- a/test/refract/dsd/test-InfoElements.cc
+++ b/test/refract/dsd/test-InfoElements.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/InfoElements.h"
 #include "refract/ElementIfc.h"

--- a/test/refract/dsd/test-Member.cc
+++ b/test/refract/dsd/test-Member.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Member.h"
 

--- a/test/refract/dsd/test-Null.cc
+++ b/test/refract/dsd/test-Null.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Null.h"
 

--- a/test/refract/dsd/test-Number.cc
+++ b/test/refract/dsd/test-Number.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Number.h"
 

--- a/test/refract/dsd/test-Object.cc
+++ b/test/refract/dsd/test-Object.cc
@@ -113,13 +113,8 @@ SCENARIO("`Object` is inserted to and erased from", "[ElementData][Object]")
             WHEN("another three ElementMocks are inserted at begin two at end")
             {
                 auto mock2 = std::make_unique<test::ElementMock>();
-                auto mock2ptr = mock.get();
-
                 auto mock3 = std::make_unique<test::ElementMock>();
-                auto mock3ptr = mock.get();
-
                 auto mock4 = std::make_unique<test::ElementMock>();
-                auto mock4ptr = mock.get();
 
                 object.insert(object.begin(), std::move(mock2));
                 object.insert(object.begin(), std::move(mock3));
@@ -129,7 +124,6 @@ SCENARIO("`Object` is inserted to and erased from", "[ElementData][Object]")
                 auto mock5ptr = mock.get();
 
                 auto mock6 = std::make_unique<test::ElementMock>();
-                auto mock6ptr = mock.get();
 
                 object.insert(object.begin(), std::move(mock5));
                 object.insert(object.begin(), std::move(mock6));

--- a/test/refract/dsd/test-Object.cc
+++ b/test/refract/dsd/test-Object.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Object.h"
 #include "refract/Element.h"

--- a/test/refract/dsd/test-Option.cc
+++ b/test/refract/dsd/test-Option.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Option.h"
 #include "refract/Element.h"

--- a/test/refract/dsd/test-Option.cc
+++ b/test/refract/dsd/test-Option.cc
@@ -113,13 +113,8 @@ SCENARIO("`Option` is inserted to and erased from", "[ElementData][Option]")
             WHEN("another three ElementMocks are inserted at begin two at end")
             {
                 auto mock2 = std::make_unique<test::ElementMock>();
-                auto mock2ptr = mock.get();
-
                 auto mock3 = std::make_unique<test::ElementMock>();
-                auto mock3ptr = mock.get();
-
                 auto mock4 = std::make_unique<test::ElementMock>();
-                auto mock4ptr = mock.get();
 
                 option.insert(option.begin(), std::move(mock2));
                 option.insert(option.begin(), std::move(mock3));
@@ -129,7 +124,6 @@ SCENARIO("`Option` is inserted to and erased from", "[ElementData][Option]")
                 auto mock5ptr = mock.get();
 
                 auto mock6 = std::make_unique<test::ElementMock>();
-                auto mock6ptr = mock.get();
 
                 option.insert(option.begin(), std::move(mock5));
                 option.insert(option.begin(), std::move(mock6));

--- a/test/refract/dsd/test-Ref.cc
+++ b/test/refract/dsd/test-Ref.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/Ref.h"
 

--- a/test/refract/dsd/test-Select.cc
+++ b/test/refract/dsd/test-Select.cc
@@ -115,13 +115,8 @@ SCENARIO("`Select` is inserted to and erased from", "[ElementData][Select]")
             WHEN("another three ElementMocks are inserted at begin two at end")
             {
                 auto mock2 = std::make_unique<test::ElementMock>();
-                auto mock2ptr = mock.get();
-
                 auto mock3 = std::make_unique<test::ElementMock>();
-                auto mock3ptr = mock.get();
-
                 auto mock4 = std::make_unique<test::ElementMock>();
-                auto mock4ptr = mock.get();
 
                 select.insert(select.begin(), make_element<OptionElement>(std::move(mock2)));
                 select.insert(select.begin(), make_element<OptionElement>(std::move(mock3)));
@@ -131,7 +126,6 @@ SCENARIO("`Select` is inserted to and erased from", "[ElementData][Select]")
                 auto mock5ptr = mock.get();
 
                 auto mock6 = std::make_unique<test::ElementMock>();
-                auto mock6ptr = mock.get();
 
                 select.insert(select.begin(), make_element<OptionElement>(std::move(mock5)));
                 select.insert(select.begin(), make_element<OptionElement>(std::move(mock6)));

--- a/test/refract/dsd/test-Select.cc
+++ b/test/refract/dsd/test-Select.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 #include "ElementMock.h"
 
 #include "refract/dsd/Select.h"

--- a/test/refract/dsd/test-String.cc
+++ b/test/refract/dsd/test-String.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2017 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/dsd/String.h"
 

--- a/test/refract/test-InfoElementsUtils.cc
+++ b/test/refract/test-InfoElementsUtils.cc
@@ -1,5 +1,5 @@
 #include "refract/InfoElementsUtils.h"
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 SCENARIO("Append InfoElement", "[InfoElements][append]")
 {

--- a/test/refract/test-JsonSchema.cc
+++ b/test/refract/test-JsonSchema.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2018 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/JsonSchema.h"
 #include "refract/Element.h"

--- a/test/refract/test-JsonSchema.cc
+++ b/test/refract/test-JsonSchema.cc
@@ -687,10 +687,6 @@ SCENARIO("JSON Schema serialization of ObjectElement", "[json-schema]")
         "An ObjectElement holding a SelectElement in turn holding, through OptionElements, a MemberElement and another "
         "SelectElement")
     {
-        // clang-format off
-        constexpr const char* expected = R"()";
-        // clang-format on
-
         auto el = make_element<ObjectElement>(                                                         //
             make_element<SelectElement>(                                                               //
                 make_element<OptionElement>(                                                           //

--- a/test/refract/test-JsonValue.cc
+++ b/test/refract/test-JsonValue.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2018 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/JsonValue.h"
 #include "refract/Element.h"

--- a/test/refract/test-Utils.cc
+++ b/test/refract/test-Utils.cc
@@ -7,7 +7,7 @@
 //
 
 #include <cassert>
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 #include "../Tracker.h"
 #include "refract/Element.h"
 

--- a/test/test-ApplyVisitorTest.cc
+++ b/test/test-ApplyVisitorTest.cc
@@ -1,10 +1,10 @@
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
-#include "Visitor.h"
-#include "Element.h"
-#include "Query.h"
-#include "Iterate.h"
-#include "FilterVisitor.h"
+#include "refract/Visitor.h"
+#include "refract/Element.h"
+#include "refract/Query.h"
+#include "refract/Iterate.h"
+#include "refract/FilterVisitor.h"
 
 using namespace refract;
 

--- a/test/test-ElementComparator.cc
+++ b/test/test-ElementComparator.cc
@@ -1,5 +1,5 @@
 #include "ElementComparator.h"
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 #include "refract/Element.h"
 
 using namespace drafter;

--- a/test/test-ElementFactoryTest.cc
+++ b/test/test-ElementFactoryTest.cc
@@ -1,7 +1,7 @@
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
-#include "Element.h"
-#include "TypeQueryVisitor.h"
+#include "refract/Element.h"
+#include "refract/TypeQueryVisitor.h"
 
 #include "RefractElementFactory.h"
 

--- a/test/test-ElementInfoUtils.cc
+++ b/test/test-ElementInfoUtils.cc
@@ -1,5 +1,5 @@
 #include "ElementInfoUtils.h"
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 template <typename ElementT>
 snowcrash::SourceMap<typename ElementT::ValueType> make_sourcemap(std::vector<mdp::Range>&& locations)

--- a/test/test-Serialize.cc
+++ b/test/test-Serialize.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2018 Apiary Inc. All rights reserved.
 //
 
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "Serialize.h"
 #include "refract/dsd/Number.h"

--- a/test/test-VisitorUtils.cc
+++ b/test/test-VisitorUtils.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include <catch2/catch.hpp>
 
 #include "refract/VisitorUtils.h"
 

--- a/test/utils/so/test-JsonIo.cc
+++ b/test/utils/so/test-JsonIo.cc
@@ -6,9 +6,11 @@
 //  Copyright (c) 2018 Apiary Inc. All rights reserved.
 //
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include <iostream>
+#include <iomanip>
+#include <sstream>
 #include <fstream>
 #include <array>
 #include <string>

--- a/test/utils/so/test-YamlIo.cc
+++ b/test/utils/so/test-YamlIo.cc
@@ -6,9 +6,10 @@
 //  Copyright (c) 2018 Apiary Inc. All rights reserved.
 //
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include <iostream>
+#include <iomanip>
 #include <fstream>
 #include <array>
 #include <string>

--- a/test/utils/so/test-YamlIo.cc
+++ b/test/utils/so/test-YamlIo.cc
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <fstream>
 #include <array>
 #include <string>

--- a/test/utils/test-Utf8.cc
+++ b/test/utils/test-Utf8.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2018 Apiary Inc. All rights reserved.
 //
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "utils/Utf8.h"
 

--- a/test/utils/test-Variant.cc
+++ b/test/utils/test-Variant.cc
@@ -6,7 +6,7 @@
 //  Copyright (c) 2018 Apiary Inc. All rights reserved.
 //
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include "../Tracker.h"
 #include <string>


### PR DESCRIPTION
Adds support for CMake. 

The following should work across platforms:
```
git clone --recursive https://github.com/apiaryio/drafter tjanc/cmake-targets
cd drafter
mkdir build
cd build
cmake .. -DCMAKE_INSTALL_PREFIX=dir/you/install/to
make
make test
make install
```
`CMAKE_INSTALL_PREFIX` defaults to your root when not set.
The resulting install should look like this:
```
dir/you/install/to
├── bin
│   └── drafter
├── include
│   └── drafter.h
└── lib
    ├── cmake
    │   └── drafter
    │       ├── drafter-config.cmake
    │       ├── drafter-config-version.cmake
    │       ├── drafter-targets.cmake
    │       └── drafter-targets-noconfig.cmake
    ├── libdrafter.a
    ├── libdrafter-pic.a
    └── libdrafter.so

```

A few notes:
- da7df98, 59782dd: Catch2 exports its headers from the `single_header` directory, which was not what we were using; I fixed our GYP config to match Catch2's CMake-exported include directories and updated headers in our tests
- 54c2f33: some warnings popped up after fixing headers, fixed those
- currently, the location of drafter's CMake config files are in `src` and `test`; that's not ideal, but until libdrafter has its own directory to live in it's the best we can do
- updating CI to use cmake is not in scope of this PR
- `CMakeLists.txt` in root just includes subprojects and ensures invocations of `find_package` in subprojects are not resolved into system paths