### PR TITLE
Update docker image to build with CMake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ workflows:
   drafter:
     jobs:
       - lint
+      - build: *tag-filter
       - test-gcc-49-debug: *tag-filter
       - test-gcc-49-release: *tag-filter
       - test-gcc-latest-debug: *tag-filter
@@ -95,6 +96,7 @@ workflows:
       - test-asan: *tag-filter
       - release:
           requires:
+            - build
             - test-gcc-49-debug
             - test-gcc-49-release
             - test-gcc-latest-debug
@@ -127,6 +129,17 @@ jobs:
           name: Verify THIRD_PARTY_LICENSES.txt
           command: |
             ./tools/third-party-licenses-check.sh
+
+  build:
+    docker:
+      - image: circleci/python:3.7
+
+    steps:
+      - checkout
+      - run: git submodule update --init --recursive
+      - setup_remote_docker
+      - run: docker build -t drafter .
+      - run: echo '# My API' | docker run -i drafter
 
   test-gyp:
     <<: *test-base-legacy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,25 @@
-FROM gcc
+FROM alpine:3.10 as build
 MAINTAINER Apiary "sre@apiary.io"
 
-ADD . /usr/src/drafter
 WORKDIR /usr/src/drafter
 
-RUN ./configure
+ADD CMakeLists.txt DefaultBuildType.cmake ./
+ADD src src
+ADD ext ext
+ADD test test
+
+WORKDIR /tmp/drafter
+
+RUN apk add --no-cache cmake make g++
+RUN cmake /usr/src/drafter
+
+RUN make drafter-cli
 RUN make install
 
-CMD /usr/local/bin/drafter
+FROM alpine:3.10
+
+RUN apk add --no-cache gcc
+COPY --from=build /usr/local/bin/drafter /usr/local/bin/drafter
+ADD LICENSE /usr/local/share/licenses/drafter/LICENSE
+
+CMD drafter


### PR DESCRIPTION
I realised the docker image isn't tested nor updated from GYP to CMake, this pull request solves both. We are now building and running the image in CI and building using CMake.

I've refactored the drafter image a bit to use Alpine to shrink the size down, making use of separate environments for build and running so we can remove build dependency slices from the image. This makes the image around 1.8GB smaller.

```
$ docker images | grep drafter
drafter           96MB
apiaryio/drafter  1.86GB
```