### PR TITLE
Declassify internal APIs as deprecated

### DIFF
--- a/ext/snowcrash/src/Blueprint.h
+++ b/ext/snowcrash/src/Blueprint.h
@@ -306,19 +306,8 @@ namespace snowcrash
         /** Link Relation */
         Relation relation;
 
-        /**
-         *  \brief Action-specific HTTP headers
-         *
-         *  DEPRECATION WARNING:
-         *  --------------------
-         *
-         *  This AST node is build for deprecated API Blueprint syntax
-         *  and as such it will be removed in a future version of
-         *  Snow Crash.
-         *
-         *  Use respective payload's header collection instead.
-         */
-        DEPRECATED Headers headers;
+        /** Action-specific HTTP headers */
+        Headers headers;
 
         /** Transactions examples */
         TransactionExamples examples;
@@ -350,19 +339,8 @@ namespace snowcrash
         /** Parameters */
         Parameters parameters;
 
-        /**
-         *  \brief Resource-specific HTTP Headers
-         *
-         *  DEPRECATION WARNING:
-         *  --------------------
-         *
-         *  This AST node is build for deprecated API Blueprint syntax
-         *  and as such it will be removed in a future version of
-         *  Snow Crash.
-         *
-         *  Use respective payload's header collection instead.
-         */
-        DEPRECATED Headers headers;
+        /** Resource-specific HTTP Headers */
+        Headers headers;
 
         /** A set of Actions specified for this Resource */
         Actions actions;

--- a/ext/snowcrash/src/BlueprintSourcemap.h
+++ b/ext/snowcrash/src/BlueprintSourcemap.h
@@ -164,19 +164,8 @@ namespace snowcrash
         /** Source Map of Link Relation (THIS SHOULD NOT BE HERE - should be under element attributes) */
         SourceMap<Relation> relation;
 
-        /**
-         *  \brief Action-specific HTTP headers
-         *
-         *  DEPRECATION WARNING:
-         *  --------------------
-         *
-         *  This AST node is build for deprecated API Blueprint syntax
-         *  and as such it will be removed in a future version of
-         *  Snow Crash.
-         *
-         *  Use respective payload's header collection instead.
-         */
-        DEPRECATED SourceMap<Headers> headers;
+        /** Action-specific HTTP headers */
+        SourceMap<Headers> headers;
 
         /** Transactions examples */
         SourceMap<TransactionExamples> examples;
@@ -209,19 +198,8 @@ namespace snowcrash
         /** Parameters */
         SourceMap<Parameters> parameters;
 
-        /**
-         *  \brief Resource-specific HTTP Headers
-         *
-         *  DEPRECATION WARNING:
-         *  --------------------
-         *
-         *  This AST node is build for deprecated API Blueprint syntax
-         *  and as such it will be removed in a future version of
-         *  Snow Crash.
-         *
-         *  Use respective payload's header collection instead.
-         */
-        DEPRECATED SourceMap<Headers> headers;
+        /** Resource-specific HTTP Headers */
+        SourceMap<Headers> headers;
 
         /** A set of Actions specified for this Resource */
         SourceMap<Actions> actions;

--- a/ext/snowcrash/src/Platform.h
+++ b/ext/snowcrash/src/Platform.h
@@ -12,22 +12,4 @@
 #define AS_TYPE(Type, Obj) reinterpret_cast<Type*>(Obj)
 #define AS_CTYPE(Type, Obj) reinterpret_cast<const Type*>(Obj)
 
-#if defined(BUILDING_DRAFTER)
-#define DEPRECATED
-#endif
-
-#if defined(_MSC_VER)
-#if !defined(DEPRECATED)
-#define DEPRECATED __declspec(deprecated)
-#endif
-#elif defined(__clang__) || defined(__GNUC__)
-#if !defined(DEPRECATED)
-#define DEPRECATED __attribute__((deprecated))
-#endif
-#else
-#if !defined(DEPRECATED)
-#define DEPRECATED
-#endif
-#endif
-
 #endif

--- a/src/drafter.h
+++ b/src/drafter.h
@@ -13,24 +13,6 @@
 extern "C" {
 #endif
 
-#if defined(BUILDING_DRAFTER)
-#define DEPRECATED
-#endif
-
-#if defined(_MSC_VER)
-#if !defined(DEPRECATED)
-#define DEPRECATED __declspec(deprecated)
-#endif
-#elif defined(__clang__) || defined(__GNUC__)
-#if !defined(DEPRECATED)
-#define DEPRECATED __attribute__((deprecated))
-#endif
-#else
-#if !defined(DEPRECATED)
-#define DEPRECATED
-#endif
-#endif
-
 #ifndef DRAFTER_API
 #if defined _WIN32 || defined __CYGWIN__
 #if defined(DRAFTER_BUILD_SHARED) /* build dll */


### PR DESCRIPTION
The APIs of snowcrash are no longer public facing and thus deprecation warnings at
build time is not necessary (`-Wdeprecations`).

I believe the whole structure is deprecated internally, not sure that having DEPRECATION on these specific properties adds any value.