### PR TITLE
Avoid Visual C++ warning c4800 in MSON.h

### DIFF
--- a/ext/snowcrash/src/MSON.h
+++ b/ext/snowcrash/src/MSON.h
@@ -421,7 +421,7 @@ namespace mson
 
         bool empty() const noexcept
         {
-            return mpark::get_if<Empty>(&content);
+            return nullptr != mpark::get_if<Empty>(&content);
         }
 
         template <typename F>


### PR DESCRIPTION
Example:
```
c:\projects\drafter\ext\snowcrash\src\MSON.h(424): warning C4800: 'const mpark::monostate *': forcing value to bool 'true' or 'false' (performance warning) [C:\projects\drafter\build\ext\snowcrash\snowcrash.vcxproj]
  BlueprintSourcemap.cc
```