### PR TITLE
Remove GYP configuration from release tarballs

### DIFF
--- a/tools/make-tarball.sh
+++ b/tools/make-tarball.sh
@@ -29,7 +29,7 @@ $(pwd)/tools/make-tarball.sh checkout $TMPDIR/$DIR/
 (
   # Remove unnessecery files
   cd $TMPDIR/$DIR
-  rm -fr appveyor.yml circle.yml .npmignore tools/*.{sh,py} tools/homebrew package.json emcc/
+  rm -fr appveyor.yml .circleci .clang-format ARCHITECTURE.md .git* Dockerfile Gemfile* *.gyp *.gypi vcbuild.bat tools *.xcodeproj *.xcworkspace
 )
 
 (


### PR DESCRIPTION
We're distributing GYP source (in `tools/`) and the GYP configuration which is no longer supported in the release tarballs, this PR removes GYP completely from these tarballs, CMake is the only supported way to build and install Drafter releases.

The release tarball script was a little outdated and tried to remove files that have been renamed (CircleCI config) or are non-existant. I've updated some of these rules too.

The tarball looks something like the following after this patch:

```
x drafter-v4.0.0-pre.7/
x drafter-v4.0.0-pre.7/CMakeLists.txt
x drafter-v4.0.0-pre.7/LICENSE
x drafter-v4.0.0-pre.7/test/
x drafter-v4.0.0-pre.7/cmake/
x drafter-v4.0.0-pre.7/configure
x drafter-v4.0.0-pre.7/CHANGELOG.md
x drafter-v4.0.0-pre.7/Makefile
x drafter-v4.0.0-pre.7/CTestConfig.cmake
x drafter-v4.0.0-pre.7/ext/
x drafter-v4.0.0-pre.7/features/
x drafter-v4.0.0-pre.7/README.md
x drafter-v4.0.0-pre.7/DefaultBuildType.cmake
x drafter-v4.0.0-pre.7/integration.cmake
x drafter-v4.0.0-pre.7/cmake/unix.cmake
x drafter-v4.0.0-pre.7/cmake/unix-ubsan.cmake
x drafter-v4.0.0-pre.7/cmake/unix-coverage.cmake
```