### PR TITLE
Fix issue #752

### DIFF
--- a/src/MsonTypeSectionToApie.cc
+++ b/src/MsonTypeSectionToApie.cc
@@ -106,13 +106,43 @@ std::unique_ptr<IElement> drafter::MsonTypeSectionToApie( //
         defaultNestedType);
 }
 
+namespace
+{
+    std::string msonToApieSymbol(mson::BaseTypeName base)
+    {
+        switch (base) {
+            case mson::BooleanTypeName:
+                return "boolean";
+            case mson::StringTypeName:
+                return "string";
+            case mson::NumberTypeName:
+                return "number";
+            case mson::ArrayTypeName:
+                return "array";
+            case mson::EnumTypeName:
+                return "enum";
+            case mson::ObjectTypeName:
+                return "object";
+            default:
+                assert(false);
+        }
+        return "";
+    }
+
+    std::string msonToApieSymbol(const mson::TypeName& name)
+    {
+        assert(!name.empty());
+        return name.symbol.empty() ? msonToApieSymbol(name.base) : name.symbol.literal;
+    }
+}
+
 std::unique_ptr<IElement> drafter::MsonTypeSectionToApie( //
     const mson::Element::MixinSection& section,
     const snowcrash::SourceMap<mson::Element>* sourceMap,
     ConversionContext&,
     const mson::BaseTypeName)
 {
-    auto ref = make_element<RefElement>(section.typeSpecification.name.symbol.literal);
+    auto ref = make_element<RefElement>(msonToApieSymbol(section.typeSpecification.name));
     ref->attributes().set(SerializeKey::Path, from_primitive(SerializeKey::Content));
     return std::move(ref);
 }

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -59,7 +59,7 @@ std::unique_ptr<IElement> drafter::WrapRefract(
             error = e;
         }
 
-        context.GetNamedTypesRegistry().clearAll(true);
+        context.GetNamedTypesRegistry().clear();
 
         if (error.code != snowcrash::Error::OK) {
             blueprint.report.error = error;

--- a/src/refract/ElementSize.cc
+++ b/src/refract/ElementSize.cc
@@ -10,6 +10,7 @@
 
 #include "Element.h"
 #include "ElementUtils.h"
+#include "../utils/log/Trivial.h"
 #include <algorithm>
 #include <numeric>
 #include <limits>
@@ -158,8 +159,10 @@ cardinal refract::sizeOf(const ExtendElement& e, bool inheritsFixed)
 
 cardinal refract::sizeOf(const RefElement& e, bool inheritsFixed)
 {
-    const auto& resolved = resolve(e);
-    return sizeOf(resolved, inheritsFixed);
+    if (const IElement* resolved = resolve(e))
+        return sizeOf(*resolved, inheritsFixed);
+    LOG(warning) << "ignoring unresolved reference calculating type cardinality";
+    return cardinal::empty();
 }
 
 cardinal refract::sizeOf(const HolderElement& e, bool inheritsFixed)

--- a/src/refract/ElementUtils.cc
+++ b/src/refract/ElementUtils.cc
@@ -294,15 +294,14 @@ bool refract::definesValue(const IElement& e)
     return nullptr != findValue(e);
 }
 
-const IElement& refract::resolve(const RefElement& element)
+const IElement* refract::resolve(const RefElement& element)
 {
-    const auto& resolvedEntry = element.attributes().find("resolved");
+    const auto resolvedEntry = element.attributes().find("resolved");
     if (resolvedEntry == element.attributes().end()) {
         LOG(error) << "expected all references to be resolved in backend";
         assert(false);
-        return element;
     }
 
     assert(resolvedEntry->second);
-    return *resolvedEntry->second;
+    return resolvedEntry->second.get();
 }

--- a/src/refract/ElementUtils.h
+++ b/src/refract/ElementUtils.h
@@ -142,7 +142,7 @@ namespace refract
     ///
     /// Resolve a previously expanded reference
     ///
-    const IElement& resolve(const RefElement& element);
+    const IElement* resolve(const RefElement& element);
 }
 
 #endif

--- a/src/refract/JsonSchema.cc
+++ b/src/refract/JsonSchema.cc
@@ -360,7 +360,7 @@ namespace
     so::Object& errorByImpossibleSchema(so::Object& schema, const T& element)
     {
         LOG(error) << "invalid element, interpreting as unsatisfiable schema: " << element.element();
-        addOneOf(schema, so::Array{so::from_list{}, so::Object{}, so::Object{}});
+        addOneOf(schema, so::Array{ so::from_list{}, so::Object{}, so::Object{} });
         return schema;
     }
 
