### PR TITLE
Fix support for MSVC 2019

### DIFF
--- a/ext/snowcrash/src/Just.h
+++ b/ext/snowcrash/src/Just.h
@@ -18,7 +18,7 @@ namespace mson
 
         T content;
 
-        just() noexcept(T()) : content{} {}
+        just() : content{} {}
 
         explicit just(T&& c) noexcept : content{ std::move(c) } {}
         explicit just(const T& c) : content{ c } {}


### PR DESCRIPTION
https://github.com/apiaryio/drafter/pull/726 broken MSVC 2019 compatibility, I was finding the following compiler error:

    ext\snowcrash\src\Just.h(21, 26): error C2131:  expression did not evaluate to a constant
    ext\snowcrash\src\Just.h(21, 1): error C2440:  'noexcept': cannot convert from 'T' to 'bool
    ...
    ext\snowcrash\src\Just.h(21, 26): message :  No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called

Fixes #738