### PR TITLE
Windows cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
+project(DrafterProjects)
 
 include(DefaultBuildType.cmake)
 

--- a/ext/snowcrash/CMakeLists.txt
+++ b/ext/snowcrash/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     set(snowcrash_SOURCES ${snowcrash_SOURCES} src/posix/RegexMatch.cc)
 endif()
 
-add_library(snowcrash SHARED ${snowcrash_SOURCES})
+add_library(snowcrash ${snowcrash_SOURCES})
 
 find_package(markdown-parser 1.0 REQUIRED)
 

--- a/ext/snowcrash/ext/markdown-parser/CMakeLists.txt
+++ b/ext/snowcrash/ext/markdown-parser/CMakeLists.txt
@@ -52,11 +52,11 @@ set(MARKDOWN_PARSER_COMPILE_FEATURES
     cxx_template_template_parameters
     )
 
-add_library(markdown-parser SHARED ${MARKDOWN_PARSER_SOURCES})
+add_library(markdown-parser ${MARKDOWN_PARSER_SOURCES})
 
 find_package(Sundown 1.0 REQUIRED)
 
-target_link_libraries(markdown-parser PUBLIC Apiary::sundown-pic)
+target_link_libraries(markdown-parser PUBLIC Apiary::sundown)
 
 target_include_directories(markdown-parser PUBLIC
     $<BUILD_INTERFACE:${markdown-parser_BINARY_DIR}/src>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,9 +74,9 @@ set(DRAFTER_COMPILE_FEATURES
     )
 
 # libdrafter
-add_library(drafter SHARED ${DRAFTER_SOURCES})
+add_library(drafter ${DRAFTER_SOURCES})
 
-set_target_properties(drafter PROPERTIES PUBLIC_HEADER "drafter.h")
+set_target_properties(drafter PROPERTIES PUBLIC_HEADER "drafter.h" WINDOWS_EXPORT_ALL_SYMBOLS 1)
 
 # production dependencies
 find_package(snowcrash 1.0 REQUIRED)
@@ -99,7 +99,7 @@ target_include_directories(drafter PUBLIC
 
 target_compile_definitions(drafter PRIVATE BUILDING_DRAFTER=1)
 
-target_compile_definitions(drafter PUBLIC DRAFTER_BUILD_SHARED=1)
+target_compile_definitions(drafter PUBLIC DRAFTER_BUILD_STATIC=1)
 
 target_compile_features(drafter PUBLIC ${DRAFTER_COMPILE_FEATURES})
 

--- a/src/utils/Utf8.h
+++ b/src/utils/Utf8.h
@@ -213,7 +213,8 @@ namespace drafter
 
                 template <typename Container>
                 explicit constexpr input_iterator(const Container& last) noexcept //
-                    : input_iterator(last.begin(), last.end())
+                    : e_(last.end()),
+		      cp_and_next_(decode_one(last.begin(), last.end()))
                 {
                 }
 

--- a/src/utils/Utf8.h
+++ b/src/utils/Utf8.h
@@ -214,7 +214,7 @@ namespace drafter
                 template <typename Container>
                 explicit constexpr input_iterator(const Container& last) noexcept //
                     : e_(last.end()),
-		      cp_and_next_(decode_one(last.begin(), last.end()))
+                      cp_and_next_(decode_one(last.begin(), last.end()))
                 {
                 }
 


### PR DESCRIPTION
In Visual C++ 2015 Build Tools:
```
drafter> mkdir build
drafter> cd build
drafter/build> cmake .. -DCMAKE_INSTALL_PREFIX=..\install -DCMAKE_BUILD_TYPE=Release
drafter/build> cd ..
drafter> cmake --build build -t drafter-cli --config Release
drafter> cmake --build install -t drafter-cli --config Release
```
After a successful build, a standalone `drafter.exe` is located in `install/bin`.

### Notes
* can be improved without too much effort by generating a Windows installer via CPack
* introduction of a CTest dashboard script is not in the scope of this PR
* debug build fails to load the debug version of `ucrtbase.dll`, called `ucrtbased.dll`; that's expected, as Visual C++ 2015 Build Tools don't ship the debug version