### PR TITLE
Add coverage to CI via ctest_coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,12 @@ aliases:
       command: |
           ctest -VV -j4 -S cmake/unix.cmake -DCTEST_BUILD_TYPE=Release -DCTEST_BUILD_NAME="gcc $(c++ -dumpversion)"
 
+  - &coverage
+    run:
+      name: Build drafter/release with gcc
+      command: |
+          ctest -VV -j4 -S cmake/unix-coverage.cmake -DCTEST_BUILD_TYPE=Debug -DCTEST_BUILD_NAME="coverage $(c++ -dumpversion)"
+
   - &update-submodules
     run:
       name: Update submodules
@@ -72,6 +78,7 @@ workflows:
       - test-osx-debug: *tag-filter
       - test-gyp: *tag-filter
       - test-valgrind: *tag-filter
+      - test-coverage: *tag-filter
       - release:
           requires:
             - test-gcc-49-debug
@@ -227,6 +234,16 @@ jobs:
 
       - store_artifacts:
           path: artifacts
+
+  test-coverage:
+    <<: *test-base
+    steps:
+      - checkout
+      - <<: *update-submodules
+      - <<: *coverage
+    docker:
+      - image: apiaryio/drafter-ci:gcc-latest
+
 
   release:
     docker:

--- a/cmake/unix-coverage.cmake
+++ b/cmake/unix-coverage.cmake
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.6)
+
+if("${CTEST_BUILD_NAME}" STREQUAL "")
+    set(CTEST_BUILD_NAME "${CTEST_BUILD_TYPE}")
+else()
+    set(CTEST_BUILD_NAME "${CTEST_BUILD_TYPE}/${CTEST_BUILD_NAME}")
+endif()
+
+set(CTEST_SOURCE_DIRECTORY ".")
+set(CTEST_BINARY_DIRECTORY "build")
+
+set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+
+set(CTEST_USE_LAUNCHERS 1)
+set(CTEST_COVERAGE_COMMAND "/usr/bin/gcov")
+set(CTEST_COVERAGE_EXTRA_FLAGS --preserve-paths)
+set(Drafter_CONFIG_OPTIONS
+    "-DCMAKE_CXX_FLAGS=--coverage"
+    "-DINTEGRATION_TESTS=ON"
+)
+
+set(CTEST_MODEL "Continuous")
+
+ctest_read_custom_files(${CTEST_BINARY_DIRECTORY})
+
+ctest_start(${CTEST_MODEL} TRACK ${CTEST_MODEL})
+ctest_configure(BUILD ${CTEST_BINARY_DIRECTORY} OPTIONS "${Drafter_CONFIG_OPTIONS}" RETURN_VALUE ret_con)
+ctest_build(BUILD ${CTEST_BINARY_DIRECTORY} RETURN_VALUE ret_bld)
+
+if(ret_bld EQUAL 0)
+    ctest_test(BUILD ${CTEST_BINARY_DIRECTORY} RETURN_VALUE ret_tst)
+endif()
+
+if(ret_bld EQUAL 0)
+    ctest_coverage(BUILD ${CTEST_BINARY_DIRECTORY} RETURN_VALUE ret_gcov CAPTURE_CMAKE_ERROR ret_gcov_cmake)
+endif()
+
+ctest_submit(RETURN_VALUE ret_sub)
+
+if(NOT ret_con EQUAL 0)
+    message(FATAL_ERROR "CI failing on config")
+endif()
+
+if(NOT ret_bld EQUAL 0)
+    message(FATAL_ERROR "CI failing on build")
+endif()
+
+if(NOT ret_tst EQUAL 0)
+    message(FATAL_ERROR "CI failing on tests")
+endif()
+
+if(NOT ret_gcov EQUAL 0)
+    message(WARNING "Coverage failed with ${ret_gcov}")
+endif()
+
+if(NOT ret_sub EQUAL 0)
+    message(WARNING "Unable to submit results to CDash")
+endif()


### PR DESCRIPTION
Generate test coverage when running ctest with the script `cmake/unix-coverage.cmake`.

## Notes
* `gcov` coverage files are in `build/Testing/CoverageInfo/` after running
   ```
   $drafter> ctest -S cmake/unix-coverage.cmake
   ```
   For example:
   ```
        -:    0:Source:/home/tj/projects/apiary/drafter/src/refract/dsd/Number.cc
        -:    0:Graph:/home/tj/projects/apiary/drafter/build/src/CMakeFiles/drafter.dir/refract/dsd/Number.cc.gcno
        -:    0:Data:/home/tj/projects/apiary/drafter/build/src/CMakeFiles/drafter.dir/refract/dsd/Number.cc.gcda
        -:    0:Runs:1
        -:    0:Programs:1
        -:    1://
        -:    2://  refract/dsd/Number.cc
        -:    3://  librefract
        -:    4://
        -:    5://  Created by Thomas Jandecka on 04/09/2017
        -:    6://  Copyright (c) 2017 Apiary Inc. All rights reserved.
        -:    7://
        -:    8:
        -:    9:#include "Number.h"
        -:   10:
        -:   11:#include "Traits.h"
        -:   12:#include "../../utils/log/Trivial.h"
        -:   13:
        -:   14:using namespace refract;
        -:   15:using namespace dsd;
        -:   16:using namespace drafter::utils::log;
        -:   17:
        -:   18:const char* Number::name = "number";
        -:   19:
        -:   20:static_assert(!supports_erase<Number>::value, "");
        -:   21:static_assert(!supports_empty<Number>::value, "");
        -:   22:static_assert(!supports_insert<Number>::value, "");
        -:   23:static_assert(!supports_push_back<Number>::value, "");
        -:   24:static_assert(!supports_begin<Number>::value, "");
        -:   25:static_assert(!supports_end<Number>::value, "");
        -:   26:static_assert(!supports_size<Number>::value, "");
        -:   27:static_assert(!supports_erase<Number>::value, "");
        -:   28:static_assert(!supports_key<Number>::value, "");
        -:   29:static_assert(!supports_value<Number>::value, "");
        -:   30:static_assert(!supports_merge<Number>::value, "");
        -:   31:static_assert(!is_iterable<Number>::value, "");
        -:   32:static_assert(!is_pair<Number>::value, "");
        -:   33:
      366:   34:Number::Number(std::string v) noexcept : value_(v) {}
        -:   35:
     1856:   36:const std::string& Number::get() const noexcept
        -:   37:{
     1856:   38:    return value_;
        -:   39:}
        -:   40:
    #####:   41:Number::operator std::int64_t() const noexcept
        -:   42:{
        -:   43:    std::string::size_type idx;
    #####:   44:    std::int64_t result = std::stoi(value_, &idx);
    #####:   45:    if (idx < value_.size())
    #####:   46:        LOG(warning) << "dsd::Number to int; dropped trailing `" << value_.substr(idx) << "`";
    #####:   47:    return result;
        -:   48:}
        -:   49:
       79:   50:bool dsd::operator==(const Number& lhs, const Number& rhs) noexcept
        -:   51:{
       79:   52:    return lhs.get() == rhs.get();
        -:   53:}
        -:   54:
        3:   55:bool dsd::operator!=(const Number& lhs, const Number& rhs) noexcept
        -:   56:{
        3:   57:    return !(lhs == rhs);
        -:   58:}

   ```
* Currently, we don't have a way to show coverage reports in CI, because we've reached our maximum submissions on CDash. Either that will be solved in the coming days or we will find an alternative.