### PR TITLE
Improve readability of ConversionContext; remove WrapperOptions

### DIFF
--- a/drafter.gyp
+++ b/drafter.gyp
@@ -396,6 +396,7 @@
         'src/refract',
       ],
       'sources': [
+        "test/draftertest.cc",
         "test/test-drafter.cc",
         "test/test-RefractDataStructureTest.cc",
         "test/test-RefractAPITest.cc",

--- a/src/ConversionContext.cc
+++ b/src/ConversionContext.cc
@@ -3,42 +3,70 @@
 //  drafter
 //
 //  Created by Pavan Kumar Sunkara on 18/08/16.
-//  Copyright © 2016 Apiary. All rights reserved.
+//  Copyright (c) 2016 Apiary. All rights reserved.
 //
 
 #include "ConversionContext.h"
 
-namespace drafter
+#include "snowcrash.h"
+
+using namespace drafter;
+
+ConversionContext::ConversionContext(const char* src, bool expandMson) noexcept
+    : newline_indices_(GetLinesEndIndex(src)),
+      expand_mson_{ expandMson },
+      registry_{},
+      warnings_{}
 {
+}
 
-    ConversionContext::ConversionContext(const char* source, const WrapperOptions& options)
-        : newLinesIndex(GetLinesEndIndex(source)), options(options)
-    {
-    }
+refract::Registry& ConversionContext::typeRegistry() noexcept
+{
+    return registry_;
+}
 
-    void ConversionContext::warn(const snowcrash::Warning& warning)
-    {
-        for (auto& item : warnings) {
-            bool equalSourceMap = true;
+const refract::Registry& ConversionContext::typeRegistry() const noexcept
+{
+    return registry_;
+}
 
-            // Compare sourcemap
-            if (item.location.size() == warning.location.size()) {
-                for (size_t i = 0; i < item.location.size(); i++) {
-                    if (item.location.at(i).length != warning.location.at(i).length
-                        || item.location.at(i).location != warning.location.at(i).location) {
+const NewLinesIndex& ConversionContext::newlineIndices() const noexcept
+{
+    return newline_indices_;
+}
 
-                        equalSourceMap = false;
-                    }
+bool ConversionContext::expandMson() const noexcept
+{
+    return expand_mson_;
+}
+
+void ConversionContext::warn(const snowcrash::Warning& warning)
+{
+    for (auto& item : warnings_) {
+        bool equalSourceMap = true;
+
+        // Compare sourcemap
+        if (item.location.size() == warning.location.size()) {
+            for (size_t i = 0; i < item.location.size(); i++) {
+                if (item.location.at(i).length != warning.location.at(i).length
+                    || item.location.at(i).location != warning.location.at(i).location) {
+
+                    equalSourceMap = false;
                 }
-            } else {
-                equalSourceMap = false;
             }
-
-            if (equalSourceMap && item.code == warning.code && item.message == warning.message) {
-                return;
-            }
+        } else {
+            equalSourceMap = false;
         }
 
-        warnings.push_back(warning);
+        if (equalSourceMap && item.code == warning.code && item.message == warning.message) {
+            return;
+        }
     }
+
+    warnings_.push_back(warning);
+}
+
+const ConversionContext::Warnings& ConversionContext::warnings() const noexcept
+{
+    return warnings_;
 }

--- a/src/ConversionContext.h
+++ b/src/ConversionContext.h
@@ -8,42 +8,42 @@
 #ifndef DRAFTER_CONVERSIONCONTEXT_H
 #define DRAFTER_CONVERSIONCONTEXT_H
 
+#include <boost/container/vector.hpp>
+
 #include "refract/Registry.h"
-#include "snowcrash.h"
 #include "SourceMapUtils.h"
+
+namespace snowcrash
+{
+    struct SourceAnnotation;
+}
 
 namespace drafter
 {
-
-    struct WrapperOptions;
-
     class ConversionContext
     {
-        refract::Registry registry;
-        const NewLinesIndex newLinesIndex;
+    public:
+        using Warnings = boost::container::vector<snowcrash::SourceAnnotation>;
+
+    private:
+        const NewLinesIndex newline_indices_;
+        const bool expand_mson_;
+
+        refract::Registry registry_;
+        Warnings warnings_;
 
     public:
-        ConversionContext(const char* source, const WrapperOptions& options);
+        explicit ConversionContext(const char*, bool expandMson = false) noexcept;
 
-        const WrapperOptions& options;
-        std::vector<snowcrash::Warning> warnings;
+        const NewLinesIndex& newlineIndices() const noexcept;
 
-        inline refract::Registry& GetNamedTypesRegistry()
-        {
-            return registry;
-        }
+        bool expandMson() const noexcept;
 
-        inline const refract::Registry& GetNamedTypesRegistry() const
-        {
-            return registry;
-        }
+        refract::Registry& typeRegistry() noexcept;
+        const refract::Registry& typeRegistry() const noexcept;
 
-        inline const NewLinesIndex& GetNewLinesIndex() const
-        {
-            return newLinesIndex;
-        }
-
+        const Warnings& warnings() const noexcept;
         void warn(const snowcrash::Warning& warning);
     };
 }
-#endif // #ifndef DRAFTER_CONVERSIONCONTEXT_H
+#endif

--- a/src/MsonTypeSectionToApie.cc
+++ b/src/MsonTypeSectionToApie.cc
@@ -61,7 +61,7 @@ mson::BaseTypeName drafter::ResolveType(const mson::TypeSpecification& spec, Con
     const std::string& parent = spec.name.symbol.literal;
 
     if (nameType == mson::UndefinedTypeName && !parent.empty()) {
-        const IElement* base = FindRootAncestor(parent, context.GetNamedTypesRegistry());
+        const IElement* base = FindRootAncestor(parent, context.typeRegistry());
         if (base) {
             nameType = NamedTypeFromElement(*base);
         }

--- a/src/NamedTypesRegistry.cc
+++ b/src/NamedTypesRegistry.cc
@@ -425,7 +425,7 @@ namespace drafter
             element->meta().set("id", from_primitive(name));
 
             try {
-                context.GetNamedTypesRegistry().add(std::move(element));
+                context.typeRegistry().add(std::move(element));
             } catch (LogicError& e) {
                 std::ostringstream out;
                 out << name << " is a reserved keyword and cannot be used.";
@@ -447,10 +447,10 @@ namespace drafter
 #endif /* DEBUG_DEPENDENCIES */
 
                 // remove preregistrated element
-                context.GetNamedTypesRegistry().remove(name);
+                context.typeRegistry().remove(name);
 
                 try {
-                    context.GetNamedTypesRegistry().add(std::move(element));
+                    context.typeRegistry().add(std::move(element));
                 } catch (LogicError& e) {
                     std::ostringstream out;
                     out << name << " is a reserved keyword and cannot be used.";

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -143,7 +143,7 @@ std::unique_ptr<IElement> drafter::DataStructureToRefract(
     // which is a breaking change. Once we remove APIB AST code, we can move forward with this.
     auto msonElement = MSONToRefract(dataStructure, context);
 
-    if (context.options.expandMSON) {
+    if (context.expandMson()) {
         auto msonExpanded = ExpandRefract(std::move(msonElement), context);
         msonElement = std::move(msonExpanded);
     }
@@ -343,7 +343,7 @@ std::unique_ptr<IElement> PayloadToRefract( //
         nullptr :
         MSONToRefract(MAKE_NODE_INFO(payload, attributes), context);
 
-    std::unique_ptr<IElement> payloadAttributeExpanded = payloadAttributeElement && context.options.expandMSON ? //
+    std::unique_ptr<IElement> payloadAttributeExpanded = payloadAttributeElement && context.expandMson() ? //
         ExpandRefract(std::move(payloadAttributeElement), context) :
         nullptr;
 
@@ -366,7 +366,7 @@ std::unique_ptr<IElement> PayloadToRefract( //
     } else {
         if (!payload.node->attributes.empty()
             && ((payload.node->body.empty() && renderFormat != UndefinedRenderFormat)
-                   || (payload.node->schema.empty() && renderFormat == JSONRenderFormat))) {
+                || (payload.node->schema.empty() && renderFormat == JSONRenderFormat))) {
 
             if (!payloadAttributeElement)
                 payloadAttributeElement = MSONToRefract(MAKE_NODE_INFO(payload, attributes), context);
@@ -381,7 +381,7 @@ std::unique_ptr<IElement> PayloadToRefract( //
     }
 
     // Push dataStructure
-    if (context.options.expandMSON) {
+    if (context.expandMson()) {
         if (payloadAttributeExpanded) {
             content.push_back(refract::make_unique<HolderElement>(
                 SerializeKey::DataStructure, dsd::Holder(std::move(payloadAttributeExpanded))));

--- a/src/RefractDataStructure.cc
+++ b/src/RefractDataStructure.cc
@@ -373,7 +373,7 @@ namespace
 
     mson::BaseTypeName GetMsonTypeFromName(const std::string& name, const ConversionContext& context)
     {
-        const IElement* e = FindRootAncestor(name, context.GetNamedTypesRegistry());
+        const IElement* e = FindRootAncestor(name, context.typeRegistry());
         if (!e) {
             return mson::UndefinedTypeName;
         }
@@ -998,7 +998,7 @@ namespace
         }
 
         if (TypeQueryVisitor::as<StringElement>(FindRootAncestor(
-                variable.typeDefinition.typeSpecification.name.symbol.literal, context.GetNamedTypesRegistry()))) {
+                variable.typeDefinition.typeSpecification.name.symbol.literal, context.typeRegistry()))) {
             return true;
         }
 
@@ -1333,7 +1333,7 @@ std::unique_ptr<IElement> drafter::ExpandRefract(std::unique_ptr<IElement> eleme
         return nullptr;
     }
 
-    ExpandVisitor expander(context.GetNamedTypesRegistry());
+    ExpandVisitor expander(context.typeRegistry());
     Visit(expander, *element);
 
     if (auto expanded = expander.get()) {

--- a/src/RefractSourceMap.cc
+++ b/src/RefractSourceMap.cc
@@ -39,7 +39,7 @@ std::unique_ptr<IElement> drafter::SourceMapToRefractWithColumnLineInfo(
         sourceMap.end(),
         std::back_inserter(sourceMapElement->get()),
         [&context](const mdp::CharactersRange& sourceMap) {
-            auto position = GetLineFromMap(context.GetNewLinesIndex(), sourceMap);
+            auto position = GetLineFromMap(context.newlineIndices(), sourceMap);
 
             auto location = make_element<NumberElement>(sourceMap.location);
             location->attributes().set("line", from_primitive(position.fromLine));

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -33,27 +33,11 @@ namespace snowcrash
 
 namespace drafter
 {
-
     enum SerializeFormat
     {
         JSONFormat = 0, // JSON Format
         YAMLFormat,     // YAML Format
         UnknownFormat = -1
-    };
-
-    // Options struct for drafter
-    struct WrapperOptions {
-        const bool generateSourceMap;
-        const bool expandMSON;
-
-        WrapperOptions(const bool generateSourceMap, const bool expandMSON)
-            : generateSourceMap(generateSourceMap), expandMSON(expandMSON)
-        {
-        }
-
-        WrapperOptions(const bool generateSourceMap) : generateSourceMap(generateSourceMap), expandMSON(false) {}
-
-        WrapperOptions() : generateSourceMap(false), expandMSON(false) {}
     };
 
     template <typename T>

--- a/src/SerializeResult.cc
+++ b/src/SerializeResult.cc
@@ -59,7 +59,7 @@ std::unique_ptr<IElement> drafter::WrapRefract(
             error = e;
         }
 
-        context.GetNamedTypesRegistry().clear();
+        context.typeRegistry().clear();
 
         if (error.code != snowcrash::Error::OK) {
             blueprint.report.error = error;
@@ -76,8 +76,8 @@ std::unique_ptr<IElement> drafter::WrapRefract(
 
     snowcrash::Warnings& warnings = blueprint.report.warnings;
 
-    if (!context.warnings.empty()) {
-        warnings.insert(warnings.end(), context.warnings.begin(), context.warnings.end());
+    if (!context.warnings().empty()) {
+        warnings.insert(warnings.end(), context.warnings().begin(), context.warnings().end());
     }
 
     if (!warnings.empty()) {

--- a/src/drafter.cc
+++ b/src/drafter.cc
@@ -18,9 +18,8 @@
 #include "refract/Iterate.h"
 #include "refract/SerializeSo.h"
 
-#include "SerializeResult.h"      // FIXME: remove - actualy required by WrapParseResultRefract()
-#include "Serialize.h"            // FIXME: remove - actualy required by WrapperOptions
-#include "ConversionContext.h"    // FIXME: remove - required by ConversionContext
+#include "SerializeResult.h" // FIXME: remove - actualy required by WrapParseResultRefract()
+#include "ConversionContext.h"
 #include "RefractDataStructure.h" // FIXME: remove - required by SerializeRefract()
 
 #if defined CMAKE_BUILD_TYPE
@@ -90,8 +89,7 @@ DRAFTER_API drafter_error drafter_parse_blueprint(
     sc::ParseResult<sc::Blueprint> blueprint;
     sc::parse(source, scOptions, blueprint);
 
-    drafter::WrapperOptions wrapperOptions;
-    drafter::ConversionContext context(source, wrapperOptions);
+    drafter::ConversionContext context(source);
     auto result = WrapRefract(blueprint, context);
 
     *out = result.release();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(drafter-test
     refract/test-JsonSchema.cc
     refract/test-JsonValue.cc
     refract/test-Utils.cc
+    draftertest.cc
     test-VisitorUtils.cc
     test-SyntaxIssuesTest.cc
     test-ApplyVisitorTest.cc

--- a/test/draftertest.cc
+++ b/test/draftertest.cc
@@ -1,0 +1,154 @@
+#include "draftertest.h"
+
+#include <catch2/catch.hpp>
+#include "dtl.hpp"
+
+#include "snowcrash.h"
+
+#include "RefractAPI.h"
+#include "RefractDataStructure.h"
+#include "ConversionContext.h"
+
+#include "stream.h"
+
+#include "refract/SerializeSo.h"
+#include "utils/log/Trivial.h"
+#include "utils/so/JsonIo.h"
+
+#include "Serialize.h"
+#include "SerializeResult.h"
+
+using namespace draftertest;
+
+namespace // copied over from header @tjanc
+{
+    namespace ext
+    {
+        const std::string apib = ".apib";
+        const std::string json = ".json";
+        const std::string sourceMapJson = ".sourcemap.json";
+    } // namespace ext
+
+    std::string normalizePath(std::string path)
+    {
+#ifdef WIN
+        std::string normalized = path;
+        std::transform(path.begin(), //
+            path.end(),              //
+            normalized.begin(),      //
+            [](const char& c) { return c == '/' ? '\\' : c; });
+        return normalized;
+#else
+        return path;
+#endif
+    }
+
+    class ITFixtureFiles
+    {
+
+        const std::string base_;
+
+    public:
+        ITFixtureFiles(const std::string& base) : base_(base) {}
+
+        typedef std::unique_ptr<std::istream> input_stream_type;
+
+        const std::string fetchContent(const std::string& filename) const
+        {
+
+            input_stream_type in(CreateStreamFromName<std::istream>(normalizePath(filename)));
+            std::stringstream strStream;
+            strStream << in->rdbuf();
+
+            return strStream.str();
+        }
+
+        const std::string get(const std::string& ext) const
+        {
+            return fetchContent(base_ + ext);
+        }
+
+        /// Set the contents of the fixture with the given file extension
+        void set(const std::string& extension, const std::string& content)
+        {
+            std::string filename = base_ + extension;
+            std::ofstream outputStream(normalizePath(filename).c_str());
+            outputStream << content;
+        }
+    };
+
+    const std::string printDiff(const std::string& actual, const std::string& expected)
+    {
+        // First, convert strings into arrays of lines.
+        std::vector<std::string> actualLines, expectedLines;
+
+        std::stringstream actualStream(actual.c_str());
+        std::stringstream expectedStream(expected.c_str());
+        std::stringstream output;
+        std::string buf;
+
+        while (getline(actualStream, buf)) {
+            actualLines.push_back(buf);
+        }
+
+        while (getline(expectedStream, buf)) {
+            expectedLines.push_back(buf);
+        }
+
+        // Now, diff the arrays of lines and save the output.
+        dtl::Diff<std::string> d(expectedLines, actualLines);
+        d.compose();
+        d.composeUnifiedHunks();
+        d.printUnifiedFormat(output);
+
+        return output.str();
+    }
+}
+
+bool draftertest::handleResultJSON(const std::string& fixturePath, test_options testOpts, bool mustBeOk)
+{
+    ENABLE_LOGGING;
+    ITFixtureFiles fixture = ITFixtureFiles(fixturePath);
+
+    snowcrash::ParseResult<snowcrash::Blueprint> blueprint;
+
+    const auto source = fixture.get(ext::apib);
+
+    int result = snowcrash::parse(source, snowcrash::ExportSourcemapOption, blueprint);
+
+    std::ostringstream outStream;
+    drafter::ConversionContext context(source.c_str(), testOpts.test(TEST_OPTION_EXPAND_MSON));
+
+    if (auto parsed = WrapRefract(blueprint, context)) {
+        auto soValue = refract::serialize::renderSo(*parsed, testOpts.test(TEST_OPTION_SOURCEMAPS));
+        drafter::utils::so::serialize_json(outStream, soValue);
+    }
+
+    outStream << "\n";
+
+    std::string actual = outStream.str();
+    std::string expected;
+    const std::string extension = testOpts.test(TEST_OPTION_SOURCEMAPS) ? ext::sourceMapJson : ext::json;
+
+    INFO("Filename: \x1b[35m" << fixturePath << extension << "\x1b[0m");
+    expected = fixture.get(extension);
+
+    if (actual != expected) {
+        const char* generate = std::getenv("GENERATE");
+
+        if (generate && std::string(generate) == "1") {
+            INFO("Updating incorrect fixture")
+            fixture.set(extension, actual);
+        } else {
+            // If the two don't match, then output the diff.
+            std::string diff = printDiff(actual, expected);
+            FAIL(diff);
+        }
+    }
+
+    if (mustBeOk) {
+        REQUIRE(result == snowcrash::Error::OK);
+    }
+
+    return actual == expected;
+}

--- a/test/draftertest.h
+++ b/test/draftertest.h
@@ -1,8 +1,12 @@
 #ifndef DRAFTER_DRAFTERTEST_H
 #define DRAFTER_DRAFTERTEST_H
 
+#include <bitset>
+
 #include <catch2/catch.hpp>
 #include "dtl.hpp"
+
+#include "snowcrash.h"
 
 #include "RefractAPI.h"
 #include "RefractDataStructure.h"
@@ -17,180 +21,36 @@
 #include "Serialize.h"
 #include "SerializeResult.h"
 
-static drafter::WrapperOptions MSONTestOptions(false, true);
+namespace draftertest
+{
+    constexpr std::size_t TEST_OPTION_EXPAND_MSON = 0;
+    constexpr std::size_t TEST_OPTION_SOURCEMAPS = 1;
+
+    using test_options = std::bitset<2>;
+
+    constexpr test_options MSONTestOptions = test_options(0b01);
+
+    bool handleResultJSON(const std::string& fixturePath, test_options testOpts, bool mustBeOk = false);
+}
 
 #define TEST_MSON(name, mustBeOk)                                                                                      \
     TEST_CASE("Testing MSON serialization for " name, "[refract][MSON][" name "]")                                     \
     {                                                                                                                  \
-        REQUIRE(FixtureHelper::handleResultJSON("test/fixtures/mson/" name, MSONTestOptions, mustBeOk));               \
+        REQUIRE(::draftertest::handleResultJSON("test/fixtures/mson/" name, MSONTestOptions, mustBeOk));               \
     }
 
 #define TEST_REFRACT(category, name)                                                                                   \
     TEST_CASE("Testing refract serialization for " category " " name, "[refract][" category "][" name "]")             \
     {                                                                                                                  \
-        FixtureHelper::handleResultJSON("test/fixtures/" category "/" name, drafter::WrapperOptions(false));           \
+        ::draftertest::handleResultJSON("test/fixtures/" category "/" name, test_options(0));                          \
     }
 
 #define TEST_REFRACT_SOURCE_MAP(category, name)                                                                        \
     TEST_CASE("Testing refract + source map serialization for " category " " name,                                     \
         "[refract_sourcemap][" category "][" name "]")                                                                 \
     {                                                                                                                  \
-        FixtureHelper::handleResultJSON("test/fixtures/" category "/" name, drafter::WrapperOptions(true));            \
+        ::draftertest::handleResultJSON(                                                                               \
+            "test/fixtures/" category "/" name, test_options(0).set(TEST_OPTION_SOURCEMAPS));                          \
     }
-
-namespace draftertest
-{
-    namespace ext
-    {
-        const std::string apib = ".apib";
-        const std::string json = ".json";
-        const std::string sourceMapJson = ".sourcemap.json";
-    } // namespace ext
-
-    class ITFixtureFiles
-    {
-
-        const std::string base_;
-
-#ifdef WIN
-        struct slashToBackslash {
-            char operator()(const char& c)
-            {
-                return c == '/' ? '\\' : c;
-            }
-        };
-#endif
-
-        std::string normalizePath(const std::string& path) const
-        {
-            std::string normalized = path;
-
-#ifdef WIN
-            std::transform(path.begin(), path.end(), normalized.begin(), slashToBackslash());
-#endif
-
-            return normalized;
-        }
-
-    public:
-        ITFixtureFiles(const std::string& base) : base_(base) {}
-
-        typedef std::unique_ptr<std::istream> input_stream_type;
-
-        const std::string fetchContent(const std::string& filename) const
-        {
-
-            input_stream_type in(CreateStreamFromName<std::istream>(normalizePath(filename)));
-            std::stringstream strStream;
-            strStream << in->rdbuf();
-
-            return strStream.str();
-        }
-
-        const std::string get(const std::string& ext) const
-        {
-            return fetchContent(base_ + ext);
-        }
-
-        /// Set the contents of the fixture with the given file extension
-        void set(const std::string& extension, const std::string& content)
-        {
-            std::string filename = base_ + extension;
-            std::ofstream outputStream(normalizePath(filename).c_str());
-            outputStream << content;
-        }
-    };
-
-    struct FixtureHelper {
-
-        static const std::string printDiff(const std::string& actual, const std::string& expected)
-        {
-            // First, convert strings into arrays of lines.
-            std::vector<std::string> actualLines, expectedLines;
-
-            std::stringstream actualStream(actual.c_str());
-            std::stringstream expectedStream(expected.c_str());
-            std::stringstream output;
-            std::string buf;
-
-            while (getline(actualStream, buf)) {
-                actualLines.push_back(buf);
-            }
-
-            while (getline(expectedStream, buf)) {
-                expectedLines.push_back(buf);
-            }
-
-            // Now, diff the arrays of lines and save the output.
-            dtl::Diff<std::string> d(expectedLines, actualLines);
-            d.compose();
-            d.composeUnifiedHunks();
-            d.printUnifiedFormat(output);
-
-            return output.str();
-        }
-
-        static std::string getFixtureExtension(const drafter::WrapperOptions& options)
-        {
-
-            if (options.generateSourceMap) {
-                return ext::sourceMapJson;
-            } else {
-                return ext::json;
-            }
-
-            return ext::json;
-        }
-
-        static bool handleResultJSON(
-            const std::string& fixturePath, const drafter::WrapperOptions& options, bool mustBeOk = false)
-        {
-            ENABLE_LOGGING;
-            ITFixtureFiles fixture = ITFixtureFiles(fixturePath);
-
-            snowcrash::ParseResult<snowcrash::Blueprint> blueprint;
-
-            const auto source = fixture.get(ext::apib);
-
-            int result = snowcrash::parse(source, snowcrash::ExportSourcemapOption, blueprint);
-
-            std::ostringstream outStream;
-            drafter::ConversionContext context(source.c_str(), options);
-
-            if (auto parsed = WrapRefract(blueprint, context)) {
-                auto soValue = refract::serialize::renderSo(*parsed, options.generateSourceMap);
-                drafter::utils::so::serialize_json(outStream, soValue);
-            }
-
-            outStream << "\n";
-
-            std::string actual = outStream.str();
-            std::string expected;
-            std::string extension = getFixtureExtension(options);
-
-            INFO("Filename: \x1b[35m" << fixturePath << extension << "\x1b[0m");
-            expected = fixture.get(extension);
-
-            if (actual != expected) {
-                const char* generate = std::getenv("GENERATE");
-
-                if (generate && std::string(generate) == "1") {
-                    INFO("Updating incorrect fixture")
-                    fixture.set(extension, actual);
-                } else {
-                    // If the two don't match, then output the diff.
-                    std::string diff = FixtureHelper::printDiff(actual, expected);
-                    FAIL(diff);
-                }
-            }
-
-            if (mustBeOk) {
-                REQUIRE(result == snowcrash::Error::OK);
-            }
-
-            return actual == expected;
-        }
-    };
-} // namespace draftertest
 
 #endif // #ifndef DRAFTER_DRAFTERTEST_H


### PR DESCRIPTION
Some basic refactoring of ConversionContext:
- removed wrapper options, a needless abstraction
- moved some implementations to source files
- shortened two FarTooMuchLong method names

Stumbled upon this while adding an option to omit generating assets.