### PR TITLE
Update Aruba

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@
 source 'https://rubygems.org'
 
 gem 'cucumber'
-gem 'aruba', '0.7.4'
+gem 'aruba'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
-# 
-# Gems as needed for thesting snowcrash CLI with cucumber
+#
+# Gems needed for integration testing Drafter CLI with cucumber
 #
 
 source 'https://rubygems.org'
 
 gem 'cucumber'
-gem 'aruba', :tag => 'v0.7.4', :git => 'http://github.com/cucumber/aruba.git'
+gem 'aruba', '0.7.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aruba (0.7.4)
-      childprocess (>= 0.3.6)
-      cucumber (>= 1.1.1)
-      rspec-expectations (>= 2.7.0)
+    aruba (0.14.9)
+      childprocess (>= 0.6.3, < 1.1.0)
+      contracts (~> 0.9)
+      cucumber (>= 1.3.19)
+      ffi (~> 1.9)
+      rspec-expectations (>= 2.99)
+      thor (~> 0.19)
     backports (3.12.0)
     builder (3.2.3)
     childprocess (1.0.1)
       rake (< 13.0)
+    contracts (0.16.0)
     cucumber (3.1.2)
       builder (>= 2.1.2)
       cucumber-core (~> 3.2.0)
@@ -26,6 +30,8 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
+    ffi (1.10.0)
+    ffi (1.10.0-x86-mingw32)
     gherkin (5.1.0)
     multi_json (1.13.1)
     multi_test (0.1.2)
@@ -34,13 +40,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    thor (0.20.3)
 
 PLATFORMS
   ruby
   x86-mingw32
 
 DEPENDENCIES
