### PR TITLE
fix issue 749

### DIFF
--- a/src/ElementData.h
+++ b/src/ElementData.h
@@ -93,6 +93,7 @@ namespace drafter
     template <typename T>
     struct ElementData {
 
+        ElementInfoContainer<T> inlines;
         ElementInfoContainer<T> values;
         ElementInfoContainer<T> defaults;
         ElementInfoContainer<T> samples;

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -701,23 +701,13 @@ namespace
             auto info = Merge<T>()(std::move(data.values));
             auto hint = Merge<T>()(std::move(data.hints));
 
-            if (!hint.value.empty()) {
-                if (element.empty())
-                    element.set();
-                std::move(hint.value.begin(), hint.value.end(), std::back_inserter(element.get()));
+            if (!(hint.value.empty() && inlines.value.empty() && info.value.empty()) && element.empty()) {
+                element.set();
             }
 
-            if (!inlines.value.empty()) {
-                if (element.empty())
-                    element.set();
-                std::move(inlines.value.begin(), inlines.value.end(), std::back_inserter(element.get()));
-            }
-
-            if (!info.value.empty()) {
-                if (element.empty())
-                    element.set();
-                std::move(info.value.begin(), info.value.end(), std::back_inserter(element.get()));
-            }
+            std::move(hint.value.begin(), hint.value.end(), std::back_inserter(element.get()));
+            std::move(inlines.value.begin(), inlines.value.end(), std::back_inserter(element.get()));
+            std::move(info.value.begin(), info.value.end(), std::back_inserter(element.get()));
         }
     };
 
@@ -820,7 +810,6 @@ namespace
                 });
 
             if (!enums.empty()) {
-
                 std::for_each(enums.begin(), enums.end(), [](std::unique_ptr<IElement>& info) {
                     if (IsLiteral(*info)) {
                         AppendInfoElement<ArrayElement>(info->attributes(), "typeAttributes", dsd::String{ "fixed" });

--- a/test/fixtures/mson/enum-variants.apib
+++ b/test/fixtures/mson/enum-variants.apib
@@ -6,7 +6,7 @@
 
 - size2: S, M, L, XL (enum) - E: ['S','M','L','XL']
 
-- size3: L (enum) - C: 'L', E: ['L','S','M','XL'] - first 'L' it in value
+- size3: L (enum) - C: 'L', E: ['L','S','M','XL'] - ignore "inline" duplicity "L"
     - S
     - M
     - L

--- a/test/fixtures/mson/enum-variants.json
+++ b/test/fixtures/mson/enum-variants.json
@@ -189,7 +189,7 @@
                     "meta": {
                       "description": {
                         "element": "string",
-                        "content": "C: 'L', E: ['L','S','M','XL'] - first 'L' it in value"
+                        "content": "C: 'L', E: ['L','S','M','XL'] - ignore \"inline\" duplicity \"L\""
                       }
                     },
                     "content": {
@@ -203,21 +203,6 @@
                           "enumerations": {
                             "element": "array",
                             "content": [
-                              {
-                                "element": "string",
-                                "attributes": {
-                                  "typeAttributes": {
-                                    "element": "array",
-                                    "content": [
-                                      {
-                                        "element": "string",
-                                        "content": "fixed"
-                                      }
-                                    ]
-                                  }
-                                },
-                                "content": "L"
-                              },
                               {
                                 "element": "string",
                                 "attributes": {
@@ -247,6 +232,21 @@
                                   }
                                 },
                                 "content": "M"
+                              },
+                              {
+                                "element": "string",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "L"
                               },
                               {
                                 "element": "string",
@@ -1666,70 +1666,6 @@
                       "attributes": {
                         "line": {
                           "element": "number",
-                          "content": 9
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 3
-                        }
-                      },
-                      "content": 145
-                    },
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
-                          "content": 9
-                        },
-                        "column": {
-                          "element": "number",
-                          "content": 74
-                        }
-                      },
-                      "content": 72
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "content": "duplicit value in enumeration"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": {
-          "element": "array",
-          "content": [
-            {
-              "element": "string",
-              "content": "warning"
-            }
-          ]
-        }
-      },
-      "attributes": {
-        "code": {
-          "element": "number",
-          "content": 4
-        },
-        "sourceMap": {
-          "element": "array",
-          "content": [
-            {
-              "element": "sourceMap",
-              "content": [
-                {
-                  "element": "array",
-                  "content": [
-                    {
-                      "element": "number",
-                      "attributes": {
-                        "line": {
-                          "element": "number",
                           "content": 60
                         },
                         "column": {
@@ -1737,7 +1673,7 @@
                           "content": 3
                         }
                       },
-                      "content": 1133
+                      "content": 1141
                     },
                     {
                       "element": "number",
@@ -1801,7 +1737,7 @@
                           "content": 3
                         }
                       },
-                      "content": 1188
+                      "content": 1196
                     },
                     {
                       "element": "number",
@@ -1865,7 +1801,7 @@
                           "content": 5
                         }
                       },
-                      "content": 1440
+                      "content": 1448
                     },
                     {
                       "element": "number",
@@ -1898,7 +1834,7 @@
                           "content": 5
                         }
                       },
-                      "content": 1454
+                      "content": 1462
                     },
                     {
                       "element": "number",
@@ -1931,7 +1867,7 @@
                           "content": 5
                         }
                       },
-                      "content": 1466
+                      "content": 1474
                     },
                     {
                       "element": "number",

--- a/test/fixtures/mson/issue-749-1.apib
+++ b/test/fixtures/mson/issue-749-1.apib
@@ -1,0 +1,8 @@
+# Data Structures
+## WaveRecord (object)
+
++ status: `Processed` (enum, required) - The wave status.
+    + Members
+        + `Draft` - The wave has been created but not queued.
+        + `Processed` - The wave has been processed.
+        + `Queued` - The wave has been queued but not processed.

--- a/test/fixtures/mson/issue-749-1.json
+++ b/test/fixtures/mson/issue-749-1.json
@@ -1,0 +1,169 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": ""
+        }
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "dataStructures"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "content": "WaveRecord"
+                  }
+                },
+                "content": [
+                  {
+                    "element": "member",
+                    "meta": {
+                      "description": {
+                        "element": "string",
+                        "content": "The wave status."
+                      }
+                    },
+                    "attributes": {
+                      "typeAttributes": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "string",
+                            "content": "required"
+                          }
+                        ]
+                      }
+                    },
+                    "content": {
+                      "key": {
+                        "element": "string",
+                        "content": "status"
+                      },
+                      "value": {
+                        "element": "enum",
+                        "attributes": {
+                          "enumerations": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "string",
+                                "meta": {
+                                  "description": {
+                                    "element": "string",
+                                    "content": "The wave has been created but not queued."
+                                  }
+                                },
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "Draft"
+                              },
+                              {
+                                "element": "string",
+                                "meta": {
+                                  "description": {
+                                    "element": "string",
+                                    "content": "The wave has been processed."
+                                  }
+                                },
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "Processed"
+                              },
+                              {
+                                "element": "string",
+                                "meta": {
+                                  "description": {
+                                    "element": "string",
+                                    "content": "The wave has been queued but not processed."
+                                  }
+                                },
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "Queued"
+                              }
+                            ]
+                          }
+                        },
+                        "content": {
+                          "element": "string",
+                          "attributes": {
+                            "typeAttributes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "fixed"
+                                }
+                              ]
+                            }
+                          },
+                          "content": "Processed"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/mson/issue-749-2.apib
+++ b/test/fixtures/mson/issue-749-2.apib
@@ -1,0 +1,8 @@
+# Data Structures
+## WaveRecord (object)
+
++ status: Processed, Queued, Done (enum, required) - The wave status.
+    + Members
+        + `Draft` - The wave has been created but not queued.
+        + `Processed` - The wave has been processed.
+        + `Queued` - The wave has been queued but not processed.

