### PR TITLE
Update to Xcode 11 bon Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ jobs:
       - run: brew install cmake
       - <<: *clang-debug
     macos:
-      xcode: "9.4.0"
+      xcode: "11.2.1"
 
   test-osx-release:
     <<: *test-base
@@ -256,7 +256,7 @@ jobs:
       - run: brew install cmake
       - <<: *clang-release
     macos:
-      xcode: "9.4.0"
+      xcode: "11.2.1"
 
   test-valgrind:
     <<: *test-base-legacy


### PR DESCRIPTION
Xcode 9 image contains macOS 10.13 which doesn't appear to be compatible with the latest version of Homebrew which now emits Ruby errors causing failing master.