-  aruba (= 0.7.4)
+  aruba
   cucumber
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,44 +1,46 @@
-GIT
-  remote: http://github.com/cucumber/aruba.git
-  revision: 5ae1ba967deaa904b275197d7f1236e783d72b65
-  specs:
-    aruba (0.6.2)
-      childprocess (>= 0.3.6)
-      cucumber (>= 1.1.1)
-      rspec-expectations (>= 2.7.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    builder (3.2.2)
-    childprocess (0.5.3)
-      ffi (~> 1.0, >= 1.0.11)
-    cucumber (1.3.19)
+    aruba (0.7.4)
+      childprocess (>= 0.3.6)
+      cucumber (>= 1.1.1)
+      rspec-expectations (>= 2.7.0)
+    backports (3.12.0)
+    builder (3.2.3)
+    childprocess (1.0.1)
+      rake (< 13.0)
+    cucumber (3.1.2)
       builder (>= 2.1.2)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
-    diff-lcs (1.2.5)
-    ffi (1.9.6)
-    ffi (1.9.6-x86-mingw32)
-    gherkin (2.12.2)
-      multi_json (~> 1.3)
-    gherkin (2.12.2-x86-mingw32)
-      multi_json (~> 1.3)
-    multi_json (1.11.0)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
+    diff-lcs (1.3)
+    gherkin (5.1.0)
+    multi_json (1.13.1)
     multi_test (0.1.2)
-    rspec-expectations (3.2.0)
+    rake (12.3.2)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-support (3.2.2)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
 
 PLATFORMS
   ruby
   x86-mingw32
 
 DEPENDENCIES
-  aruba!
+  aruba (= 0.7.4)
   cucumber
 
 BUNDLED WITH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,24 +2,25 @@ image:
   - Visual Studio 2015
   - Visual Studio 2017
 
+cache:
+  - vendor/bundle
+
 environment:
   matrix:
-    - VS_VERSION: 
+    - VS_VERSION:
+      RUBY_VERSION: 25-x64
     - VS_VERSION: debug
+      RUBY_VERSION: 25-x64
 
 install:
-  - set PATH=C:\Ruby25\bin;%PATH%
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle config --local path vendor/bundle
+  - bundle install
 
 build_script:
-  - curl -O https://curl.haxx.se/ca/cacert.pem
-  - SET SSL_CERT_FILE=%cd%\cacert.pem
-
   - git submodule update --init --recursive
-  - bundle install --path bundle
-
   - vcbuild.bat %VS_VERSION%
 
 test_script:
-
   - vcbuild.bat %VS_VERSION% test
   - vcbuild.bat %VS_VERSION% inttest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,8 @@ install:
 build_script:
   - curl -O https://curl.haxx.se/ca/cacert.pem
   - SET SSL_CERT_FILE=%cd%\cacert.pem
-  
+
   - git submodule update --init --recursive
-  - rm Gemfile.lock
   - bundle install --path bundle
 
   - vcbuild.bat %VS_VERSION%

--- a/features/step_definitions/file_content_step.rb
+++ b/features/step_definitions/file_content_step.rb
@@ -1,11 +1,11 @@
 Then /^the output should contain the content of file "(.*)"$/ do |filename|
   expected = nil
-  in_current_dir do
-    expected = File.read(filename)
 
-    if ENV['GENERATE'] == '1'
-      File.write(filename, all_output)
-    end
+  path = File.join(aruba.config.fixtures_directories[0], filename)
+  expected = File.read(path)
+
+  if ENV['GENERATE'] == '1'
+    File.write(path, all_output)
   end
 
   assert_partial_output(expected, all_output)

--- a/features/support/aruba_config.rb
+++ b/features/support/aruba_config.rb
@@ -1,0 +1,4 @@
+Aruba.configure do |config|
+  bin =  File.join(Dir.pwd, 'bin')
+  ENV['PATH'] = "#{bin}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,6 @@
 require 'aruba/cucumber'
 
 Before do
-  @dirs << "../../features/fixtures"
-  
-  ENV['PATH'] = "#{ENV['PWD']}/src#{File::PATH_SEPARATOR}#{ENV['PATH']}"  
+  copy File.join(aruba.config.fixtures_path_prefix, 'blueprint.apib'), 'blueprint.apib'
+  copy File.join(aruba.config.fixtures_path_prefix, 'invalid_blueprint.apib'), 'invalid_blueprint.apib'
 end

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -139,51 +139,7 @@ if defined inttest goto run-integration-test
 goto success
 
 :run-integration-test
-copy %work_dir%\build\%config%\drafter.exe .
-if "%config%"=="Debug" (
-SET "Replacement=      ENV['PATH'] = "../../build/Debug""
-goto :run-cucumber
-)
-SET "Replacement=      ENV['PATH'] = "../../build/Release""
-goto :run-cucumber
-
-:run-cucumber
-SET "file=features\support\env-win.rb"
-if exist "%file%" goto env-exist
-SETLOCAL ENABLEDELAYEDEXPANSION
-SET "line=require 'aruba/cucumber'"
-ECHO !line! >"%file%"
-SET "line=require 'rbconfig'"
-ECHO !line! >>"%file%"
-SET "line=Before do"
-ECHO !line! >>"%file%"
-SET "line=  @dirs << "../../features/fixtures""
-ECHO !line! >>"%file%"
-SET "line=  case RbConfig::CONFIG['host_os']"
-ECHO !line! >>"%file%"
-SET "line=    when /mswin|msys|mingw|cygwin|bccwin|wince|emc/"
-ECHO !line! >>"%file%"
-ECHO !Replacement! >>"%file%"
-SET "line=end"
-ECHO !line! >>"%file%"
-SET "line=end"
-ECHO !line! >>"%file%"
-ENDLOCAL
-
-bundle exec cucumber
-goto success
-
-:env-exist
-SET /a Line#ToSearch=7
-(FOR /f "tokens=1*delims=:" %%a IN ('findstr /n "^" "%file%"') DO (
-    SET "Line=%%b"
-    IF %%a equ %Line#ToSearch% SET "Line=%Replacement%"
-    SETLOCAL ENABLEDELAYEDEXPANSION
-    ECHO(!Line!)
-    ENDLOCAL
-)>"%file%.new"
-MOVE "%file%.new" "%file%" >nul
-
+copy %work_dir%\build\%config%\drafter.exe bin\drafter
 bundle exec cucumber
 goto success
 


### PR DESCRIPTION
I discovered some problems with the current setup, I'll list them below:

- We depend on 0.7.4 aruba in Gemfile (Gemfile.lock locks to 0.6.2). Bundler is in inconsistent state and simple "bundle install" will cause file to be updated removing `ffi`
- AppVeyor config was deleting Gemfile.lock upfront so it was ignored completely to resolve the Ruby dependencies on windows CI

The way that the windows build was setup is a little tricky, we're generating code (`features/support/win-env.rb`) during vcbuild.bat, and we're replacing existing paths in other code.

To clean up the current state, I've attempted to update to latest version of Aruba so we're not pinned to a version that's unsupported and many years old. This update brings breaking changes, `@dirs` is removed, `in_current_dir` is deprecated. I've updated code to work on newer Aruba. I've then begin to align how windows aruba in an attempt to remove the "generating ruby code" and "altering existing ruby code" behaviours.

This PR is not complete, but it is working on Linux and macOS.
