### PR TITLE
Fix compatbility with MSVC and GYP

### DIFF
--- a/ext/snowcrash/ext/markdown-parser/src/MarkdownNode.cc
+++ b/ext/snowcrash/ext/markdown-parser/src/MarkdownNode.cc
@@ -15,10 +15,33 @@
 using namespace mdp;
 
 MarkdownNode::MarkdownNode(MarkdownNodeType type_, MarkdownNode* parent_, const ByteBuffer& text_, const Data& data_)
-    : type(type_), text(text_), data(data_), sourceMap(), m_parent(parent_), m_children(nullptr)
+    : type(type_), text(text_), data(data_), m_parent(parent_)
 {
     m_children.reset(::new MarkdownNodes);
 }
+
+MarkdownNode::MarkdownNode(const MarkdownNode& rhs)
+{
+    this->type = rhs.type;
+    this->text = rhs.text;
+    this->data = rhs.data;
+    this->sourceMap = rhs.sourceMap;
+    this->m_children.reset(::new MarkdownNodes(*rhs.m_children.get()));
+    this->m_parent = rhs.m_parent;
+}
+
+MarkdownNode& MarkdownNode::operator=(const MarkdownNode& rhs)
+{
+    this->type = rhs.type;
+    this->text = rhs.text;
+    this->data = rhs.data;
+    this->sourceMap = rhs.sourceMap;
+    this->m_children.reset(::new MarkdownNodes(*rhs.m_children.get()));
+    this->m_parent = rhs.m_parent;
+    return *this;
+}
+
+MarkdownNode::~MarkdownNode() {}
 
 MarkdownNode& MarkdownNode::parent()
 {

--- a/ext/snowcrash/ext/markdown-parser/src/MarkdownNode.h
+++ b/ext/snowcrash/ext/markdown-parser/src/MarkdownNode.h
@@ -82,15 +82,13 @@ namespace mdp
             const Data& data_ = Data());
 
         /** Copy constructor */
-        MarkdownNode(const MarkdownNode& rhs) = delete;
-        MarkdownNode(MarkdownNode&& rhs) = default;
+        MarkdownNode(const MarkdownNode& rhs);
 
         /** Assignment operator */
-        MarkdownNode& operator=(const MarkdownNode& rhs) = delete;
-        MarkdownNode& operator=(MarkdownNode&& rhs) = default;
+        MarkdownNode& operator=(const MarkdownNode& rhs);
 
         /** Destructor */
-        ~MarkdownNode() = default;
+        ~MarkdownNode();
 
 #ifdef DEBUG
         /** Prints the node to the stderr */

--- a/ext/snowcrash/ext/markdown-parser/src/MarkdownParser.h
+++ b/ext/snowcrash/ext/markdown-parser/src/MarkdownParser.h
@@ -39,9 +39,9 @@ namespace mdp
          *  \brief Parse source buffer
          *
          *  \param source   Markdown source data to be parsed
-         *  \return         Parsed AST (root node)
+         *  \param ast      Parsed AST (root node)
          */
-        MarkdownNode parse(const ByteBuffer& source);
+        void parse(const ByteBuffer& source, MarkdownNode& ast);
 
     private:
         MarkdownNode* m_workingNode;