@@ -373,8 +373,10 @@ namespace
 
     so::Object& renderSchemaSpecific(so::Object& s, const RefElement& e, TypeAttributes options)
     {
-        const auto& resolved = resolve(e);
-        return renderSchema(s, resolved, passFlags(options));
+        if (const IElement* resolved = resolve(e))
+            return renderSchema(s, *resolved, passFlags(options));
+        LOG(warning) << "ignoring unresolved reference in backend";
+        return s;
     }
 
     so::Object& renderSchemaSpecific(so::Object& s, const ObjectElement& e, TypeAttributes options)
@@ -723,8 +725,9 @@ namespace
 
     void renderPropertySpecific(ObjectSchema& s, const RefElement& e, TypeAttributes options)
     {
-        const auto& resolved = resolve(e);
-        renderProperty(s, resolved, passFlags(options));
+        if (const IElement* resolved = resolve(e))
+            renderProperty(s, *resolved, passFlags(options));
+        LOG(warning) << "ignoring unresolved reference in json schema backend";
     }
 
     void renderPropertySpecific(ObjectSchema& s, const SelectElement& e, TypeAttributes options)

--- a/src/refract/Registry.h
+++ b/src/refract/Registry.h
@@ -18,17 +18,21 @@ namespace refract
 {
     class Registry
     {
-        typedef std::map<std::string, std::unique_ptr<IElement> > Map;
-        Map registrated;
+    public:
+        using type_map = std::map<std::string, std::unique_ptr<IElement> >;
 
-        std::string getElementId(IElement& element);
+    private:
+        type_map types_;
+
+    public:
+        Registry();
 
     public:
         const IElement* find(const std::string& name) const;
 
         bool add(std::unique_ptr<IElement> element);
         bool remove(const std::string& name);
-        void clearAll(bool releaseElements = false);
+        void clear();
     };
 
     const IElement* FindRootAncestor(const std::string& name, const Registry& registry);

--- a/test/fixtures/mson/issue-752.apib
+++ b/test/fixtures/mson/issue-752.apib
@@ -1,0 +1,9 @@
+# My API
+
+## GET /
+
++ Response 200 (application/json)
+    + Attributes
+        + One Of
+            + Include (object)
+                + key: value

--- a/test/fixtures/mson/issue-752.json
+++ b/test/fixtures/mson/issue-752.json
@@ -1,0 +1,231 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "My API"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "meta": {
+            "title": {
+              "element": "string",
+              "content": ""
+            }
+          },
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": ""
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "object",
+                            "content": [
+                              {
+                                "element": "select",
+                                "content": [
+                                  {
+                                    "element": "option",
+                                    "content": [
+                                      {
+                                        "element": "ref",
+                                        "attributes": {
+                                          "path": {
+                                            "element": "string",
+                                            "content": "content"
+                                          }
+                                        },
+                                        "content": "object"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBody"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/json"
+                            }
+                          },
+                          "content": "{}"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBodySchema"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/schema+json"
+                            }
+                          },
+                          "content": "{\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"allOf\": [\n    {\n      \"oneOf\": [\n        {}\n      ]\n    }\n  ]\n}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "warning"
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 5
+        },
+        "sourceMap": {
+          "element": "array",
+          "content": [
+            {
+              "element": "sourceMap",
+              "content": [
+                {
+                  "element": "array",
+                  "content": [
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 9
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 17
+                        }
+                      },
+                      "content": 135
+                    },
+                    {
+                      "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 9
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 29
+                        }
+                      },
+                      "content": 13
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "content": "ignoring unrecognized block"
+    }
+  ]
+}

--- a/test/test-RefractDataStructureTest.cc
+++ b/test/test-RefractDataStructureTest.cc
@@ -65,6 +65,7 @@ TEST_REFRACT("mson", "issue-709");
 TEST_REFRACT("mson", "issue-709-b");
 TEST_REFRACT("mson", "issue-713");
 TEST_REFRACT("mson", "issue-718");
+TEST_REFRACT("mson", "issue-752");
 
 #undef TEST_MSON_SUCCESS
 #undef TEST_MSON


### PR DESCRIPTION
## Fixed
- primitive type names are now added to type registry
- release build: unresolved references are ignored in backend
- debug build: unresolved references are asserted on in backend

## Not fixed
- snowcrash not recognizing nested sections in
a primitive mixin.