### PR TITLE
C API to support output parameters `== NULL`

### DIFF
--- a/src/drafter.cc
+++ b/src/drafter.cc
@@ -45,12 +45,7 @@ DRAFTER_API drafter_error drafter_parse_blueprint_to(const char* source,
         return DRAFTER_EINVALID_INPUT;
     }
 
-    if (!out) {
-        return DRAFTER_EINVALID_OUTPUT;
-    }
-
     drafter_result* result = nullptr;
-    *out = nullptr;
 
     drafter_error ret = drafter_parse_blueprint(source, &result, parse_opts);
 
@@ -58,7 +53,8 @@ DRAFTER_API drafter_error drafter_parse_blueprint_to(const char* source,
         return ret;
     }
 
-    *out = drafter_serialize(result, serialize_opts);
+    if(out)
+        *out = drafter_serialize(result, serialize_opts);
 
     drafter_free_result(result);
 
@@ -76,10 +72,6 @@ DRAFTER_API drafter_error drafter_parse_blueprint(
         return DRAFTER_EINVALID_INPUT;
     }
 
-    if (!out) {
-        return DRAFTER_EINVALID_OUTPUT;
-    }
-
     sc::BlueprintParserOptions scOptions = sc::ExportSourcemapOption;
 
     if (drafter::is_name_required(parse_opts)) {
@@ -92,7 +84,8 @@ DRAFTER_API drafter_error drafter_parse_blueprint(
     drafter::ConversionContext context(source);
     auto result = WrapRefract(blueprint, context);
 
-    *out = result.release();
+    if(out)
+        *out = result.release();
 
     return (drafter_error)blueprint.report.error.code;
 }
@@ -136,7 +129,8 @@ DRAFTER_API drafter_error drafter_check_blueprint(
 
     drafter_result* result = nullptr;
 
-    drafter_error ret = drafter_parse_blueprint(source, &result, parse_opts);
+    drafter_error ret = res ? drafter_parse_blueprint(source, &result, parse_opts) :
+                              drafter_parse_blueprint(source, nullptr, parse_opts);
 
     if (!result) {
         return ret;

--- a/src/drafter.cc
+++ b/src/drafter.cc
@@ -53,8 +53,9 @@ DRAFTER_API drafter_error drafter_parse_blueprint_to(const char* source,
         return ret;
     }
 
-    if(out)
+    if (out) {
         *out = drafter_serialize(result, serialize_opts);
+    }
 
     drafter_free_result(result);
 
@@ -84,8 +85,9 @@ DRAFTER_API drafter_error drafter_parse_blueprint(
     drafter::ConversionContext context(source);
     auto result = WrapRefract(blueprint, context);
 
-    if(out)
+    if (out) {
         *out = result.release();
+    }
 
     return (drafter_error)blueprint.report.error.code;
 }

--- a/test/test-CAPI.c
+++ b/test/test-CAPI.c
@@ -113,6 +113,24 @@ int test_validation()
     return 0;
 }
 
+int test_validation_default()
+{
+    REQUIRE(DRAFTER_OK == drafter_check_blueprint(source, NULL, NULL));
+    return 0;
+}
+
+int test_blueprint_to_serialized_elements_default()
+{
+    REQUIRE(DRAFTER_OK == drafter_parse_blueprint_to(source, NULL, NULL, NULL));
+    return 0;
+}
+
+int test_blueprint_to_elements_default()
+{
+    REQUIRE(DRAFTER_OK == drafter_parse_blueprint(source, NULL, NULL));
+    return 0;
+}
+
 const char* source_without_name = "# GET /\n+ Response 204\n";
 const char* expected_without_name = "expected API name, e.g. '# <API Name>'";
 
@@ -147,5 +165,9 @@ int main()
     REQUIRE(test_version() == 0);
     REQUIRE(test_validation() == 0);
     REQUIRE(test_parse_to_string_requiring_name() == 0);
+    REQUIRE(test_validation_default() == 0);
+    REQUIRE(test_blueprint_to_serialized_elements_default() == 0);
+    REQUIRE(test_blueprint_to_elements_default() == 0);
+
     return 0;
 }


### PR DESCRIPTION
Some pointers passed to the drafter C API have the character of output parameters. 

If set to `NULL`, their assignment could be skipped - perhaps the user is only testing for success.

This also contributes to simpler [examples](https://github.com/apiaryio/drafter/blob/tjanc/capi-allow-null-result/test/test-CAPI.c#L116).