--- a/test/fixtures/mson/issue-749-2.json
+++ b/test/fixtures/mson/issue-749-2.json
@@ -1,0 +1,169 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": ""
+        }
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "dataStructures"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "content": "WaveRecord"
+                  }
+                },
+                "content": [
+                  {
+                    "element": "member",
+                    "meta": {
+                      "description": {
+                        "element": "string",
+                        "content": "The wave status."
+                      }
+                    },
+                    "attributes": {
+                      "typeAttributes": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "string",
+                            "content": "required"
+                          }
+                        ]
+                      }
+                    },
+                    "content": {
+                      "key": {
+                        "element": "string",
+                        "content": "status"
+                      },
+                      "value": {
+                        "element": "enum",
+                        "attributes": {
+                          "enumerations": {
+                            "element": "array",
+                            "content": [
+                              {
+                                "element": "string",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "Done"
+                              },
+                              {
+                                "element": "string",
+                                "meta": {
+                                  "description": {
+                                    "element": "string",
+                                    "content": "The wave has been created but not queued."
+                                  }
+                                },
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "Draft"
+                              },
+                              {
+                                "element": "string",
+                                "meta": {
+                                  "description": {
+                                    "element": "string",
+                                    "content": "The wave has been processed."
+                                  }
+                                },
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "Processed"
+                              },
+                              {
+                                "element": "string",
+                                "meta": {
+                                  "description": {
+                                    "element": "string",
+                                    "content": "The wave has been queued but not processed."
+                                  }
+                                },
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "fixed"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": "Queued"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test-RefractDataStructureTest.cc
+++ b/test/test-RefractDataStructureTest.cc
@@ -66,6 +66,8 @@ TEST_REFRACT("mson", "issue-709-b");
 TEST_REFRACT("mson", "issue-713");
 TEST_REFRACT("mson", "issue-718");
 TEST_REFRACT("mson", "issue-752");
+TEST_REFRACT("mson", "issue-749-1");
+TEST_REFRACT("mson", "issue-749-2");
 
 #undef TEST_MSON_SUCCESS
 #undef TEST_MSON


### PR DESCRIPTION
closes #749 

Ignore enum duplicity if defined inline and later again in members
```
+ state: processed (enum)
+ Members
    + queued
    + processed
    + done
```