### PR TITLE
Generalized clang-format config & fixed some style issues

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,9 +1,10 @@
+---
 Language:        Cpp
-# BasedOnStyle:  WebKit
 AccessModifierOffset: -4
-AlignAfterOpenBracket: false
+AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false
-AlignEscapedNewlinesLeft: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
 AlignOperands:   false
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
@@ -13,27 +14,39 @@ AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
+BraceWrapping:   
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      true
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: All
 BreakBeforeBraces: Custom
-BraceWrapping:
-  AfterClass: true
-  AfterControlStatement: false
-  AfterEnum: true
-  AfterFunction: true
-  AfterNamespace: true
-  AfterStruct: false
-  AfterUnion: true
-  BeforeCatch: false
-  BeforeElse: false
-  IndentBraces: false
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: false
-BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
 ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
@@ -41,25 +54,55 @@ Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+FixNamespaceComments: false
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: true
+IndentPPDirectives: None
 IndentWidth:     4
 IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false
@@ -70,5 +113,5 @@ SpacesInSquareBrackets: false
 Standard:        Cpp03
 TabWidth:        4
 UseTab:          Never
-SortIncludes: false
+...
 

--- a/src/drafter.h
+++ b/src/drafter.h
@@ -61,7 +61,11 @@ typedef refract::IElement drafter_result;
 #endif
 
 /* Serialization formats, currently only YAML or JSON */
-typedef enum { DRAFTER_SERIALIZE_YAML = 0, DRAFTER_SERIALIZE_JSON } drafter_format;
+typedef enum
+{
+    DRAFTER_SERIALIZE_YAML = 0,
+    DRAFTER_SERIALIZE_JSON
+} drafter_format;
 
 /* Parsing options
  * - requireBlueprintName : API has to have a name, if not it is a parsing error
@@ -79,7 +83,8 @@ typedef struct {
     drafter_format format;
 } drafter_serialize_options;
 
-typedef enum {
+typedef enum
+{
     DRAFTER_OK = 0,
     DRAFTER_EUNKNOWN = -1,
     DRAFTER_EINVALID_INPUT = -2,

--- a/src/refract/ElementIfc.h
+++ b/src/refract/ElementIfc.h
@@ -26,7 +26,8 @@ namespace refract
         ///
         /// Composable clone flags
         ///
-        typedef enum {
+        typedef enum
+        {
             cMeta = 0x01,                                   //< Clone meta
             cAttributes = 0x02,                             //< Clone attributes
             cValue = 0x04,                                  //< Clone value

--- a/src/refract/ExpandVisitor.cc
+++ b/src/refract/ExpandVisitor.cc
@@ -108,7 +108,7 @@ namespace refract
 
             // FIXME: add check against recursive inheritance
             // walk recursive in registry and expand inheritance tree
-            for (const IElement *parent = registry.find(en); parent && !isReserved(en);
+            for (const IElement* parent = registry.find(en); parent && !isReserved(en);
                  en = parent->element(), parent = registry.find(en)) {
 
                 inheritance.push(clone(*parent, ((IElement::cAll ^ IElement::cElement) | IElement::cNoMetaId)));

--- a/src/refract/TypeQueryVisitor.h
+++ b/src/refract/TypeQueryVisitor.h
@@ -18,7 +18,8 @@ namespace refract
     {
 
     public:
-        typedef enum {
+        typedef enum
+        {
             Null,
             Holder,
 

--- a/src/refract/dsd/Extend.cc
+++ b/src/refract/dsd/Extend.cc
@@ -99,7 +99,6 @@ namespace
                             assert(mergeKey);
 
                             return std::find_if(value.get().begin(), value.get().end(), [mergeKey](const auto& e) {
-
                                 if (auto valueMember = TypeQueryVisitor::as<const MemberElement>(e.get())) {
                                     auto valueKey = TypeQueryVisitor::as<const StringElement>(valueMember->get().key());
                                     assert(valueKey);

--- a/src/utils/Variant.h
+++ b/src/utils/Variant.h
@@ -143,7 +143,7 @@ namespace drafter
             }
 
             template <size_t I>
-            const auto& get() const &
+            const auto& get() const&
             {
                 static_assert(I >= 0 && I < sizeof...(Variants), "invalid index");
                 using Which = typename type_at<I, Variants...>::type;

--- a/tools/clang-format-check.sh
+++ b/tools/clang-format-check.sh
@@ -7,6 +7,4 @@ function report_error () {
   exit 1;
 }
 
-clang-format --version | cut -d ' '  -f 3 | grep -q "^5\." || (echo "Requires clang-format version 5" && exit 1)
-
 clang-format -style=file -output-replacements-xml $(git ls-files | grep -e '\.cc$\|\.h$' | grep -v 'ext/boost') | awk '/\<replacement /{exit 1}' || report_error

--- a/tools/clang-format-fix.sh
+++ b/tools/clang-format-fix.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-clang-format --version | cut -d ' '  -f 3 | grep -q "^5\." || (echo "Requires clang-format version 5" && exit 1)
-
 clang-format -style=file -i $(git ls-files | grep -e '\.cc$\|\.h$' | grep -v 'ext/boost')


### PR DESCRIPTION
Updated our `.clang-format` to also list configuration options for newer clang-format versions; allows same results across different versions of clang-format.

This was achieved by taking a recent release of clang-format and letting it generate the new configuration from the old one.

```
clang-format --style=file -dump-config > .clang-format-new
```

The only modification made afterwards was setting `FixNamespaceComments: false`, which matches the behaviour of older versions.