### PR TITLE
Go back to c++11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * generated JSON Schema makes use of the `enum` validation instead of the more syntax heavy `anyOf` for each enumerations EnumElement entry typing a single value
 
+* transitioned from C++14 back to C++11 to support older compilers
+
 ## 4.0.0-pre.2
 
 ### Bug Fixes

--- a/common.gypi
+++ b/common.gypi
@@ -104,7 +104,7 @@
       [ 'OS in "linux freebsd openbsd solaris android"', {
         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', '-Wno-comment' ],
         'cflags_cc!': [ '-fno-rtti', '-fno-exceptions' ],
-        'cflags_cc': [ '-std=c++14' ],
+        'cflags_cc': [ '-std=c++11' ],
         'ldflags': [ '-rdynamic' ],
         'target_conditions': [
           ['_type=="static_library"', {
@@ -138,7 +138,7 @@
           'OTHER_CFLAGS': [
             '-fno-strict-aliasing',
           ],
-          'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',
+          'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
           'CLANG_CXX_LIBRARY': 'libc++',
           'WARNING_CFLAGS': [
             '-Wall',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,48 +51,26 @@ set(DRAFTER_SOURCES
     )
 
 set(DRAFTER_COMPILE_FEATURES
-    cxx_alias_templates
     cxx_alignas
     cxx_alignof
-    cxx_attribute_deprecated
     cxx_auto_type
     cxx_constexpr
-    cxx_contextual_conversions
     cxx_decltype
-    cxx_decltype_auto
     cxx_defaulted_functions
     cxx_defaulted_move_initializers
     cxx_delegating_constructors
     cxx_deleted_functions
-    cxx_digit_separators
-    cxx_explicit_conversions
     cxx_final
-    cxx_generalized_initializers
-    cxx_generic_lambdas
-    cxx_inheriting_constructors
     cxx_lambdas
-    cxx_lambda_init_captures
     cxx_noexcept
-    cxx_nonstatic_member_init
     cxx_nullptr
     cxx_override
     cxx_range_for
     cxx_raw_string_literals
-    cxx_return_type_deduction
     cxx_rvalue_references
-    cxx_sizeof_member
     cxx_static_assert
-    cxx_strong_enums
-    cxx_thread_local
     cxx_trailing_return_types
-    cxx_unicode_literals
-    cxx_uniform_initialization
-    cxx_unrestricted_unions
-    cxx_user_literals
-    cxx_variable_templates
-    cxx_variadic_macros
     cxx_variadic_templates
-    cxx_template_template_parameters
     )
 
 # libdrafter

--- a/src/ElementData.h
+++ b/src/ElementData.h
@@ -66,9 +66,10 @@ namespace drafter
         ElementInfo(const ElementInfo& other)
         {
             sourceMap = other.sourceMap;
-            std::transform(other.value.begin(), other.value.end(), std::back_inserter(value), [](const auto& element) {
-                return element->clone();
-            });
+            std::transform(other.value.begin(),
+                other.value.end(),
+                std::back_inserter(value),
+                [](const std::unique_ptr<refract::IElement>& element) { return element->clone(); });
         }
 
         ElementInfo(ElementInfo&&) = default;

--- a/src/ElementInfoUtils.h
+++ b/src/ElementInfoUtils.h
@@ -22,7 +22,7 @@ namespace drafter
         using Info = ElementInfo<T>;
         using Container = std::deque<Info>;
 
-        ElementInfo<T> operator()(Container container) const
+        Info operator()(Container container) const
         {
             if (container.empty()) {
                 return ElementInfo<T>();

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -148,8 +148,8 @@ std::unique_ptr<IElement> drafter::DataStructureToRefract(
         msonElement = std::move(msonExpanded);
     }
 
-    return msonElement ?                                                                             //
-        make_unique<HolderElement>(SerializeKey::DataStructure, dsd::Holder(std::move(msonElement))) //
+    return msonElement ?                                                                                      //
+        refract::make_unique<HolderElement>(SerializeKey::DataStructure, dsd::Holder(std::move(msonElement))) //
         :
         nullptr;
 }
@@ -383,12 +383,12 @@ std::unique_ptr<IElement> PayloadToRefract( //
     // Push dataStructure
     if (context.options.expandMSON) {
         if (payloadAttributeExpanded) {
-            content.push_back(make_unique<HolderElement>(
+            content.push_back(refract::make_unique<HolderElement>(
                 SerializeKey::DataStructure, dsd::Holder(std::move(payloadAttributeExpanded))));
         }
     } else {
         if (payloadAttributeElement) {
-            content.push_back(make_unique<HolderElement>(
+            content.push_back(refract::make_unique<HolderElement>(
                 SerializeKey::DataStructure, dsd::Holder(std::move(payloadAttributeElement))));
         }
     }

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -167,7 +167,7 @@ std::unique_ptr<IElement> MetadataToRefract(const NodeInfo<snowcrash::Metadata>&
 
     AttachSourceMap(*element, metadata);
 
-    return element;
+    return std::move(element);
 }
 
 std::unique_ptr<IElement> CopyToRefract(const NodeInfo<std::string>& copy)
@@ -200,7 +200,7 @@ std::unique_ptr<IElement> ParameterValuesToRefract(
     element->attributes().set(SerializeKey::Enumerations,
         CollectionToRefract<ArrayElement>(MAKE_NODE_INFO(parameter, values), context, LiteralToRefract));
 
-    return element;
+    return std::move(element);
 }
 
 // NOTE: We removed type specific templates from here in https://github.com/apiaryio/drafter/pull/447
@@ -218,7 +218,7 @@ std::unique_ptr<IElement> ExtractParameter(const NodeInfo<snowcrash::Parameter>&
                 SerializeKey::Default, PrimitiveToRefract(MAKE_NODE_INFO(parameter, defaultValue)));
         }
 
-        return element;
+        return std::move(element);
     } else {
         return ParameterValuesToRefract(parameter, context);
     }
@@ -251,7 +251,7 @@ std::unique_ptr<IElement> ParameterToRefract(
         element->attributes().set(SerializeKey::TypeAttributes, make_element<ArrayElement>(from_primitive(use)));
     }
 
-    return element;
+    return std::move(element);
 }
 
 std::unique_ptr<IElement> ParametersToRefract(
@@ -266,7 +266,7 @@ std::unique_ptr<IElement> HeaderToRefract(const NodeInfo<snowcrash::Header>& hea
 
     AttachSourceMap(*element, header);
 
-    return element;
+    return std::move(element);
 }
 
 std::unique_ptr<IElement> AssetToRefract(
@@ -320,7 +320,7 @@ std::unique_ptr<IElement> PayloadToRefract( //
 
     // If no payload, return immediately
     if (payload.isNull()) {
-        return result;
+        return std::move(result);
     }
 
     if (!payload.node->parameters.empty()) {
@@ -413,7 +413,7 @@ std::unique_ptr<IElement> PayloadToRefract( //
 
     RemoveEmptyElements(content);
 
-    return result;
+    return std::move(result);
 }
 
 std::unique_ptr<ArrayElement> TransactionToRefract(const NodeInfo<snowcrash::TransactionExample>& transaction,
@@ -622,7 +622,7 @@ std::unique_ptr<IElement> drafter::BlueprintToRefract(
 
     RemoveEmptyElements(content);
 
-    return ast;
+    return std::move(ast);
 }
 
 std::unique_ptr<IElement> drafter::AnnotationToRefract(
@@ -638,5 +638,5 @@ std::unique_ptr<IElement> drafter::AnnotationToRefract(
     element->attributes().set(
         SerializeKey::SourceMap, SourceMapToRefractWithColumnLineInfo(annotation.location, context));
 
-    return element;
+    return std::move(element);
 }

--- a/src/RefractSourceMap.cc
+++ b/src/RefractSourceMap.cc
@@ -38,7 +38,7 @@ std::unique_ptr<IElement> drafter::SourceMapToRefractWithColumnLineInfo(
         sourceMap.begin(),
         sourceMap.end(),
         std::back_inserter(sourceMapElement->get()),
-        [&context](auto& sourceMap) {
+        [&context](const mdp::CharactersRange& sourceMap) {
             auto position = GetLineFromMap(context.GetNewLinesIndex(), sourceMap);
 
             auto location = make_element<NumberElement>(sourceMap.location);

--- a/src/RefractSourceMap.h
+++ b/src/RefractSourceMap.h
@@ -29,7 +29,7 @@ namespace drafter
     }
 
     template <typename T>
-    auto PrimitiveToRefract(const NodeInfo<T>& primitive)
+    std::unique_ptr<refract::IElement> PrimitiveToRefract(const NodeInfo<T>& primitive)
     {
         auto element = refract::from_primitive(*primitive.node);
         AttachSourceMap(*element, primitive);

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -30,7 +30,7 @@ namespace helper
 
         AnnotationToRefract(const std::string& key, ConversionContext& context) : key(key), context(context) {}
 
-        auto operator()(snowcrash::SourceAnnotation& annotation)
+        std::unique_ptr<refract::IElement> operator()(snowcrash::SourceAnnotation& annotation)
         {
             return drafter::AnnotationToRefract(annotation, key, context);
         }

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -40,11 +40,12 @@ namespace helper
 std::unique_ptr<IElement> drafter::WrapRefract(
     snowcrash::ParseResult<snowcrash::Blueprint>& blueprint, ConversionContext& context)
 {
-    snowcrash::Error error;
-    std::unique_ptr<IElement> blueprintRefract = nullptr;
-
     // auto parseResult = make_empty<ArrayElement>();
     auto parseResult = make_element<ArrayElement>(); // XXX @tjanc@ review
+    snowcrash::Error error;
+
+    std::unique_ptr<IElement> blueprintRefract = nullptr;
+
     parseResult->element(SerializeKey::ParseResult);
 
     if (blueprint.report.error.code == snowcrash::Error::OK) {
@@ -86,5 +87,5 @@ std::unique_ptr<IElement> drafter::WrapRefract(
             helper::AnnotationToRefract(SerializeKey::Warning, context));
     }
 
-    return parseResult;
+    return std::move(parseResult);
 }

--- a/src/refract/Element.h
+++ b/src/refract/Element.h
@@ -40,7 +40,7 @@ namespace refract
         bool hasValue_ = false; //< Whether DSD is set
         DataType data_ = {};    //< DSD
 
-        std::string name_ = DataType::name; //< Name of the Element
+        std::string name_ = { DataType::name }; //< Name of the Element
 
     public:
         using ValueType = DataType; //< DSD type definition

--- a/src/refract/Element.h
+++ b/src/refract/Element.h
@@ -10,14 +10,13 @@
 #define REFRACT_ELEMENT_H
 
 #include <string>
-
 #include "dsd/ElementData.h"
 #include "dsd/Traits.h"
-
 #include "ElementIfc.h"
 #include "InfoElements.h"
 #include "Visitor.h"
 #include "Utils.h"
+#include <memory>
 
 namespace refract
 {

--- a/src/refract/Element.h
+++ b/src/refract/Element.h
@@ -21,6 +21,12 @@
 
 namespace refract
 {
+    template <typename T, typename... Args>
+    std::unique_ptr<T> make_unique(Args&&... args)
+    {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
+
     ///
     /// Refract Element definition
     ///
@@ -126,7 +132,7 @@ namespace refract
 
         std::unique_ptr<IElement> clone(int flags = IElement::cAll) const override
         {
-            auto el = std::make_unique<Element>();
+            auto el = make_unique<Element>();
 
             if (flags & IElement::cElement)
                 el->element(name_);
@@ -156,9 +162,9 @@ namespace refract
     /// @remark an empty Element has an empty data structure definition (DSD)
     ///
     template <typename ElementT>
-    auto make_empty()
+    std::unique_ptr<ElementT> make_empty()
     {
-        return std::make_unique<ElementT>();
+        return make_unique<ElementT>();
     }
 
     ///
@@ -166,20 +172,20 @@ namespace refract
     /// of its data structure definition (DSD)
     ///
     template <typename ElementT, typename... Args>
-    auto make_element(Args&&... args)
+    std::unique_ptr<ElementT> make_element(Args&&... args)
     {
         using DataT = typename ElementT::ValueType;
-        return std::make_unique<ElementT>(DataT{ std::forward<Args>(args)... });
+        return make_unique<ElementT>(DataT{ std::forward<Args>(args)... });
     }
 
     template <typename Primitive, typename DataT = typename dsd::data_of<Primitive>::type>
-    auto from_primitive(const Primitive& p)
+    std::unique_ptr<Element<DataT> > from_primitive(const Primitive& p)
     {
         return make_element<Element<DataT> >(p);
     }
 
     template <typename ElementT, typename ContentVisitor, typename... Args>
-    auto generate_element(ContentVisitor visit, Args&&... visitorArgs)
+    std::unique_ptr<ElementT> generate_element(ContentVisitor visit, Args&&... visitorArgs)
     {
         auto element = make_element<ElementT>();
         visit(element->get(), std::forward<Args>(visitorArgs)...);

--- a/src/refract/ElementSize.cc
+++ b/src/refract/ElementSize.cc
@@ -30,7 +30,8 @@ namespace
     template <typename It>
     cardinal sizeOfMult(It begin, It end, bool inheritsFixed) noexcept
     {
-        return std::accumulate(begin, end, cardinal{ 1 }, [inheritsFixed](const auto& a, const auto& b) { //
+        using ElementPtr = decltype(*begin);
+        return std::accumulate(begin, end, cardinal{ 1 }, [inheritsFixed](cardinal a, const ElementPtr& b) { //
             return a * sizeOf(*b, inheritsFixed);
         });
     }
@@ -38,7 +39,8 @@ namespace
     template <typename It>
     cardinal sizeOfSum(It begin, It end, bool inheritsFixed) noexcept
     {
-        return std::accumulate(begin, end, cardinal::empty(), [inheritsFixed](const auto& a, const auto& b) { //
+        using ElementPtr = decltype(*begin);
+        return std::accumulate(begin, end, cardinal::empty(), [inheritsFixed](cardinal a, const ElementPtr& b) { //
             return a + sizeOf(*b, inheritsFixed);
         });
     }
@@ -47,13 +49,21 @@ namespace
     {
         return hasNullableTypeAttr(e) ? (s + cardinal{ 1 }) : s;
     }
+
+    struct SizeOfVisitor {
+        bool inheritsFixed;
+
+        template <typename ElementT>
+        cardinal operator()(const ElementT& el) const
+        {
+            return sizeOf(el, inheritsFixed);
+        }
+    };
 }
 
 cardinal refract::sizeOf(const IElement& e, bool inheritsFixed)
 {
-    return refract::visit(e, [inheritsFixed](const auto& el) { //
-        return sizeOf(el, inheritsFixed);
-    });
+    return refract::visit(e, SizeOfVisitor{ inheritsFixed });
 }
 
 cardinal refract::sizeOf(const ObjectElement& e, bool inheritsFixed)

--- a/src/refract/ElementUtils.cc
+++ b/src/refract/ElementUtils.cc
@@ -19,12 +19,21 @@
 
 using namespace refract;
 
+namespace
+{
+    struct InheritsFixedVisitor {
+        template <typename ElementT>
+        bool operator()(const ElementT& el) const noexcept
+        {
+            return inheritsFixed(el);
+        }
+    };
+}
+
 bool refract::inheritsFixed(const IElement& e)
 {
     // otherwise interpret based on specific Element
-    return refract::visit(e, [](const auto& el) { //
-        return inheritsFixed(el);
-    });
+    return refract::visit(e, InheritsFixedVisitor{});
 }
 
 bool refract::inheritsFixed(const ObjectElement& e)
@@ -97,7 +106,7 @@ bool refract::hasTypeAttr(const IElement& e, const char* name)
         if (const auto* typeAttrs = get<const ArrayElement>(typeAttrIt->second.get())) {
             const auto b = typeAttrs->get().begin();
             const auto e = typeAttrs->get().end();
-            return e != std::find_if(b, e, [&name](const auto& el) { //
+            return e != std::find_if(b, e, [&name](const std::unique_ptr<IElement>& el) { //
                 const auto* entry = get<const StringElement>(el.get());
                 return entry && !entry->empty() && (entry->get().get() == name);
             });
@@ -198,7 +207,7 @@ void refract::setTypeAttribute(IElement& e, const std::string& typeAttribute)
         if (auto* typeAttrs = get<ArrayElement>(typeAttrIt->second.get())) {
             const auto b = typeAttrs->get().begin();
             const auto e = typeAttrs->get().end();
-            if (e == std::find_if(b, e, [&typeAttribute](const auto& el) { //
+            if (e == std::find_if(b, e, [&typeAttribute](const std::unique_ptr<IElement>& el) { //
                     const auto* entry = get<const StringElement>(el.get());
                     return entry && !entry->empty() && (entry->get().get() == typeAttribute);
                 })) {

--- a/src/refract/ExpandVisitor.cc
+++ b/src/refract/ExpandVisitor.cc
@@ -94,9 +94,10 @@ namespace refract
             T operator()(const T& value, Functor& expand)
             {
                 T members;
-                std::transform(value.begin(), value.end(), std::back_inserter(members), [&expand](const auto& el) {
-                    return expand(el.get());
-                });
+                std::transform(
+                    value.begin(), value.end(), std::back_inserter(members), [&expand](const typename T::value_type& el) {
+                        return expand(el.get());
+                    });
                 return std::move(members);
             }
         };
@@ -164,7 +165,7 @@ namespace refract
         template <typename V>
         V ExpandValue(const V& v)
         {
-            auto expandOrClone = [this](const auto& el) { return this->ExpandOrClone(el); };
+            auto expandOrClone = [this](const IElement* el) { return this->ExpandOrClone(el); };
 
             return ExpandValueImpl<V>()(v, expandOrClone);
         }

--- a/src/refract/InfoElements.cc
+++ b/src/refract/InfoElements.cc
@@ -72,25 +72,27 @@ namespace refract
     InfoElements::InfoElements(const InfoElements& other) : elements()
     {
         elements.reserve(other.size());
-        std::transform(other.begin(), other.end(), std::back_inserter(elements), [](const auto& el) {
-            assert(el.second);
-            return std::make_pair(el.first, refract::clone(*el.second));
-        });
+        std::transform(
+            other.begin(), other.end(), std::back_inserter(elements), [](const InfoElements::value_type& el) {
+                assert(el.second);
+                return std::make_pair(el.first, refract::clone(*el.second));
+            });
     }
 
     void InfoElements::clone(const InfoElements& other)
     {
-        std::transform(other.begin(), other.end(), std::back_inserter(elements), [](const auto& el) {
-            assert(el.second);
-            return std::make_pair(el.first, refract::clone(*el.second));
-        });
+        std::transform(
+            other.begin(), other.end(), std::back_inserter(elements), [](const InfoElements::value_type& el) {
+                assert(el.second);
+                return std::make_pair(el.first, refract::clone(*el.second));
+            });
     }
 
     void InfoElements::erase(const std::string& key)
     {
-        elements.erase(
-            std::remove_if(
-                elements.begin(), elements.end(), [&key](const auto& keyValue) { return keyValue.first == key; }),
+        elements.erase(std::remove_if(elements.begin(),
+                           elements.end(),
+                           [&key](const InfoElements::value_type& keyValue) { return keyValue.first == key; }),
             elements.end());
     }
 
@@ -131,13 +133,15 @@ namespace refract
 
     InfoElements::const_iterator InfoElements::find(const std::string& name) const
     {
-        return std::find_if(
-            elements.begin(), elements.end(), [&name](const auto& keyValue) { return keyValue.first == name; });
+        return std::find_if(elements.begin(), elements.end(), [&name](const InfoElements::value_type& keyValue) {
+            return keyValue.first == name;
+        });
     }
 
     InfoElements::iterator InfoElements::find(const std::string& name)
     {
-        return std::find_if(
-            elements.begin(), elements.end(), [&name](const auto& keyValue) { return keyValue.first == name; });
+        return std::find_if(elements.begin(), elements.end(), [&name](const InfoElements::value_type& keyValue) {
+            return keyValue.first == name;
+        });
     }
 }

--- a/src/refract/InfoElementsUtils.h
+++ b/src/refract/InfoElementsUtils.h
@@ -62,7 +62,7 @@ namespace refract
             }
 
             const auto e = arr->get().end();
-            if (e == std::find_if(arr->get().begin(), e, [&value](const auto& attr) {
+            if (e == std::find_if(arr->get().begin(), e, [&value](const std::unique_ptr<IElement>& attr) {
                     if (const auto& str = TypeQueryVisitor::as<Element<DSDType> >(attr.get())) {
                         if (str->get() == value.get())
                             return true;

--- a/src/refract/JsonSchema.cc
+++ b/src/refract/JsonSchema.cc
@@ -207,7 +207,8 @@ namespace
                 return R"(^(?![\s\S]))";
             } else {
                 std::regex sanitizer{ R"([-[\]{}()*+?.,\^$|#\s])" };
-                return std::regex_replace(e.get().get(), sanitizer, R"(\$&)");
+                const std::string replacement{R"(\$&)"};
+                return std::regex_replace(e.get().get(), sanitizer, replacement);
             }
         }
         // clang-format on

--- a/src/refract/JsonSchema.cc
+++ b/src/refract/JsonSchema.cc
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <bitset>
 #include <cassert>
-#include <regex>
 
 using namespace refract;
 using namespace schema;
@@ -206,9 +205,64 @@ namespace
             if(e.empty()) {
                 return R"(^(?![\s\S]))";
             } else {
-                std::regex sanitizer{ R"([-[\]{}()*+?.,\^$|#\s])" };
-                const std::string replacement{R"(\$&)"};
-                return std::regex_replace(e.get().get(), sanitizer, replacement);
+
+                // TODO gcc4.8 support forced us to replace std::regex with the
+                //   naive loop-switch implementation that follows
+                // std::regex sanitizer{ R"([-[\]{}()*+?.,\^$|#\s])" };
+                // const std::string fmt = R"(\$&)";
+                // return std::regex_replace(e.get().get(), sanitizer, fmt);
+                std::string result{};
+                for(char c : e.get().get()) {
+                    switch(c) {
+                        default:
+                            result += c;
+                            break;
+                        case '^':
+                            result += "\\^";
+                            break;
+                        case '$':
+                            result += "\\$";
+                            break;
+                        case '*':
+                            result += "\\*";
+                            break;
+                        case '+':
+                            result += "\\+";
+                            break;
+                        case '?':
+                            result += "\\?";
+                            break;
+                        case '.':
+                            result += "\\.";
+                            break;
+                        case '(':
+                            result += "\\(";
+                            break;
+                        case ')':
+                            result += "\\)";
+                            break;
+                        case '|':
+                            result += "\\|";
+                            break;
+                        case '{':
+                            result += "\\{";
+                            break;
+                        case '}':
+                            result += "\\}";
+                            break;
+                        case '[':
+                            result += "\\[";
+                            break;
+                        case ']':
+                            result += "\\]";
+                            break;
+                        case '\\':
+                            result += "\\\\";
+                            break;
+                    
+                    }
+                }
+                return result;
             }
         }
         // clang-format on
@@ -347,389 +401,391 @@ namespace
         if (e.empty())
             LOG(warning) << "empty data structure element in backend";
         else
-            for (const auto& item : e.get()) {
-                assert(item);
-                if (options.test(FIXED_TYPE_FLAG) || options.test(FIXED_FLAG))
-                    renderProperty(
-                        result, *item, inheritOrPassFlags(options, *item) | TypeAttributes{}.set(REQUIRED_FLAG));
-                else
-                    renderProperty(result, *item, inheritOrPassFlags(options, *item));
-            }
+            for (const auto& item : e.get())
+                            {
+                                assert(item);
+                                if (options.test(FIXED_TYPE_FLAG) || options.test(FIXED_FLAG))
+                                    renderProperty(result,
+                                        *item,
+                                        inheritOrPassFlags(options, *item) | TypeAttributes{}.set(REQUIRED_FLAG));
+                                else
+                                    renderProperty(result, *item, inheritOrPassFlags(options, *item));
+                            }
 
-        materialize(schema, std::move(result));
+                            materialize(schema, std::move(result));
 
-        if (options.test(FIXED_TYPE_FLAG) || options.test(FIXED_FLAG))
-            addAdditionalProperties(schema, so::False{});
+                            if (options.test(FIXED_TYPE_FLAG) || options.test(FIXED_FLAG))
+                                addAdditionalProperties(schema, so::False{});
 
-        return schema;
-    }
-
-    so::Object& renderSchema(so::Object& s, const ArrayElement& e, TypeAttributes options)
-    {
-        constexpr const char* TYPE_NAME = "array";
-
-        options = updateTypeAttributes(e, options);
-
-        if (options.test(FIXED_TYPE_FLAG)) { // array of any of types
-
-            so::Array items{};
-            if (!e.empty())
-                for (const auto& entry : e.get()) {
-                    assert(entry);
-                    so::emplace_unique(items, makeSchema(*entry, inheritOrPassFlags(options, *entry)));
-                }
-
-            auto& schema = wrapNullable(s, options);
-            addType(schema, TYPE_NAME);
-            addItems(schema, so::Object{ so::from_list{}, std::make_pair("anyOf", std::move(items)) });
-
-        } else if (options.test(FIXED_FLAG)) { // tuple of N constants/types
-
-            so::Array items{};
-            if (!e.empty())
-                for (const auto& item : e.get()) {
-                    assert(item);
-                    items.data.emplace_back(makeSchema(*item, inheritOrPassFlags(options, *item)));
-                }
-
-            auto& schema = wrapNullable(s, options);
-            addType(schema, TYPE_NAME);
-            addMinItems(schema, items.data.size());  // minimum of N entries
-            addItems(schema, std::move(items));      // schemas of tuple entries
-            addAdditionalItems(schema, so::False{}); // no more entries
-
-        } else {
-            auto& schema = wrapNullable(s, options);
-            addType(schema, TYPE_NAME);
-        }
-
-        return s;
-    }
-
-    so::Object& renderSchema(so::Object& schema, const EnumElement& e, TypeAttributes options)
-    {
-        options = updateTypeAttributes(e, options);
-
-        so::Array enm{};   // schemas typing single value accumulated in `enum`
-        so::Array anyOf{}; // anything other schemas
-
-        if (options.test(NULLABLE_FLAG))
-            so::emplace_unique(enm, so::Null{});
-
-        auto enumerationsIt = e.attributes().find("enumerations");
-        if (e.attributes().end() != enumerationsIt) {
-
-            const auto enums = get<const ArrayElement>(enumerationsIt->second.get());
-
-            assert(enums);
-            assert(!enums->empty());
-            for (const auto& enumEntry : enums->get()) {
-                assert(enumEntry);
-                if (sizeOf(*enumEntry) == cardinal{ 1 }) // schema types single value
-                    so::emplace_unique(enm, generateJsonValue(*enumEntry));
-                else { // schema MAY type more values
-                    auto s = makeSchema(*enumEntry, inheritFlags(options));
-                    if (s.data.size() == 1) {
-                        const auto& key = s.data.at(0).first;
-                        auto* vals = mpark::get_if<so::Array>(&s.data.at(0).second);
-                        if (key == "enum") {
-                            for (auto& val : vals->data)
-                                so::emplace_unique(enm, std::move(val));
-                        } else if (key == "anyOf") {
-                            for (auto& val : vals->data)
-                                so::emplace_unique(anyOf, std::move(val));
-                        } else {
-                            so::emplace_unique(anyOf, std::move(s));
-                        }
-                    } else {
-                        so::emplace_unique(anyOf, std::move(s));
+                            return schema;
                     }
-                }
-            }
-        } else {
-            LOG(warning) << "Enum Element SHALL hold enumerations attribute; interpreting as empty";
-        }
 
-        if (anyOf.data.empty()) // use `enum`, all schemas type single values
-            addEnum(schema, std::move(enm));
+                    so::Object& renderSchema(so::Object & s, const ArrayElement& e, TypeAttributes options)
+                    {
+                        constexpr const char* TYPE_NAME = "array";
 
-        else { // use `anyOf`, some schemas MAY type multiple values
-            // add accumulated single-valued schemas as an option
-            if (!enm.data.empty()) {
-                so::Object enms;
-                addEnum(enms, std::move(enm));
-                so::emplace_unique(anyOf, std::move(enms));
-            }
+                        options = updateTypeAttributes(e, options);
 
-            addAnyOf(schema, std::move(anyOf));
-        }
+                        if (options.test(FIXED_TYPE_FLAG)) { // array of any of types
 
-        return schema;
-    }
+                            so::Array items{};
+                            if (!e.empty())
+                                for (const auto& entry : e.get()) {
+                                    assert(entry);
+                                    so::emplace_unique(items, makeSchema(*entry, inheritOrPassFlags(options, *entry)));
+                                }
 
-    so::Object& renderSchema(so::Object& schema, const NullElement& e, TypeAttributes options)
-    {
-        addType(schema, "null");
-        return schema;
-    }
+                            auto& schema = wrapNullable(s, options);
+                            addType(schema, TYPE_NAME);
+                            addItems(schema, so::Object{ so::from_list{}, std::make_pair("anyOf", std::move(items)) });
 
-    template <typename E>
-    struct type_name;
+                        } else if (options.test(FIXED_FLAG)) { // tuple of N constants/types
 
-    template <>
-    struct type_name<StringElement> {
-        constexpr static const char* value = "string";
-    };
+                            so::Array items{};
+                            if (!e.empty())
+                                for (const auto& item : e.get()) {
+                                    assert(item);
+                                    items.data.emplace_back(makeSchema(*item, inheritOrPassFlags(options, *item)));
+                                }
 
-    template <>
-    struct type_name<NumberElement> {
-        constexpr static const char* value = "number";
-    };
+                            auto& schema = wrapNullable(s, options);
+                            addType(schema, TYPE_NAME);
+                            addMinItems(schema, items.data.size());  // minimum of N entries
+                            addItems(schema, std::move(items));      // schemas of tuple entries
+                            addAdditionalItems(schema, so::False{}); // no more entries
 
-    template <>
-    struct type_name<BooleanElement> {
-        constexpr static const char* value = "boolean";
-    };
+                        } else {
+                            auto& schema = wrapNullable(s, options);
+                            addType(schema, TYPE_NAME);
+                        }
 
-    template <typename E>
-    so::Object& renderSchemaPrimitive(so::Object& s, const E& e, TypeAttributes options)
-    {
-        options = updateTypeAttributes(e, options);
+                        return s;
+                    }
 
-        if (options.test(FIXED_FLAG)) {
-            if (!e.empty()) {
-                if (options.test(NULLABLE_FLAG))
-                    addEnum(s, so::Array{ so::from_list{}, so::Null{}, utils::instantiate(e.get()) });
-                else
-                    addEnum(s, so::Array{ so::from_list{}, utils::instantiate(e.get()) });
-                return s;
-            }
-        }
+                    so::Object& renderSchema(so::Object & schema, const EnumElement& e, TypeAttributes options)
+                    {
+                        options = updateTypeAttributes(e, options);
 
-        if (options.test(NULLABLE_FLAG)) {
-            addAnyOf(s, so::Array{ so::from_list{}, nullSchema(), typeSchema(type_name<E>::value) });
-            return s;
-        }
+                        so::Array enm{};   // schemas typing single value accumulated in `enum`
+                        so::Array anyOf{}; // anything other schemas
 
-        addType(s, type_name<E>::value);
+                        if (options.test(NULLABLE_FLAG))
+                            so::emplace_unique(enm, so::Null{});
 
-        return s;
-    }
+                        auto enumerationsIt = e.attributes().find("enumerations");
+                        if (e.attributes().end() != enumerationsIt) {
 
-    so::Object& renderSchema(so::Object& s, const StringElement& e, TypeAttributes options)
-    {
-        return renderSchemaPrimitive(s, e, options);
-    }
+                            const auto enums = get<const ArrayElement>(enumerationsIt->second.get());
 
-    so::Object& renderSchema(so::Object& s, const NumberElement& e, TypeAttributes options)
-    {
-        return renderSchemaPrimitive(s, e, options);
-    }
+                            assert(enums);
+                            assert(!enums->empty());
+                            for (const auto& enumEntry : enums->get()) {
+                                assert(enumEntry);
+                                if (sizeOf(*enumEntry) == cardinal{ 1 }) // schema types single value
+                                    so::emplace_unique(enm, generateJsonValue(*enumEntry));
+                                else { // schema MAY type more values
+                                    auto s = makeSchema(*enumEntry, inheritFlags(options));
+                                    if (s.data.size() == 1) {
+                                        const auto& key = s.data.at(0).first;
+                                        auto* vals = mpark::get_if<so::Array>(&s.data.at(0).second);
+                                        if (key == "enum") {
+                                            for (auto& val : vals->data)
+                                                so::emplace_unique(enm, std::move(val));
+                                        } else if (key == "anyOf") {
+                                            for (auto& val : vals->data)
+                                                so::emplace_unique(anyOf, std::move(val));
+                                        } else {
+                                            so::emplace_unique(anyOf, std::move(s));
+                                        }
+                                    } else {
+                                        so::emplace_unique(anyOf, std::move(s));
+                                    }
+                                }
+                            }
+                        } else {
+                            LOG(warning) << "Enum Element SHALL hold enumerations attribute; interpreting as empty";
+                        }
 
-    so::Object& renderSchema(so::Object& s, const BooleanElement& e, TypeAttributes options)
-    {
-        return renderSchemaPrimitive(s, e, options);
-    }
+                        if (anyOf.data.empty()) // use `enum`, all schemas type single values
+                            addEnum(schema, std::move(enm));
 
-    so::Object& renderSchema(so::Object& s, const ExtendElement& e, TypeAttributes options)
-    {
-        auto merged = e.get().merge();
-        renderSchema(s, *merged, options);
-        return s;
-    }
+                        else { // use `anyOf`, some schemas MAY type multiple values
+                            // add accumulated single-valued schemas as an option
+                            if (!enm.data.empty()) {
+                                so::Object enms;
+                                addEnum(enms, std::move(enm));
+                                so::emplace_unique(anyOf, std::move(enms));
+                            }
 
-} // namespace
+                            addAnyOf(schema, std::move(anyOf));
+                        }
 
-namespace
-{
+                        return schema;
+                    }
 
-    void renderProperty(ObjectSchema& s, const MemberElement& e, TypeAttributes options)
-    {
-        if (hasFixedTypeAttr(e))
-            options.set(FIXED_FLAG);
+                    so::Object& renderSchema(so::Object & schema, const NullElement& e, TypeAttributes options)
+                    {
+                        addType(schema, "null");
+                        return schema;
+                    }
 
-        options.set(FIXED_TYPE_FLAG, hasFixedTypeTypeAttr(e));
-        options.set(NULLABLE_FLAG, hasNullableTypeAttr(e));
+                    template <typename E>
+                    struct type_name;
 
-        if (hasRequiredTypeAttr(e))
-            options.set(REQUIRED_FLAG);
+                    template <>
+                    struct type_name<StringElement> {
+                        constexpr static const char* value = "string";
+                    };
 
-        if (hasOptionalTypeAttr(e))
-            options.reset(REQUIRED_FLAG);
+                    template <>
+                    struct type_name<NumberElement> {
+                        constexpr static const char* value = "number";
+                    };
 
-        const auto k = e.get().key();
-        const auto v = e.get().value();
+                    template <>
+                    struct type_name<BooleanElement> {
+                        constexpr static const char* value = "boolean";
+                    };
 
-        assert(k);
-        if (isVariable(e)) {
+                    template <typename E>
+                    so::Object& renderSchemaPrimitive(so::Object & s, const E& e, TypeAttributes options)
+                    {
+                        options = updateTypeAttributes(e, options);
 
-            if (const auto& extKey = get<const ExtendElement>(k)) {
-                auto mergedKey = extKey->get().merge();
-                auto strKey = get<const StringElement>(mergedKey.get());
+                        if (options.test(FIXED_FLAG)) {
+                            if (!e.empty()) {
+                                if (options.test(NULLABLE_FLAG))
+                                    addEnum(s, so::Array{ so::from_list{}, so::Null{}, utils::instantiate(e.get()) });
+                                else
+                                    addEnum(s, so::Array{ so::from_list{}, utils::instantiate(e.get()) });
+                                return s;
+                            }
+                        }
 
-                if (!strKey) {
-                    LOG(error) << "Merging Member Element key yielded other than String Element: "
-                               << mergedKey->element();
-                    assert(false);
-                }
+                        if (options.test(NULLABLE_FLAG)) {
+                            addAnyOf(s, so::Array{ so::from_list{}, nullSchema(), typeSchema(type_name<E>::value) });
+                            return s;
+                        }
 
-                emplace_unique(s.patternProperties, //
-                    renderPattern(*strKey, passFlags(options)),
-                    makeSchema(*v, passFlags(options)));
+                        addType(s, type_name<E>::value);
 
-            } else if (const auto& strKey = get<const StringElement>(k)) {
+                        return s;
+                    }
 
-                emplace_unique(s.patternProperties, //
-                    renderPattern(*strKey, passFlags(options)),
-                    makeSchema(*v, passFlags(options)));
+                    so::Object& renderSchema(so::Object & s, const StringElement& e, TypeAttributes options)
+                    {
+                        return renderSchemaPrimitive(s, e, options);
+                    }
 
-            } else {
-                LOG(error) << "Unexpected element type in Member Element key: " << k->element();
-                assert(false);
-            }
+                    so::Object& renderSchema(so::Object & s, const NumberElement& e, TypeAttributes options)
+                    {
+                        return renderSchemaPrimitive(s, e, options);
+                    }
 
-        } else {
-            auto strKey = key(e);
+                    so::Object& renderSchema(so::Object & s, const BooleanElement& e, TypeAttributes options)
+                    {
+                        return renderSchemaPrimitive(s, e, options);
+                    }
 
-            s.properties.data.emplace_back(strKey, makeSchema(*v, passFlags(options)));
+                    so::Object& renderSchema(so::Object & s, const ExtendElement& e, TypeAttributes options)
+                    {
+                        auto merged = e.get().merge();
+                        renderSchema(s, *merged, options);
+                        return s;
+                    }
 
-            if (options.test(REQUIRED_FLAG))
-                s.required.data.emplace_back(so::String{ strKey });
-        }
-    }
+                } // namespace
 
-    void renderProperty(ObjectSchema& s, const RefElement& e, TypeAttributes options)
-    {
-        const auto& resolved = resolve(e);
-        renderProperty(s, resolved, passFlags(options));
-    }
+                namespace
+                {
 
-    void renderProperty(ObjectSchema& s, const SelectElement& e, TypeAttributes options)
-    {
-        so::Array oneOfs{};
-        for (const auto& option : e.get()) {
+                    void renderProperty(ObjectSchema& s, const MemberElement& e, TypeAttributes options)
+                    {
+                        if (hasFixedTypeAttr(e))
+                            options.set(FIXED_FLAG);
 
-            if (option->empty()) {
-                LOG(error) << "empty option element in backend";
-                assert(false);
-            }
+                        options.set(FIXED_TYPE_FLAG, hasFixedTypeTypeAttr(e));
+                        options.set(NULLABLE_FLAG, hasNullableTypeAttr(e));
 
-            if (option->get().size() < 1)
-                LOG(warning) << "option element without children in backend";
+                        if (hasRequiredTypeAttr(e))
+                            options.set(REQUIRED_FLAG);
 
-            ObjectSchema optionSchema{};
-            for (const auto& optionEntry : option->get()) {
-                assert(optionEntry);
-                renderProperty(optionSchema, *optionEntry, passFlags(options));
-            }
+                        if (hasOptionalTypeAttr(e))
+                            options.reset(REQUIRED_FLAG);
 
-            oneOfs.data.emplace_back(materialize(std::move(optionSchema)));
-        }
-        so::Object result{};
-        addOneOf(result, std::move(oneOfs));
-        s.allOf.data.emplace_back(std::move(result));
-    }
+                        const auto k = e.get().key();
+                        const auto v = e.get().value();
 
-    void renderProperty(ObjectSchema& s, const ObjectElement& e, TypeAttributes options)
-    {
-        if (hasFixedTypeAttr(e))
-            options.set(FIXED_FLAG);
+                        assert(k);
+                        if (isVariable(e)) {
 
-        if (e.empty())
-            LOG(warning) << "empty data structure element in backend";
-        else
-            for (const auto& item : e.get()) {
-                assert(item);
-                renderProperty(s, *item, inheritFlags(options));
-            }
-    }
+                            if (const auto& extKey = get<const ExtendElement>(k)) {
+                                auto mergedKey = extKey->get().merge();
+                                auto strKey = get<const StringElement>(mergedKey.get());
 
-    void renderProperty(ObjectSchema& s, const ExtendElement& e, TypeAttributes options)
-    {
-        if (e.empty())
-            LOG(warning) << "empty extend element in backend";
+                                if (!strKey) {
+                                    LOG(error) << "Merging Member Element key yielded other than String Element: "
+                                               << mergedKey->element();
+                                    assert(false);
+                                }
 
-        auto merged = e.get().merge();
-        renderProperty(s, *merged, passFlags(options));
-    }
+                                emplace_unique(s.patternProperties, //
+                                    renderPattern(*strKey, passFlags(options)),
+                                    makeSchema(*v, passFlags(options)));
 
-    struct RenderPropertyVisitor {
-        ObjectSchema* schemaPtr;
-        TypeAttributes options;
+                            } else if (const auto& strKey = get<const StringElement>(k)) {
 
-        template <typename ElementT>
-        void operator()(const ElementT& el)
-        {
-            renderProperty(*schemaPtr, el, options);
-        }
-    };
+                                emplace_unique(s.patternProperties, //
+                                    renderPattern(*strKey, passFlags(options)),
+                                    makeSchema(*v, passFlags(options)));
 
-    void renderProperty(ObjectSchema& s, const IElement& e, TypeAttributes options)
-    {
-        LOG(debug) << "rendering property `" << e.element() << "` as JSON Schema";
+                            } else {
+                                LOG(error) << "Unexpected element type in Member Element key: " << k->element();
+                                assert(false);
+                            }
 
-        refract::visit(e, RenderPropertyVisitor{ &s, options });
-    }
-} // namespace
+                        } else {
+                            auto strKey = key(e);
 
-namespace
-{
-    so::Array* findAnyOf(so::Object& schema)
-    {
-        if (so::Value* anys = so::find(schema, "anyOf"))
-            return mpark::get_if<so::Array>(anys);
-        return nullptr;
-    }
+                            s.properties.data.emplace_back(strKey, makeSchema(*v, passFlags(options)));
 
-    so::Object* flattenAnyOfs(so::Value& schema);
+                            if (options.test(REQUIRED_FLAG))
+                                s.required.data.emplace_back(so::String{ strKey });
+                        }
+                    }
 
-    so::Object* flattenAnyOfsSpecific(so::Object& schema)
-    {
-        if (so::Array* anyOf = findAnyOf(schema)) {
+                    void renderProperty(ObjectSchema& s, const RefElement& e, TypeAttributes options)
+                    {
+                        const auto& resolved = resolve(e);
+                        renderProperty(s, resolved, passFlags(options));
+                    }
 
-            so::Array newAnyOf{};
-            for (auto& entry : anyOf->data)
-                if (so::Object* subAnyOf = flattenAnyOfs(entry)) {
-                    auto& subAnyOfArray = mpark::get<so::Array>(subAnyOf->data.back().second);
-                    for (auto& subEntry : subAnyOfArray.data)
-                        so::emplace_unique(newAnyOf, std::move(subEntry));
+                    void renderProperty(ObjectSchema& s, const SelectElement& e, TypeAttributes options)
+                    {
+                        so::Array oneOfs{};
+                        for (const auto& option : e.get()) {
 
-                } else {
-                    newAnyOf.data.emplace_back(std::move(entry));
-                }
+                            if (option->empty()) {
+                                LOG(error) << "empty option element in backend";
+                                assert(false);
+                            }
 
-            schema.data.back().second = std::move(newAnyOf);
-            return &schema;
-        }
+                            if (option->get().size() < 1)
+                                LOG(warning) << "option element without children in backend";
 
-        for (auto& entry : schema.data)
-            flattenAnyOfs(entry.second);
+                            ObjectSchema optionSchema{};
+                            for (const auto& optionEntry : option->get()) {
+                                assert(optionEntry);
+                                renderProperty(optionSchema, *optionEntry, passFlags(options));
+                            }
 
-        return nullptr;
-    }
+                            oneOfs.data.emplace_back(materialize(std::move(optionSchema)));
+                        }
+                        so::Object result{};
+                        addOneOf(result, std::move(oneOfs));
+                        s.allOf.data.emplace_back(std::move(result));
+                    }
 
-    template <typename T>
-    so::Object* flattenAnyOfsSpecific(T& schema)
-    {
-        // do nothing
-        return nullptr;
-    }
+                    void renderProperty(ObjectSchema& s, const ObjectElement& e, TypeAttributes options)
+                    {
+                        if (hasFixedTypeAttr(e))
+                            options.set(FIXED_FLAG);
 
-    struct FlattenAnyOfsVisitor {
-        template <typename Value>
-        so::Object* operator()(const Value& s)
-        {
-            return flattenAnyOfsSpecific(s);
-        }
-    };
+                        if (e.empty())
+                            LOG(warning) << "empty data structure element in backend";
+                        else
+                            for (const auto& item : e.get()) {
+                                assert(item);
+                                renderProperty(s, *item, inheritFlags(options));
+                            }
+                    }
 
-    so::Object* flattenAnyOfs(so::Value& schema)
-    {
-        return mpark::visit(FlattenAnyOfsVisitor{}, schema);
-    }
+                    void renderProperty(ObjectSchema& s, const ExtendElement& e, TypeAttributes options)
+                    {
+                        if (e.empty())
+                            LOG(warning) << "empty extend element in backend";
 
-    void reduce(so::Object& schema)
-    {
-        flattenAnyOfsSpecific(schema);
-    }
-} // namespace
+                        auto merged = e.get().merge();
+                        renderProperty(s, *merged, passFlags(options));
+                    }
+
+                    struct RenderPropertyVisitor {
+                        ObjectSchema* schemaPtr;
+                        TypeAttributes options;
+
+                        template <typename ElementT>
+                        void operator()(const ElementT& el)
+                        {
+                            renderProperty(*schemaPtr, el, options);
+                        }
+                    };
+
+                    void renderProperty(ObjectSchema& s, const IElement& e, TypeAttributes options)
+                    {
+                        LOG(debug) << "rendering property `" << e.element() << "` as JSON Schema";
+
+                        refract::visit(e, RenderPropertyVisitor{ &s, options });
+                    }
+                } // namespace
+
+                namespace
+                {
+                    so::Array* findAnyOf(so::Object& schema)
+                    {
+                        if (so::Value* anys = so::find(schema, "anyOf"))
+                            return mpark::get_if<so::Array>(anys);
+                        return nullptr;
+                    }
+
+                    so::Object* flattenAnyOfs(so::Value& schema);
+
+                    so::Object* flattenAnyOfsSpecific(so::Object& schema)
+                    {
+                        if (so::Array* anyOf = findAnyOf(schema)) {
+
+                            so::Array newAnyOf{};
+                            for (auto& entry : anyOf->data)
+                                if (so::Object* subAnyOf = flattenAnyOfs(entry)) {
+                                    auto& subAnyOfArray = mpark::get<so::Array>(subAnyOf->data.back().second);
+                                    for (auto& subEntry : subAnyOfArray.data)
+                                        so::emplace_unique(newAnyOf, std::move(subEntry));
+
+                                } else {
+                                    newAnyOf.data.emplace_back(std::move(entry));
+                                }
+
+                            schema.data.back().second = std::move(newAnyOf);
+                            return &schema;
+                        }
+
+                        for (auto& entry : schema.data)
+                            flattenAnyOfs(entry.second);
+
+                        return nullptr;
+                    }
+
+                    template <typename T>
+                    so::Object* flattenAnyOfsSpecific(T& schema)
+                    {
+                        // do nothing
+                        return nullptr;
+                    }
+
+                    struct FlattenAnyOfsVisitor {
+                        template <typename Value>
+                        so::Object* operator()(const Value& s)
+                        {
+                            return flattenAnyOfsSpecific(s);
+                        }
+                    };
+
+                    so::Object* flattenAnyOfs(so::Value& schema)
+                    {
+                        return mpark::visit(FlattenAnyOfsVisitor{}, schema);
+                    }
+
+                    void reduce(so::Object& schema)
+                    {
+                        flattenAnyOfsSpecific(schema);
+                    }
+                } // namespace

--- a/src/refract/JsonValue.cc
+++ b/src/refract/JsonValue.cc
@@ -121,12 +121,20 @@ namespace
         return so::Null{}; // unreachable
     }
 
+    struct RenderValueVisitor {
+        TypeAttributes options;
+
+        template <typename ElementT>
+        so::Value operator()(const ElementT& el) const
+        {
+            return renderValueSpecific(el, options);
+        }
+    };
+
     so::Value renderValue(const IElement& element, TypeAttributes options)
     {
         LOG(debug) << "rendering `" << element.element() << "` element to JSON Value";
-        return refract::visit(element, [options](const auto& el) { //
-            return renderValueSpecific(el, options);
-        });
+        return refract::visit(element, RenderValueVisitor{ options });
     }
 } // namespace
 
@@ -354,14 +362,21 @@ namespace
         renderProperty(value, *merged, passFlags(options));
     }
 
+    struct RenderPropertyVisitor {
+        so::Object* objPtr;
+        TypeAttributes options;
+
+        template <typename ElementT>
+        void operator()(const ElementT& el)
+        {
+            renderProperty(*objPtr, el, options);
+        }
+    };
+
     void renderProperty(so::Object& value, const IElement& element, TypeAttributes options)
     {
         LOG(debug) << "rendering property `" << element.element() << "` as JSON Value";
-
-        auto objPtr = &value;
-        refract::visit(element, [objPtr, options](const auto& el) { //
-            renderProperty(*objPtr, el, options);
-        });
+        refract::visit(element, RenderPropertyVisitor{ &value, options });
     }
 
     void renderItemSpecific(so::Array& array, const RefElement& element, TypeAttributes options)
@@ -390,12 +405,20 @@ namespace
         renderItemPrimitive(array, element, options);
     }
 
+    struct RenderItemVisitor {
+        so::Array* aPtr;
+        TypeAttributes options;
+
+        template <typename ElementT>
+        void operator()(const ElementT& el)
+        {
+            renderItemSpecific(*aPtr, el, options);
+        }
+    };
+
     void renderItem(so::Array& array, const IElement& element, TypeAttributes options)
     {
         LOG(debug) << "rendering item `" << element.element() << "` element as JSON Value";
-        auto aPtr = &array;
-        refract::visit(element, [aPtr, options](const auto& el) { //
-            renderItemSpecific(*aPtr, el, options);
-        });
+        refract::visit(element, RenderItemVisitor{ &array, options });
     }
 } // namespace

--- a/src/refract/SerializeSo.cc
+++ b/src/refract/SerializeSo.cc
@@ -34,6 +34,16 @@ namespace
     so::Object serializeContent(const dsd::Member& e, bool renderSourceMaps);
     so::String serializeContent(const dsd::Ref& e, bool renderSourceMaps);
 
+    struct SerializeContentVisitor {
+        bool renderSourceMaps;
+
+        template <typename ElementT>
+        so::Value operator()(const ElementT& el) const
+        {
+            return serializeContent(el.get(), renderSourceMaps);
+        }
+    };
+
     so::Object serializeAny(const IElement& e, bool renderSourceMaps)
     {
         so::Object result;
@@ -60,9 +70,7 @@ namespace
         }
 
         if (!e.empty()) {
-            result.data.emplace_back("content", visit(e, [renderSourceMaps](const auto& el) { //
-                return serializeContent(el.get(), renderSourceMaps);
-            }));
+            result.data.emplace_back("content", visit(e, SerializeContentVisitor{ renderSourceMaps }));
         }
 
         return result;

--- a/src/refract/Utils.cc
+++ b/src/refract/Utils.cc
@@ -45,9 +45,13 @@ bool refract::operator!=(const IElement& lhs, const IElement& rhs) noexcept
 
 bool refract::operator==(const InfoElements& lhs, const InfoElements& rhs) noexcept
 {
-    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), [](const auto& l, const auto& r) {
-        return (l.first == r.first) && (*l.second == *r.second);
-    });
+    return lhs.size() == rhs.size()
+        && std::equal(lhs.begin(),
+               lhs.end(),
+               rhs.begin(),
+               [](const InfoElements::value_type& l, const InfoElements::value_type& r) {
+                   return (l.first == r.first) && (*l.second == *r.second);
+               });
 }
 
 bool refract::operator!=(const InfoElements& lhs, const InfoElements& rhs) noexcept

--- a/src/refract/Utils.h
+++ b/src/refract/Utils.h
@@ -241,19 +241,26 @@ namespace refract
         };
     }
 
-    template <typename How>
-    auto visit(IElement& ifc, How&& f)
+    template <typename How,
+        typename HowRef = How&,
+        typename Result = typename std::result_of<HowRef(const NullElement&)>::type,
+        typename = typename std::enable_if<std::is_void<Result>::value>::type>
+    void visit(const IElement& ifc, How&& f)
     {
         using namespace impl;
 
         state_functor<How> stm(std::forward<How>(f));
         ifc.visit(stm);
 
-        return stm.consume();
+        stm.consume();
     }
 
-    template <typename How>
-    auto visit(const IElement& ifc, How&& f)
+    template <typename How,
+        typename HowRef = How&,
+        typename Result = typename std::result_of<HowRef(const NullElement&)>::type,
+        typename = typename std::enable_if<!std::is_void<Result>::value>::type,
+        typename = void>
+    Result visit(const IElement& ifc, How&& f)
     {
         using namespace impl;
 

--- a/src/refract/VisitorUtils.cc
+++ b/src/refract/VisitorUtils.cc
@@ -58,7 +58,7 @@ std::string refract::GetKeyAsString(const MemberElement& e)
 
 MemberElement* refract::FindMemberByKey(const ObjectElement& e, const std::string& name)
 {
-    auto it = std::find_if(e.get().begin(), e.get().end(), [&name](const auto& el) {
+    auto it = std::find_if(e.get().begin(), e.get().end(), [&name](const std::unique_ptr<IElement>& el) {
         ComparableVisitor cmp(name, ComparableVisitor::key);
         VisitBy(*el, cmp);
         return cmp.get();

--- a/src/refract/dsd/Array.cc
+++ b/src/refract/dsd/Array.cc
@@ -56,7 +56,7 @@ Array::Array(const Array& other) : Array()
         });
 }
 
-Array::iterator Array::insert(Array::const_iterator it, std::unique_ptr<IElement> el)
+Array::iterator Array::insert(Array::iterator it, std::unique_ptr<IElement> el)
 {
     assert(it >= begin());
     assert(it <= end());
@@ -65,7 +65,7 @@ Array::iterator Array::insert(Array::const_iterator it, std::unique_ptr<IElement
     return elements_.insert(it, std::move(el));
 }
 
-Array::iterator Array::erase(Array::const_iterator b, Array::const_iterator e)
+Array::iterator Array::erase(Array::iterator b, Array::iterator e)
 {
     return elements_.erase(b, e);
 }

--- a/src/refract/dsd/Array.cc
+++ b/src/refract/dsd/Array.cc
@@ -50,7 +50,7 @@ Array::Array(const Array& other) : Array()
     std::transform(other.elements_.begin(),
         other.elements_.end(),
         std::back_inserter(elements_),
-        [](const auto& el) -> std::unique_ptr<IElement> {
+        [](const value_type& el) -> std::unique_ptr<IElement> {
             assert(el);
             return std::unique_ptr<IElement>(el->clone());
         });
@@ -72,16 +72,16 @@ Array::iterator Array::erase(Array::const_iterator b, Array::const_iterator e)
 
 bool dsd::operator==(const Array& lhs, const Array& rhs) noexcept
 {
-    return std::equal( //
-        lhs.begin(),
-        lhs.end(),
-        rhs.begin(),
-        rhs.end(),
-        [](const auto& l, const auto& r) {
-            assert(l);
-            assert(r);
-            return *l == *r;
-        });
+    return lhs.size() == rhs.size()
+        && std::equal( //
+               lhs.begin(),
+               lhs.end(),
+               rhs.begin(),
+               [](const Array::value_type& l, const Array::value_type& r) {
+                   assert(l);
+                   assert(r);
+                   return *l == *r;
+               });
 }
 
 bool dsd::operator!=(const Array& lhs, const Array& rhs) noexcept

--- a/src/refract/dsd/Array.h
+++ b/src/refract/dsd/Array.h
@@ -110,7 +110,7 @@ namespace refract
             ///
             /// @return iterator to Element added
             ///
-            iterator insert(const_iterator it, std::unique_ptr<IElement> el);
+            iterator insert(iterator it, std::unique_ptr<IElement> el);
 
             ///
             /// Remove a subsequence of children
@@ -120,7 +120,7 @@ namespace refract
             ///
             /// @return iterator following the last child removed
             ///
-            iterator erase(const_iterator b, const_iterator e);
+            iterator erase(iterator b, iterator e);
 
             using container_traits<Array, container_type>::erase;
         };

--- a/src/refract/dsd/Array.h
+++ b/src/refract/dsd/Array.h
@@ -83,20 +83,20 @@ namespace refract
             }
 
         public: // iterators
-            auto begin() noexcept
+            iterator begin() noexcept
             {
                 return elements_.begin();
             }
-            auto end() noexcept
+            iterator end() noexcept
             {
                 return elements_.end();
             }
 
-            auto begin() const noexcept
+            const_iterator begin() const noexcept
             {
                 return elements_.begin();
             }
-            auto end() const noexcept
+            const_iterator end() const noexcept
             {
                 return elements_.end();
             }

--- a/src/refract/dsd/Extend.cc
+++ b/src/refract/dsd/Extend.cc
@@ -347,7 +347,7 @@ Extend::Extend(const Extend& other) : elements_()
         });
 }
 
-Extend::iterator Extend::insert(Extend::const_iterator it, std::unique_ptr<IElement> el)
+Extend::iterator Extend::insert(Extend::iterator it, std::unique_ptr<IElement> el)
 {
     assert(it >= begin());
     assert(it <= end());
@@ -362,7 +362,7 @@ Extend::iterator Extend::insert(Extend::const_iterator it, std::unique_ptr<IElem
     return elements_.insert(it, std::move(el));
 }
 
-Extend::iterator Extend::erase(Extend::const_iterator b, Extend::const_iterator e)
+Extend::iterator Extend::erase(Extend::iterator b, Extend::iterator e)
 {
     return elements_.erase(b, e);
 }

--- a/src/refract/dsd/Extend.h
+++ b/src/refract/dsd/Extend.h
@@ -81,19 +81,19 @@ namespace refract
             }
 
         public: // iterators
-            auto begin() noexcept
+            iterator begin() noexcept
             {
                 return elements_.begin();
             }
-            auto end() noexcept
+            iterator end() noexcept
             {
                 return elements_.end();
             }
-            auto begin() const noexcept
+            const_iterator begin() const noexcept
             {
                 return elements_.begin();
             }
-            auto end() const noexcept
+            const_iterator end() const noexcept
             {
                 return elements_.end();
             }

--- a/src/refract/dsd/Extend.h
+++ b/src/refract/dsd/Extend.h
@@ -107,7 +107,7 @@ namespace refract
             ///
             /// @return iterator to Element added
             ///
-            iterator insert(const_iterator it, std::unique_ptr<IElement> el);
+            iterator insert(iterator it, std::unique_ptr<IElement> el);
 
             ///
             /// Remove a subsequence of children
@@ -117,7 +117,7 @@ namespace refract
             ///
             /// @return iterator following the last child removed
             ///
-            iterator erase(const_iterator b, const_iterator e);
+            iterator erase(iterator b, iterator e);
 
             using container_traits<Extend, container_type>::erase;
 

--- a/src/refract/dsd/Member.cc
+++ b/src/refract/dsd/Member.cc
@@ -63,7 +63,9 @@ Member& Member::operator=(Member rhs)
 
 bool dsd::operator==(const Member& lhs, const Member& rhs) noexcept
 {
-    auto eq = [](const auto& lptr, const auto& rptr) { return (lptr == rptr) || (lptr && rptr && (*lptr == *rptr)); };
+    auto eq = [](const IElement* lptr, const IElement* rptr) {
+        return (lptr == rptr) || (lptr && rptr && (*lptr == *rptr));
+    };
     return eq(lhs.key(), rhs.key()) && eq(lhs.value(), rhs.value());
 }
 

--- a/src/refract/dsd/Object.cc
+++ b/src/refract/dsd/Object.cc
@@ -76,7 +76,7 @@ void Object::push_back(std::unique_ptr<IElement> el)
     elements_.emplace_back(std::move(el));
 }
 
-Object::iterator Object::insert(Object::const_iterator it, std::unique_ptr<IElement> el)
+Object::iterator Object::insert(Object::iterator it, std::unique_ptr<IElement> el)
 {
     assert(it >= begin());
     assert(it <= end());
@@ -85,7 +85,7 @@ Object::iterator Object::insert(Object::const_iterator it, std::unique_ptr<IElem
     return elements_.insert(it, std::move(el));
 }
 
-Object::iterator Object::erase(Object::const_iterator b, Object::const_iterator e)
+Object::iterator Object::erase(Object::iterator b, Object::iterator e)
 {
     return elements_.erase(b, e);
 }

--- a/src/refract/dsd/Object.cc
+++ b/src/refract/dsd/Object.cc
@@ -42,7 +42,7 @@ Object::Object(const Object& other) : elements_()
     std::transform(other.elements_.begin(),
         other.elements_.end(),
         std::back_inserter(elements_),
-        [](const auto& el) -> std::unique_ptr<IElement> {
+        [](const value_type& el) -> std::unique_ptr<IElement> {
             assert(el);
             return el->clone();
         });
@@ -92,7 +92,7 @@ Object::iterator Object::erase(Object::const_iterator b, Object::const_iterator 
 
 Object::iterator Object::find(const std::string& name)
 {
-    return std::find_if(begin(), end(), [&name](const auto& entry) {
+    return std::find_if(begin(), end(), [&name](const std::unique_ptr<IElement>& entry) {
         if (auto mbr = TypeQueryVisitor::as<const MemberElement>(entry.get())) {
             if (mbr->empty())
                 return false;
@@ -113,16 +113,16 @@ Object::iterator Object::addMember(std::string name, std::unique_ptr<IElement> v
 
 bool dsd::operator==(const Object& lhs, const Object& rhs) noexcept
 {
-    return std::equal( //
-        lhs.begin(),
-        lhs.end(),
-        rhs.begin(),
-        rhs.end(),
-        [](const auto& l, const auto& r) {
-            assert(l);
-            assert(r);
-            return *l == *r;
-        });
+    return lhs.size() == rhs.size()
+        && std::equal( //
+               lhs.begin(),
+               lhs.end(),
+               rhs.begin(),
+               [](const Object::value_type& l, const Object::value_type& r) {
+                   assert(l);
+                   assert(r);
+                   return *l == *r;
+               });
 }
 
 bool dsd::operator!=(const Object& lhs, const Object& rhs) noexcept

--- a/src/refract/dsd/Object.h
+++ b/src/refract/dsd/Object.h
@@ -111,7 +111,7 @@ namespace refract
             ///
             /// @return iterator to Element added
             ///
-            iterator insert(const_iterator it, std::unique_ptr<IElement> el);
+            iterator insert(iterator it, std::unique_ptr<IElement> el);
 
             ///
             /// Remove a subsequence of children
@@ -121,7 +121,7 @@ namespace refract
             ///
             /// @return iterator following the last child removed
             ///
-            iterator erase(const_iterator b, const_iterator e);
+            iterator erase(iterator b, iterator e);
 
             using container_traits<Object, container_type>::erase;
 

--- a/src/refract/dsd/Object.h
+++ b/src/refract/dsd/Object.h
@@ -82,22 +82,22 @@ namespace refract
             }
 
         public: // iterators
-            auto begin() noexcept
+            iterator begin() noexcept
             {
                 return elements_.begin();
             }
 
-            auto end() noexcept
+            iterator end() noexcept
             {
                 return elements_.end();
             }
 
-            auto begin() const noexcept
+            const_iterator begin() const noexcept
             {
                 return elements_.begin();
             }
 
-            auto end() const noexcept
+            const_iterator end() const noexcept
             {
                 return elements_.end();
             }

--- a/src/refract/dsd/Option.cc
+++ b/src/refract/dsd/Option.cc
@@ -47,7 +47,7 @@ Option::Option(const Option& other) : elements_()
     std::transform(other.elements_.begin(),
         other.elements_.end(),
         std::back_inserter(elements_),
-        [](const auto& el) -> std::unique_ptr<IElement> {
+        [](const value_type& el) -> std::unique_ptr<IElement> {
             assert(el);
             return el->clone();
         });
@@ -75,12 +75,12 @@ Option::iterator Option::erase(Option::const_iterator b, Option::const_iterator 
 
 bool dsd::operator==(const Option& lhs, const Option& rhs) noexcept
 {
-    return std::equal( //
-        lhs.begin(),
-        lhs.end(),
-        rhs.begin(),
-        rhs.end(),
-        [](const auto& l, const auto& r) { return *l == *r; });
+    return lhs.size() == rhs.size()
+        && std::equal( //
+               lhs.begin(),
+               lhs.end(),
+               rhs.begin(),
+               [](const Option::value_type& l, const Option::value_type& r) { return *l == *r; });
 }
 
 bool dsd::operator!=(const Option& lhs, const Option& rhs) noexcept

--- a/src/refract/dsd/Option.cc
+++ b/src/refract/dsd/Option.cc
@@ -59,7 +59,7 @@ Option& Option::operator=(Option rhs)
     return *this;
 }
 
-Option::iterator Option::insert(Option::const_iterator it, std::unique_ptr<IElement> el)
+Option::iterator Option::insert(Option::iterator it, std::unique_ptr<IElement> el)
 {
     assert(it >= begin());
     assert(it <= end());
@@ -68,7 +68,7 @@ Option::iterator Option::insert(Option::const_iterator it, std::unique_ptr<IElem
     return elements_.insert(it, std::move(el));
 }
 
-Option::iterator Option::erase(Option::const_iterator b, Option::const_iterator e)
+Option::iterator Option::erase(Option::iterator b, Option::iterator e)
 {
     return elements_.erase(b, e);
 }

--- a/src/refract/dsd/Option.h
+++ b/src/refract/dsd/Option.h
@@ -107,7 +107,7 @@ namespace refract
             ///
             /// @return iterator to Element added
             ///
-            iterator insert(const_iterator it, std::unique_ptr<IElement> el);
+            iterator insert(iterator it, std::unique_ptr<IElement> el);
 
             ///
             /// Remove a subsequence of children
@@ -117,7 +117,7 @@ namespace refract
             ///
             /// @return iterator following the last child removed
             ///
-            iterator erase(const_iterator b, const_iterator e);
+            iterator erase(iterator b, iterator e);
 
             using container_traits<Option, container_type>::erase;
         };

--- a/src/refract/dsd/Option.h
+++ b/src/refract/dsd/Option.h
@@ -81,19 +81,19 @@ namespace refract
             }
 
         public: // iterators
-            auto begin() noexcept
+            iterator begin() noexcept
             {
                 return elements_.begin();
             }
-            auto end() noexcept
+            iterator end() noexcept
             {
                 return elements_.end();
             }
-            auto begin() const noexcept
+            const_iterator begin() const noexcept
             {
                 return elements_.begin();
             }
-            auto end() const noexcept
+            const_iterator end() const noexcept
             {
                 return elements_.end();
             }

--- a/src/refract/dsd/Select.cc
+++ b/src/refract/dsd/Select.cc
@@ -61,7 +61,7 @@ Select& Select::operator=(Select rhs)
     return *this;
 }
 
-Select::iterator Select::insert(Select::const_iterator it, std::unique_ptr<OptionElement> el)
+Select::iterator Select::insert(Select::iterator it, std::unique_ptr<OptionElement> el)
 {
     assert(it >= begin());
     assert(it <= end());
@@ -70,7 +70,7 @@ Select::iterator Select::insert(Select::const_iterator it, std::unique_ptr<Optio
     return elements_.insert(it, std::move(el));
 }
 
-Select::iterator Select::erase(Select::const_iterator b, Select::const_iterator e)
+Select::iterator Select::erase(Select::iterator b, Select::iterator e)
 {
     return elements_.erase(b, e);
 }

--- a/src/refract/dsd/Select.cc
+++ b/src/refract/dsd/Select.cc
@@ -48,7 +48,7 @@ Select::Select(const Select& other) : elements_()
     std::transform(other.elements_.begin(),
         other.elements_.end(),
         std::back_inserter(elements_),
-        [](const auto& el) -> std::unique_ptr<OptionElement> {
+        [](const value_type& el) -> std::unique_ptr<OptionElement> {
             if (!el)
                 return nullptr;
             return clone(*el);
@@ -79,12 +79,12 @@ Select::~Select() {}
 
 bool dsd::operator==(const Select& lhs, const Select& rhs) noexcept
 {
-    return std::equal( //
-        lhs.begin(),
-        lhs.end(),
-        rhs.begin(),
-        rhs.end(),
-        [](const auto& l, const auto& r) { return *l == *r; });
+    return lhs.size() == rhs.size()
+        && std::equal( //
+               lhs.begin(),
+               lhs.end(),
+               rhs.begin(),
+               [](const Select::value_type& l, const Select::value_type& r) { return *l == *r; });
 }
 
 bool dsd::operator!=(const Select& lhs, const Select& rhs) noexcept

--- a/src/refract/dsd/Select.h
+++ b/src/refract/dsd/Select.h
@@ -84,9 +84,8 @@ namespace refract
         public:
             ///
             /// Get reference to memory representation
-            /// @deprecated
             ///
-            [[deprecated]] const container_type& get() const noexcept
+            const container_type& get() const noexcept
             {
                 return elements_;
             }
@@ -118,7 +117,7 @@ namespace refract
             ///
             /// @return iterator to Element added
             ///
-            iterator insert(const_iterator it, std::unique_ptr<OptionElement> el);
+            iterator insert(iterator it, std::unique_ptr<OptionElement> el);
 
             ///
             /// Remove a subsequence of children
@@ -128,7 +127,7 @@ namespace refract
             ///
             /// @return iterator following the last child removed
             ///
-            iterator erase(const_iterator b, const_iterator e);
+            iterator erase(iterator b, iterator e);
 
             using container_traits<Select, container_type>::erase;
         };

--- a/src/refract/dsd/Select.h
+++ b/src/refract/dsd/Select.h
@@ -92,19 +92,19 @@ namespace refract
             }
 
         public: // iterators
-            auto begin() noexcept
+            iterator begin() noexcept
             {
                 return elements_.begin();
             }
-            auto end() noexcept
+            iterator end() noexcept
             {
                 return elements_.end();
             }
-            auto begin() const noexcept
+            const_iterator begin() const noexcept
             {
                 return elements_.begin();
             }
-            auto end() const noexcept
+            const_iterator end() const noexcept
             {
                 return elements_.end();
             }

--- a/src/refract/dsd/Traits.h
+++ b/src/refract/dsd/Traits.h
@@ -29,15 +29,16 @@ namespace refract
         using supports_end = decltype(supports_end_test(std::declval<T>()));
 
         template <typename T,
-            typename = decltype(std::declval<T>().insert(
-                std::declval<typename T::const_iterator>(), std::declval<typename T::value_type>()))>
+            typename = decltype(
+                std::declval<T>().insert(std::declval<typename T::iterator>(), std::declval<typename T::value_type>()))>
         std::true_type supports_insert_test(const T&);
         std::false_type supports_insert_test(...);
         template <typename T>
         using supports_insert = decltype(supports_insert_test(std::declval<T>()));
 
         template <typename T,
-            typename = decltype(std::declval<T>().erase(std::declval<T>().begin(), std::declval<T>().begin()))>
+            typename = decltype(
+                std::declval<T>().erase(std::declval<typename T::iterator>(), std::declval<typename T::iterator>()))>
         std::true_type supports_erase_test(const T&);
         std::false_type supports_erase_test(...);
         template <typename T>
@@ -136,7 +137,7 @@ namespace refract
             ///
             /// @return iterator following the member removed
             ///
-            const_iterator erase(const_iterator it)
+            iterator erase(iterator it)
             {
                 return self().erase(it, std::next(it));
             }

--- a/src/utils/so/Value.cc
+++ b/src/utils/so/Value.cc
@@ -72,7 +72,7 @@ Value* drafter::utils::so::find(Object& c, const std::string& key)
     auto it = std::find_if( //
         c.data.begin(),
         c.data.end(),
-        [&key](const auto& entry) { return entry.first == key; });
+        [&key](const Object::container_type::value_type& entry) { return entry.first == key; });
 
     if (it != c.data.end())
         return &it->second;
@@ -81,7 +81,9 @@ Value* drafter::utils::so::find(Object& c, const std::string& key)
 
 void drafter::utils::so::emplace_unique(Array& c, Value&& value)
 {
-    auto it = std::find_if(c.data.begin(), c.data.end(), [&value](const auto& entry) { return entry == value; });
+    auto it = std::find_if(c.data.begin(), c.data.end(), [&value](const Array::container_type::value_type& entry) {
+        return entry == value;
+    });
 
     if (it == c.data.end())
         c.data.emplace_back(std::move(value));
@@ -89,8 +91,10 @@ void drafter::utils::so::emplace_unique(Array& c, Value&& value)
 
 void drafter::utils::so::emplace_unique(Object& c, Object::container_type::value_type&& property)
 {
-    auto it = std::find_if(
-        c.data.begin(), c.data.end(), [& key = property.first](const auto& entry) { return entry.first == key; });
+    const auto& key = property.first;
+    auto it = std::find_if(c.data.begin(), c.data.end(), [&key](const Object::container_type::value_type& entry) {
+        return entry.first == key;
+    });
     if (it == c.data.end())
         c.data.emplace_back(std::move(property));
     else

--- a/src/utils/so/Value.h
+++ b/src/utils/so/Value.h
@@ -125,8 +125,13 @@ namespace drafter
             template <typename ValueType>
             void emplace_unique(Object& c, std::string key, ValueType&& value)
             {
-                auto it = std::find_if(
-                    c.data.begin(), c.data.end(), [&key](const auto& entry) { return entry.first == key; });
+                auto it = std::find_if(                                       //
+                    c.data.begin(),                                           //
+                    c.data.end(),                                             //
+                    [&key](const Object::container_type::value_type& entry) { //
+                        return entry.first == key;
+                    });
+
                 if (it == c.data.end())
                     c.data.emplace_back(key, std::forward<ValueType>(value));
                 else

--- a/src/utils/so/YamlIo.cc
+++ b/src/utils/so/YamlIo.cc
@@ -13,7 +13,6 @@
 #include <exception>
 #include <iostream>
 #include <iterator>
-#include <regex>
 #include <mpark/variant.hpp>
 #include "../Utf8.h"
 #include "../Utils.h"
@@ -28,8 +27,10 @@ namespace
 
     bool is_alphanum_dash(const std::string& str)
     {
-        thread_local const std::regex r{ "[a-zA-Z0-9-]+" };
-        return std::regex_match(str.begin(), str.end(), r);
+        for (char c : str)
+            if (c < 'A' || c > 'z' || (c > 'Z' && c < 'a') || c == '-')
+                return false;
+        return true;
     }
 
     bool is_yaml_printable(const codepoint& c)

--- a/test/refract/dsd/test-Array.cc
+++ b/test/refract/dsd/test-Array.cc
@@ -78,7 +78,7 @@ SCENARIO("`Array` is inserted to and erased from", "[ElementData][Array]")
 
         WHEN("an ElementMock is pushed back")
         {
-            auto mock = std::make_unique<test::ElementMock>();
+            auto mock = make_unique<test::ElementMock>();
             auto mock1ptr = mock.get();
 
             REQUIRE(test::ElementMock::instances().size() == 1);
@@ -112,20 +112,20 @@ SCENARIO("`Array` is inserted to and erased from", "[ElementData][Array]")
 
             WHEN("another three ElementMocks are inserted at begin two at end")
             {
-                auto mock2 = std::make_unique<test::ElementMock>();
+                auto mock2 = make_unique<test::ElementMock>();
 
-                auto mock3 = std::make_unique<test::ElementMock>();
+                auto mock3 = make_unique<test::ElementMock>();
 
-                auto mock4 = std::make_unique<test::ElementMock>();
+                auto mock4 = make_unique<test::ElementMock>();
 
                 array.insert(array.begin(), std::move(mock2));
                 array.insert(array.begin(), std::move(mock3));
                 array.insert(array.begin(), std::move(mock4));
 
-                auto mock5 = std::make_unique<test::ElementMock>();
+                auto mock5 = make_unique<test::ElementMock>();
                 auto mock5ptr = mock.get();
 
-                auto mock6 = std::make_unique<test::ElementMock>();
+                auto mock6 = make_unique<test::ElementMock>();
 
                 array.insert(array.begin(), std::move(mock5));
                 array.insert(array.begin(), std::move(mock6));
@@ -189,7 +189,7 @@ SCENARIO("`Array` is inserted to and erased from", "[ElementData][Array]")
 
             WHEN("another ElementMock is pushed back")
             {
-                auto mock2 = std::make_unique<test::ElementMock>();
+                auto mock2 = make_unique<test::ElementMock>();
                 auto mock2ptr = mock2.get();
 
                 REQUIRE(test::ElementMock::instances().size() == 2);
@@ -253,9 +253,9 @@ SCENARIO("`Array` is move-constructed from elements", "[ElementData][Array]")
     {
         REQUIRE(test::ElementMock::instances().size() == 0);
 
-        auto mock1 = std::make_unique<test::ElementMock>();
-        auto mock2 = std::make_unique<test::ElementMock>();
-        auto mock3 = std::make_unique<test::ElementMock>();
+        auto mock1 = make_unique<test::ElementMock>();
+        auto mock2 = make_unique<test::ElementMock>();
+        auto mock3 = make_unique<test::ElementMock>();
 
         const auto mock1ptr = mock1.get();
         const auto mock2ptr = mock2.get();

--- a/test/refract/dsd/test-Enum.cc
+++ b/test/refract/dsd/test-Enum.cc
@@ -9,6 +9,7 @@
 #include <catch2/catch.hpp>
 
 #include "refract/dsd/Enum.h"
+#include "refract/Element.h"
 #include "ElementMock.h"
 
 using namespace refract;
@@ -61,7 +62,7 @@ SCENARIO("`Enum` is constructed from value and is claimed", "[ElementData][Enum]
 {
     GIVEN("An `Enum` with an ElementMock value")
     {
-        Enum enm(std::make_unique<test::ElementMock>());
+        Enum enm(make_unique<test::ElementMock>());
         REQUIRE(test::ElementMock::instances().size() == 1);
 
         WHEN("it is claimed")

--- a/test/refract/dsd/test-Extend.cc
+++ b/test/refract/dsd/test-Extend.cc
@@ -79,7 +79,7 @@ SCENARIO("`Extend` is inserted to and erased from", "[ElementData][Extend]")
 
         WHEN("an ElementMock is pushed back")
         {
-            auto mock = std::make_unique<test::ElementMock>();
+            auto mock = make_unique<test::ElementMock>();
             auto mock1ptr = mock.get();
 
             REQUIRE(test::ElementMock::instances().size() == 1);
@@ -113,18 +113,18 @@ SCENARIO("`Extend` is inserted to and erased from", "[ElementData][Extend]")
 
             WHEN("another three ElementMocks are inserted at begin two at end")
             {
-                auto mock2 = std::make_unique<test::ElementMock>();
-                auto mock3 = std::make_unique<test::ElementMock>();
-                auto mock4 = std::make_unique<test::ElementMock>();
+                auto mock2 = make_unique<test::ElementMock>();
+                auto mock3 = make_unique<test::ElementMock>();
+                auto mock4 = make_unique<test::ElementMock>();
 
                 extend.insert(extend.begin(), std::move(mock2));
                 extend.insert(extend.begin(), std::move(mock3));
                 extend.insert(extend.begin(), std::move(mock4));
 
-                auto mock5 = std::make_unique<test::ElementMock>();
+                auto mock5 = make_unique<test::ElementMock>();
                 auto mock5ptr = mock.get();
 
-                auto mock6 = std::make_unique<test::ElementMock>();
+                auto mock6 = make_unique<test::ElementMock>();
 
                 extend.insert(extend.begin(), std::move(mock5));
                 extend.insert(extend.begin(), std::move(mock6));
@@ -188,7 +188,7 @@ SCENARIO("`Extend` is inserted to and erased from", "[ElementData][Extend]")
 
             WHEN("another ElementMock is pushed back")
             {
-                auto mock2 = std::make_unique<test::ElementMock>();
+                auto mock2 = make_unique<test::ElementMock>();
                 auto mock2ptr = mock2.get();
 
                 REQUIRE(test::ElementMock::instances().size() == 2);
@@ -252,9 +252,9 @@ SCENARIO("`Extend` is move-constructed from elements", "[ElementData][Extend]")
     {
         REQUIRE(test::ElementMock::instances().size() == 0);
 
-        auto mock1 = std::make_unique<test::ElementMock>();
-        auto mock2 = std::make_unique<test::ElementMock>();
-        auto mock3 = std::make_unique<test::ElementMock>();
+        auto mock1 = make_unique<test::ElementMock>();
+        auto mock2 = make_unique<test::ElementMock>();
+        auto mock3 = make_unique<test::ElementMock>();
 
         const auto mock1ptr = mock1.get();
         const auto mock2ptr = mock2.get();
@@ -1214,20 +1214,21 @@ SCENARIO("Extend::merge behaves as expected", "[Element][Extend][merge]")
                     REQUIRE(std::find_if( //
                                 result->get().begin(),
                                 result->get().end(),
-                                [&ipsum](const auto& elptr) { return *elptr == *ipsum; })
+                                [&ipsum](const std::unique_ptr<IElement>& elptr) { return *elptr == *ipsum; })
                         != result->get().end());
 
                     REQUIRE(std::find_if( //
                                 result->get().begin(),
                                 result->get().end(),
-                                [&dolorem](const auto& elptr) { return *elptr == *dolorem; })
+                                [&dolorem](const std::unique_ptr<IElement>& elptr) { return *elptr == *dolorem; })
                         != result->get().end());
 
-                    REQUIRE(
-                        std::count_if( //
-                            result->get().begin(),
-                            result->get().end(),
-                            [](const auto& elptr) { return nullptr != dynamic_cast<const RefElement*>(elptr.get()); })
+                    REQUIRE(std::count_if( //
+                                result->get().begin(),
+                                result->get().end(),
+                                [](const std::unique_ptr<IElement>& elptr) {
+                                    return nullptr != dynamic_cast<const RefElement*>(elptr.get());
+                                })
                         == 2);
 
                     THEN("the result contains one select element")
@@ -1248,13 +1249,13 @@ SCENARIO("Extend::merge behaves as expected", "[Element][Extend][merge]")
                         REQUIRE(std::find_if( //
                                     result->get().begin(),
                                     result->get().end(),
-                                    [&expected](const auto& elptr) { return *elptr == *expected; })
+                                    [&expected](const std::unique_ptr<IElement>& elptr) { return *elptr == *expected; })
                             != result->get().end());
 
                         REQUIRE(std::count_if( //
                                     result->get().begin(),
                                     result->get().end(),
-                                    [](const auto& elptr) {
+                                    [](const std::unique_ptr<IElement>& elptr) {
                                         return nullptr != dynamic_cast<const SelectElement*>(elptr.get());
                                     })
                             == 1);
@@ -1288,37 +1289,37 @@ SCENARIO("Extend::merge behaves as expected", "[Element][Extend][merge]")
                         REQUIRE(std::find_if( //
                                     result->get().begin(),
                                     result->get().end(),
-                                    [&foo](const auto& elptr) { return *elptr == *foo; })
+                                    [&foo](const std::unique_ptr<IElement>& elptr) { return *elptr == *foo; })
                             != result->get().end());
 
                         REQUIRE(std::find_if( //
                                     result->get().begin(),
                                     result->get().end(),
-                                    [&zoo](const auto& elptr) { return *elptr == *zoo; })
+                                    [&zoo](const std::unique_ptr<IElement>& elptr) { return *elptr == *zoo; })
                             != result->get().end());
 
                         REQUIRE(std::find_if( //
                                     result->get().begin(),
                                     result->get().end(),
-                                    [&state](const auto& elptr) { return *elptr == *state; })
+                                    [&state](const std::unique_ptr<IElement>& elptr) { return *elptr == *state; })
                             != result->get().end());
 
                         REQUIRE(std::find_if( //
                                     result->get().begin(),
                                     result->get().end(),
-                                    [&bar](const auto& elptr) { return *elptr == *bar; })
+                                    [&bar](const std::unique_ptr<IElement>& elptr) { return *elptr == *bar; })
                             != result->get().end());
 
                         REQUIRE(std::find_if( //
                                     result->get().begin(),
                                     result->get().end(),
-                                    [&lorem](const auto& elptr) { return *elptr == *lorem; })
+                                    [&lorem](const std::unique_ptr<IElement>& elptr) { return *elptr == *lorem; })
                             != result->get().end());
 
                         REQUIRE(std::count_if( //
                                     result->get().begin(),
                                     result->get().end(),
-                                    [](const auto& elptr) {
+                                    [](const std::unique_ptr<IElement>& elptr) {
                                         return nullptr != dynamic_cast<const MemberElement*>(elptr.get());
                                     })
                             == 5);

--- a/test/refract/dsd/test-Holder.cc
+++ b/test/refract/dsd/test-Holder.cc
@@ -8,6 +8,7 @@
 
 #include <catch2/catch.hpp>
 
+#include "refract/Element.h"
 #include "refract/dsd/Holder.h"
 #include "ElementMock.h"
 
@@ -61,7 +62,7 @@ SCENARIO("`Holder` is constructed from value and is claimed", "[ElementData][Hol
 {
     GIVEN("An `Holder` with an ElementMock value")
     {
-        Holder holder(std::make_unique<test::ElementMock>());
+        Holder holder(make_unique<test::ElementMock>());
         REQUIRE(test::ElementMock::instances().size() == 1);
 
         WHEN("it is claimed")

--- a/test/refract/dsd/test-InfoElements.cc
+++ b/test/refract/dsd/test-InfoElements.cc
@@ -158,8 +158,10 @@ SCENARIO("InfoElementss can be copied and moved", "[InfoElements]")
             }
             THEN("their keys equal")
             {
-                REQUIRE(std::equal(
-                    collection.begin(), collection.end(), collection2.begin(), [](const auto& m1, const auto& m2) {
+                REQUIRE(std::equal(collection.begin(),
+                    collection.end(),
+                    collection2.begin(),
+                    [](const InfoElements::value_type& m1, const InfoElements::value_type& m2) {
                         return m1.first == m2.first;
                     }));
             }
@@ -202,8 +204,10 @@ SCENARIO("InfoElementss can be copied and moved", "[InfoElements]")
             }
             THEN("their keys equal")
             {
-                REQUIRE(std::equal(
-                    collection.begin(), collection.end(), collection2.begin(), [](const auto& m1, const auto& m2) {
+                REQUIRE(std::equal(collection.begin(),
+                    collection.end(),
+                    collection2.begin(),
+                    [](const InfoElements::value_type& m1, const InfoElements::value_type& m2) {
                         return m1.first == m2.first;
                     }));
             }

--- a/test/refract/dsd/test-Member.cc
+++ b/test/refract/dsd/test-Member.cc
@@ -113,7 +113,7 @@ SCENARIO("Member is constructed from values, both copy- and move constructed fro
     {
         std::string key = "eigenvalue";
         auto mock = new test::ElementMock{};
-        mock->clone_out = std::make_unique<test::ElementMock>();
+        mock->clone_out = make_unique<test::ElementMock>();
         auto clone_out_ptr = mock->clone_out.get();
         mock->_value = 349802;
 

--- a/test/refract/dsd/test-Object.cc
+++ b/test/refract/dsd/test-Object.cc
@@ -78,7 +78,7 @@ SCENARIO("`Object` is inserted to and erased from", "[ElementData][Object]")
 
         WHEN("an ElementMock is pushed back")
         {
-            auto mock = std::make_unique<test::ElementMock>();
+            auto mock = make_unique<test::ElementMock>();
             auto mock1ptr = mock.get();
 
             REQUIRE(test::ElementMock::instances().size() == 1);
@@ -112,18 +112,18 @@ SCENARIO("`Object` is inserted to and erased from", "[ElementData][Object]")
 
             WHEN("another three ElementMocks are inserted at begin two at end")
             {
-                auto mock2 = std::make_unique<test::ElementMock>();
-                auto mock3 = std::make_unique<test::ElementMock>();
-                auto mock4 = std::make_unique<test::ElementMock>();
+                auto mock2 = make_unique<test::ElementMock>();
+                auto mock3 = make_unique<test::ElementMock>();
+                auto mock4 = make_unique<test::ElementMock>();
 
                 object.insert(object.begin(), std::move(mock2));
                 object.insert(object.begin(), std::move(mock3));
                 object.insert(object.begin(), std::move(mock4));
 
-                auto mock5 = std::make_unique<test::ElementMock>();
+                auto mock5 = make_unique<test::ElementMock>();
                 auto mock5ptr = mock.get();
 
-                auto mock6 = std::make_unique<test::ElementMock>();
+                auto mock6 = make_unique<test::ElementMock>();
 
                 object.insert(object.begin(), std::move(mock5));
                 object.insert(object.begin(), std::move(mock6));
@@ -187,7 +187,7 @@ SCENARIO("`Object` is inserted to and erased from", "[ElementData][Object]")
 
             WHEN("another ElementMock is pushed back")
             {
-                auto mock2 = std::make_unique<test::ElementMock>();
+                auto mock2 = make_unique<test::ElementMock>();
                 auto mock2ptr = mock2.get();
 
                 REQUIRE(test::ElementMock::instances().size() == 2);
@@ -252,9 +252,9 @@ SCENARIO("`Object` is move-constructed from elements", "[ElementData][Object]")
     {
         REQUIRE(test::ElementMock::instances().size() == 0);
 
-        auto mock1 = std::make_unique<test::ElementMock>();
-        auto mock2 = std::make_unique<test::ElementMock>();
-        auto mock3 = std::make_unique<test::ElementMock>();
+        auto mock1 = make_unique<test::ElementMock>();
+        auto mock2 = make_unique<test::ElementMock>();
+        auto mock3 = make_unique<test::ElementMock>();
 
         const auto mock1ptr = mock1.get();
         const auto mock2ptr = mock2.get();

--- a/test/refract/dsd/test-Option.cc
+++ b/test/refract/dsd/test-Option.cc
@@ -78,7 +78,7 @@ SCENARIO("`Option` is inserted to and erased from", "[ElementData][Option]")
 
         WHEN("an ElementMock is pushed back")
         {
-            auto mock = std::make_unique<test::ElementMock>();
+            auto mock = make_unique<test::ElementMock>();
             auto mock1ptr = mock.get();
 
             REQUIRE(test::ElementMock::instances().size() == 1);
@@ -112,18 +112,18 @@ SCENARIO("`Option` is inserted to and erased from", "[ElementData][Option]")
 
             WHEN("another three ElementMocks are inserted at begin two at end")
             {
-                auto mock2 = std::make_unique<test::ElementMock>();
-                auto mock3 = std::make_unique<test::ElementMock>();
-                auto mock4 = std::make_unique<test::ElementMock>();
+                auto mock2 = make_unique<test::ElementMock>();
+                auto mock3 = make_unique<test::ElementMock>();
+                auto mock4 = make_unique<test::ElementMock>();
 
                 option.insert(option.begin(), std::move(mock2));
                 option.insert(option.begin(), std::move(mock3));
                 option.insert(option.begin(), std::move(mock4));
 
-                auto mock5 = std::make_unique<test::ElementMock>();
+                auto mock5 = make_unique<test::ElementMock>();
                 auto mock5ptr = mock.get();
 
-                auto mock6 = std::make_unique<test::ElementMock>();
+                auto mock6 = make_unique<test::ElementMock>();
 
                 option.insert(option.begin(), std::move(mock5));
                 option.insert(option.begin(), std::move(mock6));
@@ -187,7 +187,7 @@ SCENARIO("`Option` is inserted to and erased from", "[ElementData][Option]")
 
             WHEN("another ElementMock is pushed back")
             {
-                auto mock2 = std::make_unique<test::ElementMock>();
+                auto mock2 = make_unique<test::ElementMock>();
                 auto mock2ptr = mock2.get();
 
                 REQUIRE(test::ElementMock::instances().size() == 2);
@@ -251,9 +251,9 @@ SCENARIO("`Option` is move-constructed from elements", "[ElementData][Option]")
     {
         REQUIRE(test::ElementMock::instances().size() == 0);
 
-        auto mock1 = std::make_unique<test::ElementMock>();
-        auto mock2 = std::make_unique<test::ElementMock>();
-        auto mock3 = std::make_unique<test::ElementMock>();
+        auto mock1 = make_unique<test::ElementMock>();
+        auto mock2 = make_unique<test::ElementMock>();
+        auto mock3 = make_unique<test::ElementMock>();
 
         const auto mock1ptr = mock1.get();
         const auto mock2ptr = mock2.get();

--- a/test/refract/dsd/test-Select.cc
+++ b/test/refract/dsd/test-Select.cc
@@ -78,7 +78,7 @@ SCENARIO("`Select` is inserted to and erased from", "[ElementData][Select]")
 
         WHEN("an ElementMock is pushed back")
         {
-            auto mock = std::make_unique<test::ElementMock>();
+            auto mock = make_unique<test::ElementMock>();
             auto mock1ptr = mock.get();
 
             REQUIRE(test::ElementMock::instances().size() == 1);
@@ -114,18 +114,18 @@ SCENARIO("`Select` is inserted to and erased from", "[ElementData][Select]")
 
             WHEN("another three ElementMocks are inserted at begin two at end")
             {
-                auto mock2 = std::make_unique<test::ElementMock>();
-                auto mock3 = std::make_unique<test::ElementMock>();
-                auto mock4 = std::make_unique<test::ElementMock>();
+                auto mock2 = make_unique<test::ElementMock>();
+                auto mock3 = make_unique<test::ElementMock>();
+                auto mock4 = make_unique<test::ElementMock>();
 
                 select.insert(select.begin(), make_element<OptionElement>(std::move(mock2)));
                 select.insert(select.begin(), make_element<OptionElement>(std::move(mock3)));
                 select.insert(select.begin(), make_element<OptionElement>(std::move(mock4)));
 
-                auto mock5 = std::make_unique<test::ElementMock>();
+                auto mock5 = make_unique<test::ElementMock>();
                 auto mock5ptr = mock.get();
 
-                auto mock6 = std::make_unique<test::ElementMock>();
+                auto mock6 = make_unique<test::ElementMock>();
 
                 select.insert(select.begin(), make_element<OptionElement>(std::move(mock5)));
                 select.insert(select.begin(), make_element<OptionElement>(std::move(mock6)));
@@ -189,7 +189,7 @@ SCENARIO("`Select` is inserted to and erased from", "[ElementData][Select]")
 
             WHEN("another ElementMock is pushed back")
             {
-                auto mock2 = std::make_unique<test::ElementMock>();
+                auto mock2 = make_unique<test::ElementMock>();
                 auto mock2ptr = mock2.get();
 
                 auto mock2Option = make_element<OptionElement>(std::move(mock2));
@@ -261,17 +261,17 @@ SCENARIO("`Select` is move-constructed from elements", "[ElementData][Select]")
     {
         REQUIRE(test::ElementMock::instances().size() == 0);
 
-        auto mock1 = std::make_unique<test::ElementMock>();
+        auto mock1 = make_unique<test::ElementMock>();
         const auto mock1ptr = mock1.get();
         auto mock1Option = make_element<OptionElement>(std::move(mock1));
         const auto mock1OptionPtr = mock1Option.get();
 
-        auto mock2 = std::make_unique<test::ElementMock>();
+        auto mock2 = make_unique<test::ElementMock>();
         const auto mock2ptr = mock2.get();
         auto mock2Option = make_element<OptionElement>(std::move(mock2));
         const auto mock2OptionPtr = mock2Option.get();
 
-        auto mock3 = std::make_unique<test::ElementMock>();
+        auto mock3 = make_unique<test::ElementMock>();
         const auto mock3ptr = mock3.get();
         auto mock3Option = make_element<OptionElement>(std::move(mock3));
         const auto mock3OptionPtr = mock3Option.get();

--- a/test/refract/test-Utils.cc
+++ b/test/refract/test-Utils.cc
@@ -20,6 +20,27 @@ namespace
     struct foo : public tracked<foo> {
         int bar_ = 42;
     };
+
+    struct VoidCaptureVisitor {
+        const IElement** arg;
+        template <typename ElementT>
+        void operator()(const ElementT& el)
+        {
+            assert(arg);
+            *arg = &el;
+        }
+    };
+
+    struct VoidCaptureReturning42Visitor {
+        const IElement** arg;
+        template <typename ElementT>
+        int operator()(const ElementT& el)
+        {
+            assert(arg);
+            *arg = &el;
+            return 42;
+        }
+    };
 } // namespace
 
 SCENARIO("Elements are visited by a void() visitor", "[Element][utils][visitor]")
@@ -31,7 +52,7 @@ SCENARIO("Elements are visited by a void() visitor", "[Element][utils][visitor]"
         WHEN("it is visited by a void visitor")
         {
             const IElement* arg = nullptr;
-            visit(b, [&arg](const auto& el) { arg = &el; });
+            visit(b, VoidCaptureVisitor{ &arg });
 
             THEN("the element is passed to the visitor by argument")
             {
@@ -50,10 +71,7 @@ SCENARIO("Elements are visited by a int() visitor", "[Element][utils][visitor]")
         WHEN("it is visited by a int() visitor returning 42")
         {
             const IElement* arg = nullptr;
-            const auto result = visit(b, [&arg](const auto& el) -> int {
-                arg = &el;
-                return 42;
-            });
+            const auto result = visit(b, VoidCaptureReturning42Visitor{ &arg });
 
             THEN("the element is passed to the visitor by argument")
             {

--- a/test/test-ApplyVisitorTest.cc
+++ b/test/test-ApplyVisitorTest.cc
@@ -287,7 +287,7 @@ TEST_CASE("Query Element name", "[Visitor]")
 
     ac.push_back(from_primitive("str"));
 
-    auto namedArrayPtr = [](auto& content) {
+    auto namedArrayPtr = [](dsd::Array& content) {
         auto namedArray = make_empty<ArrayElement>();
         namedArray->element("named");
 
@@ -297,7 +297,7 @@ TEST_CASE("Query Element name", "[Visitor]")
         return result;
     }(ac);
 
-    auto namedNumberPtr = [](auto& content) {
+    auto namedNumberPtr = [](dsd::Array& content) {
         auto namedNumber = make_empty<NumberElement>();
         namedNumber->element("named");
 

--- a/test/utils/so/test-JsonIo.cc
+++ b/test/utils/so/test-JsonIo.cc
@@ -22,8 +22,6 @@ using namespace drafter;
 using namespace utils;
 using namespace so;
 
-using namespace std::literals;
-
 namespace
 {
     const std::array<const char*, 30> utf8fixtures = {

--- a/test/utils/so/test-YamlIo.cc
+++ b/test/utils/so/test-YamlIo.cc
@@ -21,8 +21,6 @@ using namespace drafter;
 using namespace utils;
 using namespace so;
 
-using namespace std::literals;
-
 namespace
 {
     const std::array<const char*, 30> utf8fixtures = {


### PR DESCRIPTION
To support some old compilers, we are forced to go back to C++11.

Notably, this branch compiles with gcc>=4.8.3 and runs with respective libc; tested on docker image `lambci/lambda:build-nodejs8.10`.