### PR TITLE
Remove markdown-parser debug logging

### DIFF
--- a/ext/snowcrash/ext/markdown-parser/src/MarkdownNode.cc
+++ b/ext/snowcrash/ext/markdown-parser/src/MarkdownNode.cc
@@ -6,6 +6,10 @@
 //  Copyright (c) 2014 Apiary Inc. All rights reserved.
 //
 
+#ifdef DEBUG
+#include <iostream>
+#endif
+
 #include "MarkdownNode.h"
 
 using namespace mdp;
@@ -79,67 +83,69 @@ const MarkdownNodes& MarkdownNode::children() const
     return *m_children;
 }
 
+#ifdef DEBUG
 void MarkdownNode::printNode(size_t level) const
 {
-    using std::cout;
+    using std::cerr;
     for (size_t i = 0; i < level; ++i)
-        std::cout << "  ";
+        cerr << "  ";
 
-    cout << "+ ";
+    cerr << "+ ";
     switch (type) {
         case RootMarkdownNodeType:
-            cout << "root";
+            cerr << "root";
             break;
 
         case CodeMarkdownNodeType:
-            cout << "code";
+            cerr << "code";
             break;
 
         case QuoteMarkdownNodeType:
-            cout << "quote";
+            cerr << "quote";
             break;
 
         case HTMLMarkdownNodeType:
-            cout << "HTML";
+            cerr << "HTML";
             break;
 
         case HeaderMarkdownNodeType:
-            cout << "header";
+            cerr << "header";
             break;
 
         case HRuleMarkdownNodeType:
-            cout << "hrul";
+            cerr << "hrul";
             break;
 
         case ListItemMarkdownNodeType:
-            cout << "list item";
+            cerr << "list item";
             break;
 
         case ParagraphMarkdownNodeType:
-            cout << "paragraph";
+            cerr << "paragraph";
             break;
 
         default:
-            cout << "undefined";
+            cerr << "undefined";
             break;
     }
 
-    cout << " (type " << type << ", data " << data << ") - ";
-    cout << "`" << text << "`";
+    cerr << " (type " << type << ", data " << data << ") - ";
+    cerr << "`" << text << "`";
 
     if (!sourceMap.empty()) {
         for (mdp::BytesRangeSet::const_iterator it = sourceMap.begin(); it != sourceMap.end(); ++it) {
-            std::cout << ((it == sourceMap.begin()) ? " :" : ";");
-            std::cout << it->location << ":" << it->length;
+            std::cerr << ((it == sourceMap.begin()) ? " :" : ";");
+            std::cerr << it->location << ":" << it->length;
         }
     }
 
-    cout << std::endl;
+    cerr << std::endl;
 
     for (MarkdownNodeIterator it = m_children->begin(); it != m_children->end(); ++it) {
         it->printNode(level + 1);
     }
 
     if (level == 0)
-        cout << std::endl << std::endl;
+        cerr << std::endl << std::endl;
 }
+#endif

--- a/ext/snowcrash/ext/markdown-parser/src/MarkdownNode.h
+++ b/ext/snowcrash/ext/markdown-parser/src/MarkdownNode.h
@@ -11,7 +11,6 @@
 
 #include <deque>
 #include <memory>
-#include <iostream>
 #include "ByteBuffer.h"
 
 namespace mdp
@@ -91,8 +90,10 @@ namespace mdp
         /** Destructor */
         ~MarkdownNode();
 
-        /** Prints the node to the stdout */
+#ifdef DEBUG
+        /** Prints the node to the stderr */
         void printNode(size_t level = 0) const;
+#endif
 
     private:
         MarkdownNode* m_parent;

--- a/ext/snowcrash/ext/markdown-parser/src/MarkdownParser.cc
+++ b/ext/snowcrash/ext/markdown-parser/src/MarkdownParser.cc
@@ -57,10 +57,6 @@ void MarkdownParser::parse(const ByteBuffer& source, MarkdownNode& ast)
     m_source = NULL;
     m_sourceLength = 0;
     m_listBlockContext = false;
-
-#ifdef DEBUG
-    ast.printNode();
-#endif
 }
 
 MarkdownParser::RenderCallbacks MarkdownParser::renderCallbacks()


### PR DESCRIPTION
As per https://github.com/apiaryio/drafter/pull/725#pullrequestreview-258008645, this probably isn't usful. Tools like lldb/gdb exist which can make debugging experiance better.