### PR TITLE
Add some missing checks for circular references

### DIFF
--- a/src/NamedTypesRegistry.cc
+++ b/src/NamedTypesRegistry.cc
@@ -264,20 +264,24 @@ namespace drafter
 
             bool hasAncestor(const snowcrash::DataStructure* object, const snowcrash::DataStructure* ancestor) const
             {
-                std::string s = name(object);
-                const std::string& isAncestor = name(ancestor);
+                std::vector<std::string> symbols;
 
-                while (!s.empty()) {
-                    if (s == isAncestor) {
-                        return true;
-                    }
+                const std::string& object_typename = name(object);
+                const std::string& ancestor_typename = name(ancestor);
 
-                    InheritanceMap::const_iterator i = childToParent.find(s);
-                    if (i == childToParent.end()) {
-                        return false;
-                    }
+                auto current_typename = object_typename;
 
-                    s = i->second;
+                while (true) {
+                    if (current_typename == ancestor_typename)
+                        return true; // found ancestor (happy path)
+                    auto next_typename = childToParent.find(current_typename);
+                    if (next_typename == childToParent.end())
+                        return false; // arrived at the end
+
+                    if (symbols.end() != std::find(symbols.begin(), symbols.end(), current_typename))
+                        return false; // circular reference
+                    symbols.emplace_back(current_typename);
+                    current_typename = next_typename->second;
                 }
 
                 return false;

--- a/test/fixtures/api/issue-702.apib
+++ b/test/fixtures/api/issue-702.apib
@@ -1,0 +1,30 @@
+# API name
+
+## Group Instances
+
+### Instance Model [/{instance-id}]
+
+
+## Group Profiles
+
+### Profiles Collection [/profiles]
+            
+#### Create Profile [POST]
+
++ Attributes (Profile)
+
++ Request (application/json)
+   
+        + Body
+        
+                {}
+        
+        + Schema 
+        
+                {}
+        
+
+### Profile [/v1/profiles/{id}]
+
++ Attributes (Profile)
+

--- a/test/fixtures/api/issue-702.json
+++ b/test/fixtures/api/issue-702.json
@@ -1,0 +1,496 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "API name"
+        }
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "resourceGroup"
+                }
+              ]
+            },
+            "title": {
+              "element": "string",
+              "content": "Instances"
+            }
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "Instance Model"
+                }
+              },
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "content": "/{instance-id}"
+                }
+              },
+              "content": []
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "resourceGroup"
+                }
+              ]
+            },
+            "title": {
+              "element": "string",
+              "content": "Profiles"
+            }
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "Profiles Collection"
+                }
+              },
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "content": "/profiles"
+                }
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": {
+                      "element": "string",
+                      "content": "Create Profile"
+                    }
+                  },
+                  "attributes": {
+                    "data": {
+                      "element": "dataStructure",
+                      "content": {
+                        "element": "Profile"
+                      }
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": {
+                              "element": "string",
+                              "content": "POST"
+                            },
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": {
+                                  "element": "array",
+                                  "content": [
+                                    {
+                                      "element": "string",
+                                      "content": "messageBody"
+                                    }
+                                  ]
+                                }
+                              },
+                              "attributes": {
+                                "contentType": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              },
+                              "content": "+ Body\n\n        {}\n\n+ Schema \n\n        {}\n"
+                            }
+                          ]
+                        },
+                        {
+                          "element": "httpResponse",
+                          "content": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "element": "resource",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "Profile"
+                }
+              },
+              "attributes": {
+                "href": {
+                  "element": "string",
+                  "content": "/v1/profiles/{id}"
+                }
+              },
+              "content": [
+                {
+                  "element": "dataStructure",
+                  "content": {
+                    "element": "Profile",
+                    "meta": {
+                      "id": {
+                        "element": "string",
+                        "content": "Profile"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 12
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 5
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
+                      "content": 32
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 7
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
+                      "content": 38
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "URI template expression \"instance-id\" contains hyphens. Allowed characters for expressions are A-Z a-z 0-9 _ and percent encoded characters"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 10
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 18
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 5
+                        }
+                      },
+                      "content": 227
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 19
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
+                      "content": 12
+                    }
+                  ]
+                },
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 20
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 5
+                        }
+                      },
+                      "content": 251
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 21
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
+                      "content": 16
+                    }
+                  ]
+                },
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 22
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 5
+                        }
+                      },
+                      "content": 279
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 23
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
+                      "content": 15
+                    }
+                  ]
+                },
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 24
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 5
+                        }
+                      },
+                      "content": 306
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 24
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 19
+                        }
+                      },
+                      "content": 15
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "excessive indentation, message-body section is expected to be indented by just 8 spaces or 2 tabs"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 6
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 12
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
+                      "content": 138
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 13
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
+                      "content": 28
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "action is missing a response for a request"
+    }
+  ]
+}

--- a/test/test-RefractAPITest.cc
+++ b/test/test-RefractAPITest.cc
@@ -35,3 +35,5 @@ TEST_REFRACT("api", "attributes-named-type-mixin");
 TEST_REFRACT("api", "attributes-named-type-enum-reference");
 
 TEST_REFRACT("api", "mixin-inheritance");
+
+TEST_REFRACT("api", "issue-702");


### PR DESCRIPTION
## TL;DR
- fixes #702 

## More
Semantic analysis (drafter) was dependent on the parser (snowcrash) to short out circular dependencies of MSON types. If snowcrash failed to do so, we would fall into infinite loops resolving dependency paths in our type registry. That has been prevented.