--- a/ext/snowcrash/ext/markdown-parser/test/test-ByteBuffer.cc
+++ b/ext/snowcrash/ext/markdown-parser/test/test-ByteBuffer.cc
@@ -14,13 +14,14 @@ using namespace mdp;
 TEST_CASE("Multi-byte characters Czech", "[bytebuffer][sourcemap]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = "\x50\xC5\x99\xC3\xAD\xC5\xA1\x65\x72\x6E\xC4\x9B\x20\xC5\xBE\x6C\x75\xC5\xA5\x6F\x75\xC4\x8D\x6B\xC3\xBD\x20"
           "\x6B\xC5\xAF\xC5\x88\x20\xC3\xBA\x70\xC4\x9B\x6C\x20\xC4\x8F\xC3\xA1\x62\x65\x6C\x73\x6B\xC3\xA9\x20\xC3\xB3"
           "\x64\x79\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -42,11 +43,12 @@ TEST_CASE("Multi-byte characters Czech", "[bytebuffer][sourcemap]")
 TEST_CASE("Multi-byte characters in blockquote", "[bytebuffer][sourcemap]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     // "> Ni Hao"
     ByteBuffer src = "> \xE4\xBD\xA0\xE5\xA5\xBD\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -120,6 +122,7 @@ TEST_CASE("Character index")
 TEST_CASE("Byte buffer and Index should provide equal information", "[bytebuffer][sourcemap]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = "\x50\xC5\x99\xC3\xAD\xC5\xA1\x65\x72\x6E\xC4\x9B\x20\xC5\xBE\x6C\x75\xC5\xA5\x6F\x75\xC4\x8D\x6B\xC3\xBD\x20"
@@ -129,7 +132,7 @@ TEST_CASE("Byte buffer and Index should provide equal information", "[bytebuffer
     ByteBufferCharacterIndex index;
     mdp::BuildCharacterIndex(index, src);
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     CharactersRangeSet charMap = BytesRangeSetToCharactersRangeSet(ast.sourceMap, src);
     CharactersRangeSet indexMap = BytesRangeSetToCharactersRangeSet(ast.sourceMap, index);

--- a/ext/snowcrash/ext/markdown-parser/test/test-MarkdownParser.cc
+++ b/ext/snowcrash/ext/markdown-parser/test/test-MarkdownParser.cc
@@ -14,12 +14,13 @@ using namespace mdp;
 TEST_CASE("Parse one paragaraph", "[parser][paragraph]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     // NOTE: +1 Error
     // Used version of sundown automatically adds a newline if one is missing.
     // If the input buffer does not ends with new line it might be "prolonged".
 
-    MarkdownNode ast = parser.parse("Hello World!\n");
+    parser.parse("Hello World!\n", ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -40,6 +41,7 @@ TEST_CASE("Parse one paragaraph", "[parser][paragraph]")
 TEST_CASE("Parse when starting with empty line", "[parser][empty_line]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = "\n"
@@ -47,7 +49,7 @@ TEST_CASE("Parse when starting with empty line", "[parser][empty_line]")
           "\n"
           "Ipsum\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -57,39 +59,36 @@ TEST_CASE("Parse when starting with empty line", "[parser][empty_line]")
     REQUIRE(ast.sourceMap[0].location == 0);
     REQUIRE(ast.sourceMap[0].length == 14);
 
-    {
-        MarkdownNode& node = ast.children()[0];
-        REQUIRE(node.type == ParagraphMarkdownNodeType);
-        REQUIRE(node.text == "Lorem");
-        REQUIRE(node.data == 0);
-        REQUIRE(node.children().empty());
-        REQUIRE(node.sourceMap.size() == 1);
-        REQUIRE(node.sourceMap[0].location == 1);
-        REQUIRE(node.sourceMap[0].length == 7);
-    }
+    MarkdownNode& node = ast.children()[0];
+    REQUIRE(node.type == ParagraphMarkdownNodeType);
+    REQUIRE(node.text == "Lorem");
+    REQUIRE(node.data == 0);
+    REQUIRE(node.children().empty());
+    REQUIRE(node.sourceMap.size() == 1);
+    REQUIRE(node.sourceMap[0].location == 1);
+    REQUIRE(node.sourceMap[0].length == 7);
 
-    {
-        MarkdownNode& node = ast.children()[1];
-        REQUIRE(node.type == ParagraphMarkdownNodeType);
-        REQUIRE(node.text == "Ipsum");
-        REQUIRE(node.data == 0);
-        REQUIRE(node.children().empty());
-        REQUIRE(node.sourceMap.size() == 1);
-        REQUIRE(node.sourceMap[0].location == 8);
-        REQUIRE(node.sourceMap[0].length == 6);
-    }
+    node = ast.children()[1];
+    REQUIRE(node.type == ParagraphMarkdownNodeType);
+    REQUIRE(node.text == "Ipsum");
+    REQUIRE(node.data == 0);
+    REQUIRE(node.children().empty());
+    REQUIRE(node.sourceMap.size() == 1);
+    REQUIRE(node.sourceMap[0].location == 8);
+    REQUIRE(node.sourceMap[0].length == 6);
 }
 
 TEST_CASE("Parse multiple paragaraphs", "[parser][paragraph]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = "Lorem\n"
           "\n"
           "Ipsum\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -99,36 +98,33 @@ TEST_CASE("Parse multiple paragaraphs", "[parser][paragraph]")
     REQUIRE(ast.sourceMap[0].location == 0);
     REQUIRE(ast.sourceMap[0].length == 13);
 
-    {
-        MarkdownNode& node = ast.children()[0];
-        REQUIRE(node.type == ParagraphMarkdownNodeType);
-        REQUIRE(node.text == "Lorem");
-        REQUIRE(node.data == 0);
-        REQUIRE(node.children().empty());
-        REQUIRE(node.sourceMap.size() == 1);
-        REQUIRE(node.sourceMap[0].location == 0);
-        REQUIRE(node.sourceMap[0].length == 7);
-    }
+    MarkdownNode& node = ast.children()[0];
+    REQUIRE(node.type == ParagraphMarkdownNodeType);
+    REQUIRE(node.text == "Lorem");
+    REQUIRE(node.data == 0);
+    REQUIRE(node.children().empty());
+    REQUIRE(node.sourceMap.size() == 1);
+    REQUIRE(node.sourceMap[0].location == 0);
+    REQUIRE(node.sourceMap[0].length == 7);
 
-    {
-        MarkdownNode& node = ast.children()[1];
-        REQUIRE(node.type == ParagraphMarkdownNodeType);
-        REQUIRE(node.text == "Ipsum");
-        REQUIRE(node.data == 0);
-        REQUIRE(node.children().empty());
-        REQUIRE(node.sourceMap.size() == 1);
-        REQUIRE(node.sourceMap[0].location == 7);
-        REQUIRE(node.sourceMap[0].length == 6);
-    }
+    node = ast.children()[1];
+    REQUIRE(node.type == ParagraphMarkdownNodeType);
+    REQUIRE(node.text == "Ipsum");
+    REQUIRE(node.data == 0);
+    REQUIRE(node.children().empty());
+    REQUIRE(node.sourceMap.size() == 1);
+    REQUIRE(node.sourceMap[0].location == 7);
+    REQUIRE(node.sourceMap[0].length == 6);
 }
 
 TEST_CASE("Parse header", "[parser][header]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src = "# Header\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -151,12 +147,13 @@ TEST_CASE("Parse header", "[parser][header]")
 TEST_CASE("Parse multiple headers", "[parser][header]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = "# Header 1\n"
           "## Header 2\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -166,36 +163,33 @@ TEST_CASE("Parse multiple headers", "[parser][header]")
     REQUIRE(ast.sourceMap[0].location == 0);
     REQUIRE(ast.sourceMap[0].length == 23);
 
-    {
-        MarkdownNode& node = ast.children()[0];
-        REQUIRE(node.type == HeaderMarkdownNodeType);
-        REQUIRE(node.text == "Header 1");
-        REQUIRE(node.data == 1);
-        REQUIRE(node.children().empty());
-        REQUIRE(node.sourceMap.size() == 1);
-        REQUIRE(node.sourceMap[0].location == 0);
-        REQUIRE(node.sourceMap[0].length == 11);
-    }
+    MarkdownNode node = ast.children()[0];
+    REQUIRE(node.type == HeaderMarkdownNodeType);
+    REQUIRE(node.text == "Header 1");
+    REQUIRE(node.data == 1);
+    REQUIRE(node.children().empty());
+    REQUIRE(node.sourceMap.size() == 1);
+    REQUIRE(node.sourceMap[0].location == 0);
+    REQUIRE(node.sourceMap[0].length == 11);
 
-    {
-        MarkdownNode& node = ast.children()[1];
-        REQUIRE(node.type == HeaderMarkdownNodeType);
-        REQUIRE(node.text == "Header 2");
-        REQUIRE(node.data == 2);
-        REQUIRE(node.children().empty());
-        REQUIRE(node.sourceMap.size() == 1);
-        REQUIRE(node.sourceMap[0].location == 11);
-        REQUIRE(node.sourceMap[0].length == 12);
-    }
+    node = ast.children()[1];
+    REQUIRE(node.type == HeaderMarkdownNodeType);
+    REQUIRE(node.text == "Header 2");
+    REQUIRE(node.data == 2);
+    REQUIRE(node.children().empty());
+    REQUIRE(node.sourceMap.size() == 1);
+    REQUIRE(node.sourceMap[0].location == 11);
+    REQUIRE(node.sourceMap[0].length == 12);
 }
 
 TEST_CASE("Parse horizontal rule", "[parser][hrule]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src = "---\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -205,7 +199,7 @@ TEST_CASE("Parse horizontal rule", "[parser][hrule]")
     REQUIRE(ast.sourceMap[0].location == 0);
     REQUIRE(ast.sourceMap[0].length == 4);
 
-    MarkdownNode& node = ast.children().front();
+    MarkdownNode node = ast.children().front();
     REQUIRE(node.type == HRuleMarkdownNodeType);
     REQUIRE(node.text.empty());
     REQUIRE(node.data == 0);
@@ -218,10 +212,11 @@ TEST_CASE("Parse horizontal rule", "[parser][hrule]")
 TEST_CASE("Parse code block", "[parser][code]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src = "    <code>42</code>\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -231,7 +226,7 @@ TEST_CASE("Parse code block", "[parser][code]")
     REQUIRE(ast.sourceMap[0].location == 0);
     REQUIRE(ast.sourceMap[0].length == 20);
 
-    MarkdownNode& node = ast.children().front();
+    MarkdownNode node = ast.children().front();
     REQUIRE(node.type == CodeMarkdownNodeType);
     REQUIRE(node.text == "<code>42</code>\n");
     REQUIRE(node.data == 0);
@@ -244,10 +239,11 @@ TEST_CASE("Parse code block", "[parser][code]")
 TEST_CASE("Parse HTML block tag", "[parser][html]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src = "<div>some</div>\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -257,7 +253,7 @@ TEST_CASE("Parse HTML block tag", "[parser][html]")
     REQUIRE(ast.sourceMap[0].location == 0);
     REQUIRE(ast.sourceMap[0].length == 16);
 
-    MarkdownNode& node = ast.children().front();
+    MarkdownNode node = ast.children().front();
     REQUIRE(node.type == HTMLMarkdownNodeType);
     REQUIRE(node.text == "<div>some</div>\n");
     REQUIRE(node.data == 0);
@@ -270,10 +266,11 @@ TEST_CASE("Parse HTML block tag", "[parser][html]")
 TEST_CASE("Parse single list item", "[parser][list]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src = "- list item\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -283,7 +280,7 @@ TEST_CASE("Parse single list item", "[parser][list]")
     REQUIRE(ast.sourceMap[0].location == 0);
     REQUIRE(ast.sourceMap[0].length == 12);
 
-    MarkdownNode& node = ast.children()[0];
+    MarkdownNode node = ast.children()[0];
     REQUIRE(node.type == ListItemMarkdownNodeType);
     REQUIRE(node.text.empty());
     REQUIRE(node.data == 2);
@@ -292,19 +289,20 @@ TEST_CASE("Parse single list item", "[parser][list]")
     REQUIRE(node.sourceMap[0].location == 0);
     REQUIRE(node.sourceMap[0].length == 12);
 
-    MarkdownNode& item = node.children()[0];
-    REQUIRE(item.type == ParagraphMarkdownNodeType);
-    REQUIRE(item.text == "list item");
-    REQUIRE(item.data == 0);
-    REQUIRE(item.children().empty());
-    REQUIRE(item.sourceMap.size() == 1);
-    REQUIRE(item.sourceMap[0].location == 2);
-    REQUIRE(item.sourceMap[0].length == 10);
+    node = node.children()[0];
+    REQUIRE(node.type == ParagraphMarkdownNodeType);
+    REQUIRE(node.text == "list item");
+    REQUIRE(node.data == 0);
+    REQUIRE(node.children().empty());
+    REQUIRE(node.sourceMap.size() == 1);
+    REQUIRE(node.sourceMap[0].location == 2);
+    REQUIRE(node.sourceMap[0].length == 10);
 }
 
 TEST_CASE("Parse nested list items", "[parser][list]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = "- A\n"
@@ -328,7 +326,7 @@ TEST_CASE("Parse nested list items", "[parser][list]")
             + paragraph "E"
      */
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -357,7 +355,7 @@ TEST_CASE("Parse nested list items", "[parser][list]")
     REQUIRE(itemA.children()[0].sourceMap[0].length == 2);
 
     // List Item B
-    MarkdownNode& itemB = itemA.children()[1];
+    MarkdownNode itemB = itemA.children()[1];
     REQUIRE(itemB.type == ListItemMarkdownNodeType);
     REQUIRE(itemB.text.empty());
     REQUIRE(itemB.data == 2);
@@ -372,12 +370,13 @@ TEST_CASE("Parse nested list items", "[parser][list]")
     REQUIRE(itemB.children()[0].text == "B");
     REQUIRE(itemB.children()[0].data == 0);
     REQUIRE(itemB.children()[0].children().empty());
+    MarkdownNode paraBX = itemB.children()[0];
     REQUIRE(itemB.children()[0].sourceMap.size() == 1);
     REQUIRE(itemB.children()[0].sourceMap[0].location == 10);
     REQUIRE(itemB.children()[0].sourceMap[0].length == 2);
 
     // List Item C
-    MarkdownNode& itemC = itemB.children()[1];
+    MarkdownNode itemC = itemB.children()[1];
     REQUIRE(itemC.type == ListItemMarkdownNodeType);
     REQUIRE(itemC.text.empty());
     REQUIRE(itemC.data == 2);
@@ -395,7 +394,7 @@ TEST_CASE("Parse nested list items", "[parser][list]")
     REQUIRE(itemC.children()[0].sourceMap[0].length == 2);
 
     // List Item D
-    MarkdownNode& itemD = itemA.children()[2];
+    MarkdownNode itemD = itemA.children()[2];
     REQUIRE(itemD.type == ListItemMarkdownNodeType);
     REQUIRE(itemD.text.empty());
     REQUIRE(itemD.data == 2);
@@ -413,7 +412,7 @@ TEST_CASE("Parse nested list items", "[parser][list]")
     REQUIRE(itemD.children()[0].sourceMap[0].length == 2);
 
     // List Item E
-    MarkdownNode& itemE = ast.children()[1];
+    MarkdownNode itemE = ast.children()[1];
     REQUIRE(itemE.type == ListItemMarkdownNodeType);
     REQUIRE(itemE.text.empty());
     REQUIRE(itemE.data == 2);
@@ -434,6 +433,7 @@ TEST_CASE("Parse nested list items", "[parser][list]")
 TEST_CASE("Parse list item with multiple paragraphs", "[parser][list]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = "- A\n"
@@ -443,7 +443,7 @@ TEST_CASE("Parse list item with multiple paragraphs", "[parser][list]")
           "\n"
           "    E\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -453,7 +453,7 @@ TEST_CASE("Parse list item with multiple paragraphs", "[parser][list]")
     REQUIRE(ast.sourceMap[0].location == 0);
     REQUIRE(ast.sourceMap[0].length == 24);
 
-    MarkdownNode& node = ast.children()[0];
+    MarkdownNode node = ast.children()[0];
     REQUIRE(node.type == ListItemMarkdownNodeType);
     REQUIRE(node.text.empty());
     REQUIRE(node.data == 2);
@@ -495,10 +495,11 @@ TEST_CASE("Parse list item with multiple paragraphs", "[parser][list]")
 TEST_CASE("Parse a simple quote", "[parser][quote]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src = "> quote\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -530,6 +531,7 @@ TEST_CASE("Parse a simple quote", "[parser][quote]")
 TEST_CASE("Source map crash", "[parser][sourcemap][issue][snowcrash][62]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = "* B\n"
@@ -538,7 +540,7 @@ TEST_CASE("Source map crash", "[parser][sourcemap][issue][snowcrash][62]")
           "\n"
           "* E\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -549,10 +551,11 @@ TEST_CASE("Source map crash", "[parser][sourcemap][issue][snowcrash][62]")
 TEST_CASE("Map node without trailing newline", "[parser][sourcemap]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src = "# Hello World";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -574,6 +577,7 @@ TEST_CASE("Map node without trailing newline", "[parser][sourcemap]")
 TEST_CASE("Parse six nested level list items", "[parser]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = "+ 1\n"
@@ -583,52 +587,53 @@ TEST_CASE("Parse six nested level list items", "[parser]")
           "                + 5\n"
           "                    + 6\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
     REQUIRE(ast.children().size() == 1);
 
-    MarkdownNode& item1 = ast.children().back();
-    REQUIRE(item1.type == ListItemMarkdownNodeType);
-    REQUIRE(item1.children().size() == 2);
-    REQUIRE(item1.children().front().type == ParagraphMarkdownNodeType);
-    REQUIRE(item1.children().front().text == "1");
+    MarkdownNode& list = ast.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 2);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "1");
 
-    MarkdownNode& item2 = item1.children().back();
-    REQUIRE(item2.type == ListItemMarkdownNodeType);
-    REQUIRE(item2.children().size() == 2);
-    REQUIRE(item2.children().front().type == ParagraphMarkdownNodeType);
-    REQUIRE(item2.children().front().text == "2");
+    list = list.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 2);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "2");
 
-    MarkdownNode& item3 = item2.children().back();
-    REQUIRE(item3.type == ListItemMarkdownNodeType);
-    REQUIRE(item3.children().size() == 2);
-    REQUIRE(item3.children().front().type == ParagraphMarkdownNodeType);
-    REQUIRE(item3.children().front().text == "3");
+    list = list.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 2);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "3");
 
-    MarkdownNode& item4 = item3.children().back();
-    REQUIRE(item4.type == ListItemMarkdownNodeType);
-    REQUIRE(item4.children().size() == 2);
-    REQUIRE(item4.children().front().type == ParagraphMarkdownNodeType);
-    REQUIRE(item4.children().front().text == "4");
+    list = list.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 2);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "4");
 
-    MarkdownNode& item5 = item4.children().back();
-    REQUIRE(item5.type == ListItemMarkdownNodeType);
-    REQUIRE(item5.children().size() == 2);
-    REQUIRE(item5.children().front().type == ParagraphMarkdownNodeType);
-    REQUIRE(item5.children().front().text == "5");
+    list = list.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 2);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "5");
 
-    MarkdownNode& item6 = item5.children().back();
-    REQUIRE(item6.type == ListItemMarkdownNodeType);
-    REQUIRE(item6.children().size() == 1);
-    REQUIRE(item6.children().front().type == ParagraphMarkdownNodeType);
-    REQUIRE(item6.children().front().text == "6");
+    list = list.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 1);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "6");
 }
 
 TEST_CASE("Multi-paragraph list item source map", "[parser][sourcemap]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     // List item with two paragraphs & lazy indentation:
     //
@@ -645,7 +650,7 @@ TEST_CASE("Multi-paragraph list item source map", "[parser][sourcemap]")
           "    consectetur\n"
           "adipiscing elit\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
@@ -680,37 +685,35 @@ TEST_CASE("Multi-paragraph list item source map", "[parser][sourcemap]")
 TEST_CASE("Sublist should have more indentation than the list item", "[parser]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = " + 1\n"
           "+ 2\n";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());
     REQUIRE(ast.children().size() == 2);
 
-    {
-        MarkdownNode& list = ast.children().front();
-        REQUIRE(list.type == ListItemMarkdownNodeType);
-        REQUIRE(list.children().size() == 1);
-        REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
-        REQUIRE(list.children().front().text == "1");
-    }
+    MarkdownNode& list = ast.children().front();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 1);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "1");
 
-    {
-        MarkdownNode& list = ast.children().back();
-        REQUIRE(list.type == ListItemMarkdownNodeType);
-        REQUIRE(list.children().size() == 1);
-        REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
-        REQUIRE(list.children().front().text == "2");
-    }
+    list = ast.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 1);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "2");
 }
 
 TEST_CASE("Empty quota in listitem", "[parser]")
 {
     MarkdownParser parser;
+    MarkdownNode ast;
 
     ByteBuffer src
         = "+ a\n"
@@ -719,7 +722,7 @@ TEST_CASE("Empty quota in listitem", "[parser]")
           "              \"t\"\n"
           "            }";
 
-    MarkdownNode ast = parser.parse(src);
+    parser.parse(src, ast);
 
     REQUIRE(ast.type == RootMarkdownNodeType);
     REQUIRE(ast.text.empty());

--- a/ext/snowcrash/src/SignatureSectionProcessor.h
+++ b/ext/snowcrash/src/SignatureSectionProcessor.h
@@ -43,8 +43,7 @@ namespace scpl
         /**
          * \brief Process section signature markdown node (Default)
          */
-        template <typename It>
-        static It processSignature(It node,
+        static MarkdownNodeIterator processSignature(const MarkdownNodeIterator& node,
             const MarkdownNodes& siblings,
             snowcrash::SectionParserData& pd,
             snowcrash::SectionLayout& layout,
@@ -72,8 +71,7 @@ namespace scpl
          *
          * \return Signature data
          */
-        template <typename It>
-        static Signature parseSignature(It node,
+        static Signature parseSignature(const MarkdownNodeIterator& node,
             snowcrash::SectionParserData& pd,
             const SignatureTraits& traits,
             snowcrash::Report& report,

--- a/ext/snowcrash/src/snowcrash.cc
+++ b/ext/snowcrash/src/snowcrash.cc
@@ -63,7 +63,8 @@ int snowcrash::parse(
 
         // Parse Markdown
         mdp::MarkdownParser markdownParser;
-        mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+        mdp::MarkdownNode markdownAST;
+        markdownParser.parse(source, markdownAST);
 
         // Build SectionParserData
         SectionParserData pd(options, source, out.node);

--- a/ext/snowcrash/test/snowcrashtest.h
+++ b/ext/snowcrash/test/snowcrashtest.h
@@ -12,7 +12,6 @@
 #include <catch2/catch.hpp>
 #include "MarkdownParser.h"
 #include "SectionParser.h"
-#include "SignatureSectionProcessor.h"
 
 namespace snowcrashtest
 {
@@ -42,11 +41,12 @@ namespace snowcrashtest
         {
 
             mdp::MarkdownParser markdownParser;
+            mdp::MarkdownNode markdownAST;
 
             snowcrash::ParseResult<snowcrash::Blueprint> blueprint;
             snowcrash::ParseResult<snowcrash::Blueprint>* bppointer;
 
-            mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+            markdownParser.parse(source, markdownAST);
 
             REQUIRE(!markdownAST.children().empty());
 
@@ -118,17 +118,27 @@ namespace snowcrashtest
     /**
      * \brief Helper to test signature parsing. Uses Blueprint as dummy type.
      */
-    class SignatureParserHelper
-    {
+    struct SignatureParserHelper {
+
         static scpl::Signature parse(const mdp::ByteBuffer& source,
             const snowcrash::ParseResultRef<snowcrash::Blueprint>& out,
             const scpl::SignatureTraits::Traits traits,
-            const mdp::MarkdownNode& markdownAST)
+            const mdp::MarkdownNode* node = NULL)
         {
+
+            mdp::MarkdownParser markdownParser;
+            mdp::MarkdownNode markdownAST;
+
+            snowcrash::ParseResult<snowcrash::Blueprint> blueprint;
+
+            if (node == NULL) {
+                markdownParser.parse(source, markdownAST);
+            } else {
+                markdownAST = *node;
+            }
 
             REQUIRE(!markdownAST.children().empty());
 
-            snowcrash::ParseResult<snowcrash::Blueprint> blueprint;
             snowcrash::SectionParserData pd(0, source, blueprint.node);
 
             scpl::Signature signature;
@@ -138,21 +148,6 @@ namespace snowcrashtest
                 markdownAST.children().begin(), pd, signatureTraits, out.report);
 
             return signature;
-        }
-
-    public:
-        static scpl::Signature parse(const mdp::ByteBuffer& source,
-            const snowcrash::ParseResultRef<snowcrash::Blueprint>& out,
-            const scpl::SignatureTraits::Traits traits,
-            const mdp::MarkdownNode* node = NULL)
-        {
-            if (node)
-                return parse(source, out, traits, *node);
-
-            mdp::MarkdownParser markdownParser;
-            mdp::MarkdownNode markdown = markdownParser.parse(source);
-
-            return parse(source, out, traits, markdown);
         }
     };
 

--- a/ext/snowcrash/test/test-ActionParser.cc
+++ b/ext/snowcrash/test/test-ActionParser.cc
@@ -22,8 +22,9 @@ const mdp::ByteBuffer ActionFixture
 TEST_CASE("Method block classifier", "[action]")
 {
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(ActionFixture);
+    markdownParser.parse(ActionFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<Action>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-AssetParser.cc
+++ b/ext/snowcrash/test/test-AssetParser.cc
@@ -25,7 +25,8 @@ const mdp::ByteBuffer SchemaAssetFixture
 TEST_CASE("Recognize explicit body signature", "[asset]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(BodyAssetFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(BodyAssetFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Asset>::sectionType(markdownAST.children().begin());
@@ -39,7 +40,8 @@ TEST_CASE("Recognize body with content on signature", "[asset]")
           "        Lorem Ipsum\n";
 
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Asset>::sectionType(markdownAST.children().begin());
@@ -49,7 +51,8 @@ TEST_CASE("Recognize body with content on signature", "[asset]")
 TEST_CASE("Recognize schema signature", "[asset]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(SchemaAssetFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(SchemaAssetFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Asset>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-AttributesParser.cc
+++ b/ext/snowcrash/test/test-AttributesParser.cc
@@ -17,8 +17,9 @@ const mdp::ByteBuffer AttributesFixture = "+ Attributes (array[[Coupon](#coupon)
 TEST_CASE("Recognize explicit attributes signature", "[attributes]")
 {
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(AttributesFixture);
+    markdownParser.parse(AttributesFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<Attributes>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-BlueprintParser.cc
+++ b/ext/snowcrash/test/test-BlueprintParser.cc
@@ -26,8 +26,9 @@ mdp::ByteBuffer BlueprintFixture
 TEST_CASE("Blueprint block classifier", "[blueprint]")
 {
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(BlueprintFixture);
+    markdownParser.parse(BlueprintFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
 
@@ -525,12 +526,13 @@ TEST_CASE("Parsing blueprint with mson data structures", "[blueprint]")
           "\n";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
 
     ParseResult<Blueprint> blueprint;
     mson::NamedTypeBaseTable::iterator baseIt;
     mson::NamedTypeInheritanceTable::iterator inheritanceIt;
 
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
     REQUIRE(!markdownAST.children().empty());
 
     snowcrash::SectionParserData pd(ExportSourcemapOption, source, blueprint.node);

--- a/ext/snowcrash/test/test-DataStructureGroupParser.cc
+++ b/ext/snowcrash/test/test-DataStructureGroupParser.cc
@@ -17,8 +17,9 @@ const mdp::ByteBuffer DataStructuresFixture = "# Data structure";
 TEST_CASE("Recognize explicit data structures signature", "[data_structure_group]")
 {
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(DataStructuresFixture);
+    markdownParser.parse(DataStructuresFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<DataStructureGroup>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-HeadersParser.cc
+++ b/ext/snowcrash/test/test-HeadersParser.cc
@@ -26,7 +26,8 @@ const mdp::ByteBuffer HeadersSignatureContentFixture
 TEST_CASE("recognize headers signature", "[headers]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(HeadersFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(HeadersFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Headers>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-MSONMixinParser.cc
+++ b/ext/snowcrash/test/test-MSONMixinParser.cc
@@ -17,8 +17,9 @@ TEST_CASE("Mixin block classifier", "[mson][mixin]")
     mdp::ByteBuffer source = "- Include Person";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     REQUIRE(markdownAST.children().front().type == mdp::ListItemMarkdownNodeType);

--- a/ext/snowcrash/test/test-MSONOneOfParser.cc
+++ b/ext/snowcrash/test/test-MSONOneOfParser.cc
@@ -17,8 +17,9 @@ TEST_CASE("OneOf block classifier", "[mson][one_of]")
     mdp::ByteBuffer source = "- one Of";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     REQUIRE(markdownAST.children().front().type == mdp::ListItemMarkdownNodeType);
@@ -37,8 +38,9 @@ TEST_CASE("OneOf be tolerant on parsing input", "[mson][one_of]")
     mdp::ByteBuffer source = "- one \t Of";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     sectionType = SectionProcessor<mson::OneOf>::sectionType(markdownAST.children().begin());
     REQUIRE(sectionType == MSONOneOfSectionType);

--- a/ext/snowcrash/test/test-MSONTypeSectionParser.cc
+++ b/ext/snowcrash/test/test-MSONTypeSectionParser.cc
@@ -17,8 +17,9 @@ TEST_CASE("Type Section header block classifier", "[mson][type_section]")
     mdp::ByteBuffer source = "## Items";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     REQUIRE(markdownAST.children().front().type == mdp::HeaderMarkdownNodeType);
@@ -48,8 +49,9 @@ TEST_CASE("Type Section list block classifier", "[mson][type_section]")
     mdp::ByteBuffer source = "- Items";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     REQUIRE(markdownAST.children().front().type == mdp::ListItemMarkdownNodeType);

--- a/ext/snowcrash/test/test-MSONUtility.cc
+++ b/ext/snowcrash/test/test-MSONUtility.cc
@@ -417,8 +417,9 @@ TEST_CASE("Parse canonical type definition", "[mson][utility]")
 
     mdp::ByteBuffer source = "+ (number, required)";
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
 
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
     snowcrash::SectionParserData pd(0, source, blueprint);
 
     parseTypeDefinition(markdownAST.children().begin(), pd, attributes, typeDefinition.report, typeDefinition.node);
@@ -443,8 +444,9 @@ TEST_CASE("Parse type definition with non recognized type attribute", "[mson][ut
 
     mdp::ByteBuffer source = "+ ([Person][], optinal)";
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
 
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
     snowcrash::SectionParserData pd(0, source, blueprint);
 
     pd.namedTypeBaseTable["Person"] = mson::ObjectBaseType;
@@ -471,8 +473,9 @@ TEST_CASE("Parse type definition when non-structure type has nested types", "[ms
 
     mdp::ByteBuffer source = "+ (Person[number, string])";
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
 
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
     snowcrash::SectionParserData pd(0, source, blueprint);
 
     pd.namedTypeBaseTable["Person"] = mson::ObjectBaseType;
@@ -565,8 +568,9 @@ TEST_CASE("Parse canonical property name", "[mson][utility]")
 
     mdp::ByteBuffer source = "+ " + id;
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
 
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
     snowcrash::SectionParserData pd(0, source, blueprint);
 
     parsePropertyName(markdownAST.children().begin(), pd, id, propertyName.report, propertyName.node);
@@ -586,8 +590,9 @@ TEST_CASE("Parse variable property name", "[mson][utility]")
 
     mdp::ByteBuffer source = "+ " + id;
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
 
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
     snowcrash::SectionParserData pd(0, source, blueprint);
 
     parsePropertyName(markdownAST.children().begin(), pd, id, propertyName.report, propertyName.node);
@@ -613,8 +618,9 @@ TEST_CASE("Parse multi-value variable property name", "[mson][utility]")
 
     mdp::ByteBuffer source = "+ " + id;
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
 
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
     snowcrash::SectionParserData pd(0, source, blueprint);
 
     pd.namedTypeBaseTable["Custom"] = mson::ValueBaseType;

--- a/ext/snowcrash/test/test-ParameterParser.cc
+++ b/ext/snowcrash/test/test-ParameterParser.cc
@@ -23,7 +23,8 @@ const mdp::ByteBuffer ParameterFixture
 TEST_CASE("Recognize parameter definition signature", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(ParameterFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(ParameterFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -33,7 +34,8 @@ TEST_CASE("Recognize parameter definition signature", "[parameter]")
 TEST_CASE("Recognize parameter with just parameter name", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -43,7 +45,8 @@ TEST_CASE("Recognize parameter with just parameter name", "[parameter]")
 TEST_CASE("Recognize parameter with escaped identifier for new syntax", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ `user-name`");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ `user-name`", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -53,7 +56,8 @@ TEST_CASE("Recognize parameter with escaped identifier for new syntax", "[parame
 TEST_CASE("Recognize parameter with parameter name and without any values or description", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id (optional, string)");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id (optional, string)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -63,7 +67,8 @@ TEST_CASE("Recognize parameter with parameter name and without any values or des
 TEST_CASE("Recognize parameter with parameter type as first trait", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id (string, optional)");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id (string, optional)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -73,7 +78,8 @@ TEST_CASE("Recognize parameter with parameter type as first trait", "[parameter]
 TEST_CASE("Recognize parameter with new syntax example value", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id : ``1`0`` (number)");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id : ``1`0`` (number)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -83,7 +89,8 @@ TEST_CASE("Recognize parameter with new syntax example value", "[parameter]")
 TEST_CASE("Recognize parameter with only new syntax example value", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id: 10");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id: 10", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -93,7 +100,8 @@ TEST_CASE("Recognize parameter with only new syntax example value", "[parameter]
 TEST_CASE("Recognize parameter with new syntax description which has old description identifier", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id (string) - This is nice and ... awesome");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id (string) - This is nice and ... awesome", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -103,7 +111,8 @@ TEST_CASE("Recognize parameter with new syntax description which has old descrip
 TEST_CASE("Recognize parameter with new syntax description", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id (string) - This is nice and awesome");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id (string) - This is nice and awesome", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -113,7 +122,8 @@ TEST_CASE("Recognize parameter with new syntax description", "[parameter]")
 TEST_CASE("Recognize parameter with only old syntax description", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id ... The user id");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id ... The user id", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -123,7 +133,8 @@ TEST_CASE("Recognize parameter with only old syntax description", "[parameter]")
 TEST_CASE("Recognize parameter with brackets in old syntax example value", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id (optional, oData, `substringof('homer', id)`) ... test");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id (optional, oData, `substringof('homer', id)`) ... test", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -133,7 +144,8 @@ TEST_CASE("Recognize parameter with brackets in old syntax example value", "[par
 TEST_CASE("Recognize escaped parameter with brackets in old syntax example value", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ `id` (optional, oData, `example`)");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ `id` (optional, oData, `example`)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -143,7 +155,8 @@ TEST_CASE("Recognize escaped parameter with brackets in old syntax example value
 TEST_CASE("Recognize parameter with old syntax description after attributes", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id (optional, string) ... test");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id (optional, string) ... test", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -153,7 +166,8 @@ TEST_CASE("Recognize parameter with old syntax description after attributes", "[
 TEST_CASE("Recognize parameter with sample value in attributes", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id (string, `10`)");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id (string, `10`)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -163,7 +177,8 @@ TEST_CASE("Recognize parameter with sample value in attributes", "[parameter]")
 TEST_CASE("Recognize parameter with enum in attributes", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id (enum[string])");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id (enum[string])", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -173,7 +188,8 @@ TEST_CASE("Recognize parameter with enum in attributes", "[parameter]")
 TEST_CASE("Recognize parameter with both sample value and enum in attributes", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id (enum[string], `10`)");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id (enum[string], `10`)", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -183,7 +199,8 @@ TEST_CASE("Recognize parameter with both sample value and enum in attributes", "
 TEST_CASE("Recognize parameter with old syntax default value but have enum in attributes", "[parameter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse("+ id = 10 (enum[number])");
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse("+ id = 10 (enum[number])", markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -197,7 +214,8 @@ TEST_CASE("Recognize parameter with ambiguous signature but uses MSON syntax for
           "    + Default: 1";
 
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -211,7 +229,8 @@ TEST_CASE("Recognize parameter with ambiguous signature but uses MSON syntax for
           "    + Sample: 1";
 
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -225,7 +244,8 @@ TEST_CASE("Recognize parameter with ambiguous signature but uses MSON syntax for
           "    + Members";
 
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());
@@ -239,7 +259,8 @@ TEST_CASE("Recognize parameter with ambiguous signature but uses old syntax for 
           "    + Values";
 
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameter>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-ParametersParser.cc
+++ b/ext/snowcrash/test/test-ParametersParser.cc
@@ -26,7 +26,8 @@ const mdp::ByteBuffer ParametersFixture
 TEST_CASE("Recognize Parameters section block", "[parameters]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(ParametersFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(ParametersFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Parameters>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-PayloadParser.cc
+++ b/ext/snowcrash/test/test-PayloadParser.cc
@@ -41,7 +41,8 @@ const mdp::ByteBuffer EmptyBodyFixture
 TEST_CASE("recognize request signature", "[payload]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(RequestFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(RequestFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Payload>::sectionType(markdownAST.children().begin());
@@ -51,7 +52,8 @@ TEST_CASE("recognize request signature", "[payload]")
 TEST_CASE("recognize abbreviated request signature", "[payload]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(RequestBodyFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(RequestBodyFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Payload>::sectionType(markdownAST.children().begin());
@@ -61,7 +63,8 @@ TEST_CASE("recognize abbreviated request signature", "[payload]")
 TEST_CASE("recognize abbreviated response signature", "[payload]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(ResponseBodyFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(ResponseBodyFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Payload>::sectionType(markdownAST.children().begin());
@@ -71,7 +74,8 @@ TEST_CASE("recognize abbreviated response signature", "[payload]")
 TEST_CASE("recognize empty body response signature as non-abbreviated", "[payload]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(EmptyBodyFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(EmptyBodyFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Payload>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-RelationParser.cc
+++ b/ext/snowcrash/test/test-RelationParser.cc
@@ -17,8 +17,9 @@ mdp::ByteBuffer RelationFixture = "+ Relation: create";
 TEST_CASE("Recognize relation signature", "[relation]")
 {
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(RelationFixture);
+    markdownParser.parse(RelationFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
@@ -30,8 +31,9 @@ TEST_CASE("Relation signature without colon", "[relation]")
     mdp::ByteBuffer source = "+ Relation delete";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
@@ -56,8 +58,9 @@ TEST_CASE("Relation identifier starting with non lower alphabet", "[relation]")
     mdp::ByteBuffer source = "+ Relation: 9delete";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
@@ -77,8 +80,9 @@ TEST_CASE("Relation identifier containing capital letters", "[relation]")
     mdp::ByteBuffer source = "+ Relation: deLete";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
@@ -98,8 +102,9 @@ TEST_CASE("Relation identifier containing special characters", "[relation]")
     mdp::ByteBuffer source = "+ Relation: del*et_e";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());
@@ -119,8 +124,9 @@ TEST_CASE("Relation identifier consisting of dots and dashes", "[relation]")
     mdp::ByteBuffer source = "+ Relation: delete-task.2";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<Relation>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-ResourceGroupParser.cc
+++ b/ext/snowcrash/test/test-ResourceGroupParser.cc
@@ -33,8 +33,9 @@ TEST_CASE("Resource group block classifier", "[resource_group]")
     "Assembly language\n";
 
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(source);
+    markdownParser.parse(source, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<ResourceGroup>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-ResourceParser.cc
+++ b/ext/snowcrash/test/test-ResourceParser.cc
@@ -34,8 +34,9 @@ mdp::ByteBuffer ResourceFixture
 TEST_CASE("Resource block classifier", "[resource]")
 {
     mdp::MarkdownParser markdownParser;
+    mdp::MarkdownNode markdownAST;
     SectionType sectionType;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(ResourceFixture);
+    markdownParser.parse(ResourceFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     sectionType = SectionProcessor<Resource>::sectionType(markdownAST.children().begin());

--- a/ext/snowcrash/test/test-SectionParser.cc
+++ b/ext/snowcrash/test/test-SectionParser.cc
@@ -25,7 +25,8 @@ const mdp::ByteBuffer ListSectionFixture
 TEST_CASE("Header adapter with header section", "[adapter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(HeaderSectionFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(HeaderSectionFixture, markdownAST);
 
     SectionParserData pd(0, HeaderSectionFixture, Blueprint());
 
@@ -45,7 +46,8 @@ TEST_CASE("Header adapter with header section", "[adapter]")
 TEST_CASE("Header adapter with list section", "[adapter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(ListSectionFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(ListSectionFixture, markdownAST);
 
     SectionParserData pd(0, ListSectionFixture, Blueprint());
 
@@ -57,7 +59,8 @@ TEST_CASE("Header adapter with list section", "[adapter]")
 TEST_CASE("List adapter with List section", "[adapter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(ListSectionFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(ListSectionFixture, markdownAST);
 
     SectionParserData pd(0, ListSectionFixture, Blueprint());
 
@@ -67,7 +70,7 @@ TEST_CASE("List adapter with List section", "[adapter]")
     MarkdownNodeIterator it = ListSectionAdapter::startingNode(markdownAST.children().begin(), pd);
     REQUIRE(it->text == "Signature");
 
-    const MarkdownNodes& collection
+    MarkdownNodes collection
         = ListSectionAdapter::startingNodeSiblings(markdownAST.children().begin(), markdownAST.children());
     REQUIRE(collection.size() == 2);
 
@@ -78,7 +81,8 @@ TEST_CASE("List adapter with List section", "[adapter]")
 TEST_CASE("List adapter with Header section", "[adapter]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(HeaderSectionFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(HeaderSectionFixture, markdownAST);
 
     SectionParserData pd(0, HeaderSectionFixture, Blueprint());
 

--- a/ext/snowcrash/test/test-Signature.cc
+++ b/ext/snowcrash/test/test-Signature.cc
@@ -398,7 +398,9 @@ TEST_CASE("Property signature parsing without a value", "[signature]")
 TEST_CASE("Element signature parsing without value and attributes", "[signature]")
 {
     mdp::MarkdownNode source(mdp::RootMarkdownNodeType, NULL, "");
-    source.children().emplace_back(mdp::ParagraphMarkdownNodeType, &source, "- content is the king");
+    mdp::MarkdownNode paragraph(mdp::ParagraphMarkdownNodeType, &source, "- content is the king");
+
+    source.children().push_back(paragraph);
 
     ParseResult<Blueprint> blueprint;
     scpl::Signature signature = SignatureParserHelper::parse("", blueprint, ElementMemberTypeTraits, &source);

--- a/ext/snowcrash/test/test-ValuesParser.cc
+++ b/ext/snowcrash/test/test-ValuesParser.cc
@@ -22,7 +22,8 @@ const mdp::ByteBuffer ValuesFixture
 TEST_CASE("Recognize values signature", "[values]")
 {
     mdp::MarkdownParser markdownParser;
-    mdp::MarkdownNode markdownAST = markdownParser.parse(ValuesFixture);
+    mdp::MarkdownNode markdownAST;
+    markdownParser.parse(ValuesFixture, markdownAST);
 
     REQUIRE(!markdownAST.children().empty());
     SectionType sectionType = SectionProcessor<Values>::sectionType(markdownAST.children().begin());


### PR DESCRIPTION
https://github.com/apiaryio/drafter/pull/726 broken compatbility with MSVC which caused master to be unreleasable for a month. This PR reverts the changes that caused the problem to unblock releasing master. There were two problems, the code base couldn't be compiled on MSVC 2019:

```
ext\snowcrash\src\Just.h(21, 26): error C2131:  expression did not evaluate to a constant
ext\snowcrash\src\Just.h(21, 1): error C2440:  'noexcept': cannot convert from 'T' to 'bool
...
ext\snowcrash\src\Just.h(21, 26): message :  No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
```

Protagonist CI couldn't complete on MSVC 2015 and caused an access violation causing the tests to exit.

This does mean that the test-asan CircleCI step will fail (it is not required).

This reverts commit 11a8788e660d608342c73f3269cbad10bab8d533.
This reverts commit 893921c50ccf289fb940ff27b8191e209b29656f.

I have made no code changes, only reverted the two linked commits.

Fixes https://github.com/apiaryio/drafter/issues/738
Closes https://github.com/apiaryio/drafter/pull/742