### PR TITLE
Test on CI with gyp on GCC 4.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
   test-gyp:
     <<: *test-base-legacy
     docker:
-      - image: gcc:5.4
+      - image: gcc:4.8.5
 
   test-gcc-49-debug:
     <<: *test-base

--- a/src/refract/JsonSchema.cc
+++ b/src/refract/JsonSchema.cc
@@ -273,10 +273,10 @@ namespace
     }
 
     struct ObjectSchema {
-        so::Object properties;
-        so::Object patternProperties;
-        so::Array required;
-        so::Array allOf;
+        so::Object properties = {};
+        so::Object patternProperties = {};
+        so::Array required = {};
+        so::Array allOf = {};
     };
 
     so::Object& materialize(so::Object& result, ObjectSchema s)


### PR DESCRIPTION
GCC 4.8 is the oldest compiler we support with gyp (in Protagonist) and we've introduced compiler support regressions such as https://github.com/apiaryio/drafter/pull/691. This can be avoided in the future if we CI against this version.