### PR TITLE
Fix "fixed" type attribute not inheriting for empty objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Drafter Changelog
 
+## Master
+
+### Bug Fixes
+
+* The `fixed` type attribute now inherits to empty objects. This regression was
+  introduced in 4.0.0-pre.1.
+
 ## 4.0.0-pre.5 (2019-05-07)
 
 ### Bug Fixes

--- a/src/refract/ElementUtils.cc
+++ b/src/refract/ElementUtils.cc
@@ -38,7 +38,7 @@ bool refract::inheritsFixed(const IElement& e)
 
 bool refract::inheritsFixed(const ObjectElement& e)
 {
-    return definesValue(e);
+    return true;
 }
 
 bool refract::inheritsFixed(const ArrayElement& e)

--- a/test/fixtures/schema/issue-686.apib
+++ b/test/fixtures/schema/issue-686.apib
@@ -1,0 +1,6 @@
+# GET /
+
++ Response 200 (application/json)
+    + Attributes
+        + result (object, fixed)
+            + obj_member (object)

--- a/test/fixtures/schema/issue-686.json
+++ b/test/fixtures/schema/issue-686.json
@@ -1,0 +1,184 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": ""
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "meta": {
+            "title": {
+              "element": "string",
+              "content": ""
+            }
+          },
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": ""
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "object",
+                            "content": [
+                              {
+                                "element": "member",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "result"
+                                  },
+                                  "value": {
+                                    "element": "object",
+                                    "content": [
+                                      {
+                                        "element": "member",
+                                        "content": {
+                                          "key": {
+                                            "element": "string",
+                                            "content": "obj_member"
+                                          },
+                                          "value": {
+                                            "element": "object"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{\n  \"result\": {\n    \"obj_member\": {}\n  }\n}"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBodySchema"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/schema+json"
+                            }
+                          },
+                          "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"result\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"obj_member\": {\n          \"type\": \"object\"\n        }\n      },\n      \"required\": [\n        \"obj_member\"\n      ],\n      \"additionalProperties\": false\n    }\n  }\n}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/schema/issue-686.json
+++ b/test/fixtures/schema/issue-686.json
@@ -168,7 +168,7 @@
                               "content": "application/schema+json"
                             }
                           },
-                          "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"result\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"obj_member\": {\n          \"type\": \"object\"\n        }\n      },\n      \"required\": [\n        \"obj_member\"\n      ],\n      \"additionalProperties\": false\n    }\n  }\n}"
+                          "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"result\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"obj_member\": {\n          \"type\": \"object\",\n          \"additionalProperties\": false\n        }\n      },\n      \"required\": [\n        \"obj_member\"\n      ],\n      \"additionalProperties\": false\n    }\n  }\n}"
                         }
                       ]
                     }

--- a/test/test-SchemaTest.cc
+++ b/test/test-SchemaTest.cc
@@ -115,3 +115,4 @@ TEST_REFRACT("schema", "one-of-complex");
 TEST_REFRACT("schema", "one-of-properties");
 
 TEST_REFRACT("schema", "issue-493-multiple-same-required");
+TEST_REFRACT("schema", "issue-686");


### PR DESCRIPTION
For some reason, the logic for inheriting "fixed" requires an object to have a value. An empty object should inherit fixed too.