### PR TITLE
Set NDEBUG on release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
     + MSON string now interpreted as String Element instead of Object Element
   ```
 
+* Release builds of Drafter will no longer include assertions, this prevents
+  the potential for development intended assertions to cause Drafter to abort.
+
 ## 4.0.0-pre.3 (2019-04-08)
 
 ### Enhancements

--- a/common.gypi
+++ b/common.gypi
@@ -48,6 +48,7 @@
         }
       },
       'Release': {
+        'defines': [ 'NDEBUG' ],
         'cflags': [ '-O3' ],
         'conditions': [
           ['target_arch=="x64"', {

--- a/src/refract/JsonSchema.cc
+++ b/src/refract/JsonSchema.cc
@@ -81,13 +81,15 @@ namespace
     std::string key(const MemberElement& m)
     {
         if (const auto& strKey = get<const StringElement>(m.get().key())) {
-            if (strKey->empty())
-                return "";
-            return strKey->get().get();
+            if (!strKey->empty()) {
+                return strKey->get().get();
+            }
         } else {
             LOG(error) << "Non-string key in Member Element: " << m.get().key()->element();
             assert(false);
         }
+
+        return "";
     }
 
 } // namespace

--- a/src/refract/dsd/Traits.h
+++ b/src/refract/dsd/Traits.h
@@ -8,7 +8,6 @@
 #ifndef REFRACT_DSD_TRAITS_H
 #define REFRACT_DSD_TRAITS_H
 
-#include <cassert>
 #include <iterator>
 #include <type_traits>
 
@@ -180,8 +179,7 @@ namespace refract
             ///
             void clear()
             {
-                auto e = self().erase(self().begin(), self().end());
-                assert(e == self().end());
+                self().erase(self().begin(), self().end());
             }
 
             ///
@@ -195,8 +193,7 @@ namespace refract
             ///
             void push_back(value_type el)
             {
-                auto it = self().insert(self().end(), std::move(el));
-                assert(std::next(it) == self().end());
+                self().insert(self().end(), std::move(el));
             }
         };
     }


### PR DESCRIPTION
Verified using example from #682.

Before:

```
$ ./bin/drafter 682.apib -l
Assertion failed: (false), function renderProperty, file ../src/refract/JsonValue.cc, line 95.
fish: './bin/drafter bb.apib -l' terminated by signal SIGABRT (Abort)
```

After:

```shell
$ ./bin/drafter 682.apib -l

OK.
```