### PR TITLE
Fix untested error.apib fixture

### DIFF
--- a/test/fixtures/parse-result/error.json
+++ b/test/fixtures/parse-result/error.json
@@ -30,10 +30,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 4
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
                       "content": 24
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 4
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
                       "content": 1
                     }
                   ]

--- a/test/test-RefractParseResultTest.cc
+++ b/test/test-RefractParseResultTest.cc
@@ -13,6 +13,7 @@ using namespace draftertest;
 TEST_REFRACT("parse-result", "simple");
 TEST_REFRACT("parse-result", "warning");
 TEST_REFRACT("parse-result", "warnings");
+TEST_REFRACT("parse-result", "error");
 TEST_REFRACT("parse-result", "error-warning");
 TEST_REFRACT("parse-result", "blueprint");
 TEST_REFRACT("parse-result", "mson");


### PR DESCRIPTION
The fixture `error.apib` was untested and incorrect which this PR resolves.