### PR TITLE
(fix): issue #719 - escaping keys in generated JSON/JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug Fixes
 
+* Fix escaping keys in generated JSON/JSON-Scheme in generated assets
+  [#719](https://github.com/apiaryio/drafter/issues/719)
+
 * When using a type hint with an array, for example `array[Unknown]`. We will now
   emit a warning when the referenced type does not exist. The invalid type
   reference will not be present in the parse result.

--- a/src/utils/so/JsonIo.cc
+++ b/src/utils/so/JsonIo.cc
@@ -160,7 +160,9 @@ namespace
             if (!Packed)
                 break_indent(out, indent + 1);
 
-            out << '"' << m.first << "\":";
+            out << '"';
+            escape_json_string(m.first.begin(), m.first.end(), std::ostream_iterator<char>(out));
+            out << "\":";
 
             if (!Packed)
                 out << ' ';

--- a/test/fixtures/mson/variable-property-name.json
+++ b/test/fixtures/mson/variable-property-name.json
@@ -126,7 +126,7 @@
                                   "content": "application/json"
                                 }
                               },
-                              "content": "{\n  \"s\": \"start\",\n  \"direct\": \"v1\",\n  \"str\": \"v2\",\n  \"str sample\n\n\": \"s1\",\n  \"ss\": \"s2\",\n  \"str default\n\n\": \"d1\",\n  \"sd\": \"d2\",\n  \"se\": \"e2\",\n  \"e\": \"end\"\n}"
+                              "content": "{\n  \"s\": \"start\",\n  \"direct\": \"v1\",\n  \"str\": \"v2\",\n  \"str sample\\n\\n\": \"s1\",\n  \"ss\": \"s2\",\n  \"str default\\n\\n\": \"d1\",\n  \"sd\": \"d2\",\n  \"se\": \"e2\",\n  \"e\": \"end\"\n}"
                             },
                             {
                               "element": "asset",

--- a/test/utils/so/test-JsonIo.cc
+++ b/test/utils/so/test-JsonIo.cc
@@ -76,6 +76,11 @@ R"JSON({
   "bar": 5
 })JSON"};
 
+const std::string shallow_object_indented_with_escaped_key = {
+R"JSON({
+  "href\"": "Hello world!"
+})JSON"};
+
 const std::string shallow_object_packed = {
 R"JSON({"foo":"Hello world!","bar":5})JSON"};
 
@@ -437,6 +442,24 @@ SCENARIO("Serialize a utils::so::Value into indented and/or packed JSON", "[simp
             THEN("the stringstream contains: {\"foo\":\"Hello world!\",\"bar\":5}")
             {
                 REQUIRE(ss.str() == shallow_object_packed);
+            }
+        }
+    }
+
+    GIVEN("an in place constructed Object{`href\"` -> String{`Hello world!`}")
+    {
+        Value value(mpark::in_place_type_t<Object>{}, //
+            from_list{},
+            std::make_pair("href\"", String{ "Hello world!" }));
+
+        WHEN("it is serialized into stringstream as indented JSON")
+        {
+            std::stringstream ss;
+            serialize_json(ss, value);
+
+            THEN("the stringstream contains correctly escaped key {\\n  \"href\\\\\\\": \"Hello world!\"\\n}")
+            {
+                REQUIRE(ss.str() == shallow_object_indented_with_escaped_key);
             }
         }
     }


### PR DESCRIPTION
closes #719 