### PR TITLE
Skip invalid One Of entries

### DIFF
--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -1294,7 +1294,9 @@ namespace
                     std::back_inserter(option->get()),
                     context);
             } else {
-                option->get().push_back(MsonElementToRefract(oneOfInfo, context, mson::StringTypeName));
+                if (auto apie = MsonElementToRefract(oneOfInfo, context, mson::StringTypeName)) {
+                    option->get().push_back(std::move(apie));
+                }
             }
 
             select->get().push_back(std::move(option));

--- a/test/fixtures/mson/issue-699.apib
+++ b/test/fixtures/mson/issue-699.apib
@@ -1,0 +1,7 @@
+# GET /
+
++ Request (application/json)
+    + Attributes
+        + One Of
+            + 
+

--- a/test/fixtures/mson/issue-699.json
+++ b/test/fixtures/mson/issue-699.json
@@ -1,0 +1,214 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": ""
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "meta": {
+            "title": {
+              "element": "string",
+              "content": ""
+            }
+          },
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": ""
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "object",
+                            "content": [
+                              {
+                                "element": "select",
+                                "content": [
+                                  {
+                                    "element": "option",
+                                    "content": []
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{}"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBodySchema"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/schema+json"
+                            }
+                          },
+                          "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"allOf\": [\n    {\n      \"oneOf\": [\n        {}\n      ]\n    }\n  ]\n}"
+                        }
+                      ]
+                    },
+                    {
+                      "element": "httpResponse",
+                      "content": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 6
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 1
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
+                      "content": 0
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 2
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 1
+                        }
+                      },
+                      "content": 9
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "action is missing a response for a request"
+    }
+  ]
+}

--- a/test/test-RefractDataStructureTest.cc
+++ b/test/test-RefractDataStructureTest.cc
@@ -60,6 +60,7 @@ TEST_MSON_SUCCESS("enumerations");
 TEST_REFRACT("mson", "issue-682");
 TEST_REFRACT("mson", "issue-682-b");
 TEST_REFRACT("mson", "issue-689");
+TEST_REFRACT("mson", "issue-699");
 
 #undef TEST_MSON_SUCCESS
 #undef TEST_MSON


### PR DESCRIPTION
Fixes #699 by skipping invalid One Of entries when translating MSON to
API Elements.

In the example in #699, the parser (snowcrash) should skip the invalid
One Of even before it arrives in semantic analysis. Because we are planning
a complete rewrite of our parser, this issue was fixed during
semantic analysis (drafter).