### PR TITLE
C API options to allow skipping message body (schema) generation

### DIFF
--- a/drafter.gyp
+++ b/drafter.gyp
@@ -499,6 +499,8 @@
       ],
       "sources": [
         "test/test-CAPI.c"
+        "test/ctesting.h"
+        "test/ctesting.c"
       ],
       "dependencies": [
         "libdrafter",

--- a/drafter.gyp
+++ b/drafter.gyp
@@ -498,8 +498,8 @@
         [ 'libdrafter_type=="static_library"', { 'defines' : [ 'DRAFTER_BUILD_STATIC' ] }],
       ],
       "sources": [
-        "test/test-CAPI.c"
-        "test/ctesting.h"
+        "test/test-CAPI.c",
+        "test/ctesting.h",
         "test/ctesting.c"
       ],
       "dependencies": [

--- a/src/ConversionContext.cc
+++ b/src/ConversionContext.cc
@@ -12,9 +12,10 @@
 
 using namespace drafter;
 
-ConversionContext::ConversionContext(const char* src, bool expandMson) noexcept
+ConversionContext::ConversionContext(const char* src, const drafter_parse_options* opts, bool expandMson) noexcept
     : newline_indices_(GetLinesEndIndex(src)),
       expand_mson_{ expandMson },
+      options_{ opts },
       registry_{},
       warnings_{}
 {
@@ -69,4 +70,9 @@ void ConversionContext::warn(const snowcrash::Warning& warning)
 const ConversionContext::Warnings& ConversionContext::warnings() const noexcept
 {
     return warnings_;
+}
+
+const drafter_parse_options* ConversionContext::options() const noexcept
+{
+    return options_;
 }

--- a/src/ConversionContext.h
+++ b/src/ConversionContext.h
@@ -12,6 +12,7 @@
 
 #include "refract/Registry.h"
 #include "SourceMapUtils.h"
+#include "options.h"
 
 namespace snowcrash
 {
@@ -28,12 +29,17 @@ namespace drafter
     private:
         const NewLinesIndex newline_indices_;
         const bool expand_mson_;
+        const drafter_parse_options* const options_;
 
         refract::Registry registry_;
         Warnings warnings_;
 
     public:
-        explicit ConversionContext(const char*, bool expandMson = false) noexcept;
+        explicit ConversionContext( //
+            const char*,
+            const drafter_parse_options* opts = nullptr,
+            bool expandMson = false // TODO avoid, only used in unit tests
+            ) noexcept;
 
         const NewLinesIndex& newlineIndices() const noexcept;
 
@@ -44,6 +50,8 @@ namespace drafter
 
         const Warnings& warnings() const noexcept;
         void warn(const snowcrash::Warning& warning);
+
+        const drafter_parse_options* options() const noexcept;
     };
 }
 #endif

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -400,7 +400,7 @@ std::unique_ptr<IElement> PayloadToRefract( //
             serialize(mediaType),
             &payload.sourceMap->body.sourceMap));
 
-    } else if (dataStructureExpanded && !is_omit_generated_values(context.options())) {
+    } else if (dataStructureExpanded && !is_skip_gen_bodies(context.options())) {
         // otherwise, generate one from attributes
         generateValueAsset(content, context, *dataStructureExpanded, mediaType);
     }
@@ -413,7 +413,7 @@ std::unique_ptr<IElement> PayloadToRefract( //
             serialize(IsAnyJSONContentType(mediaType) ? jsonSchemaType() : textPlainType()),
             &payload.sourceMap->schema.sourceMap));
 
-    } else if (dataStructureExpanded && !is_omit_generated_schemas(context.options())) {
+    } else if (dataStructureExpanded && !is_skip_gen_body_schemas(context.options())) {
         // otherwise, generate one from attributes
         generateSchemaAsset(content, context, *dataStructureExpanded, mediaType);
     }

--- a/src/RefractAPI.cc
+++ b/src/RefractAPI.cc
@@ -395,23 +395,25 @@ std::unique_ptr<IElement> PayloadToRefract( //
     // Push Body Asset
     if (!payload.node->body.empty()) {
         content.push_back(make_asset_element( //
-            payload.node->body,               //
-            SerializeKey::MessageBody,        //
-            serialize(mediaType),             //
+            payload.node->body,
+            SerializeKey::MessageBody,
+            serialize(mediaType),
             &payload.sourceMap->body.sourceMap));
-    } else if (dataStructureExpanded) {
+
+    } else if (dataStructureExpanded && !is_omit_generated_values(context.options())) {
         // otherwise, generate one from attributes
         generateValueAsset(content, context, *dataStructureExpanded, mediaType);
     }
 
     // Push Schema Asset
     if (!payload.node->schema.empty()) {
-        content.push_back(make_asset_element(                                                //
-            payload.node->schema,                                                            //
-            SerializeKey::MessageBodySchema,                                                 //
-            serialize(IsAnyJSONContentType(mediaType) ? jsonSchemaType() : textPlainType()), //
+        content.push_back(make_asset_element( //
+            payload.node->schema,
+            SerializeKey::MessageBodySchema,
+            serialize(IsAnyJSONContentType(mediaType) ? jsonSchemaType() : textPlainType()),
             &payload.sourceMap->schema.sourceMap));
-    } else if (dataStructureExpanded) {
+
+    } else if (dataStructureExpanded && !is_omit_generated_schemas(context.options())) {
         // otherwise, generate one from attributes
         generateSchemaAsset(content, context, *dataStructureExpanded, mediaType);
     }

--- a/src/drafter.cc
+++ b/src/drafter.cc
@@ -184,16 +184,16 @@ DRAFTER_API void drafter_set_name_required(drafter_parse_options* opts)
     opts->flags.set(drafter_parse_options::NAME_REQUIRED);
 }
 
-DRAFTER_API void set_omit_generated_values(drafter_parse_options* opts)
+DRAFTER_API void set_skip_gen_bodies(drafter_parse_options* opts)
 {
     assert(opts);
-    opts->flags.set(drafter_parse_options::OMIT_GENERATED_VALUES);
+    opts->flags.set(drafter_parse_options::SKIP_GEN_BODIES);
 }
 
-DRAFTER_API void set_omit_generated_schemas(drafter_parse_options* opts)
+DRAFTER_API void set_skip_gen_body_schemas(drafter_parse_options* opts)
 {
     assert(opts);
-    opts->flags.set(drafter_parse_options::OMIT_GENERATED_SCHEMAS);
+    opts->flags.set(drafter_parse_options::SKIP_GEN_BODY_SCHEMAS);
 }
 
 DRAFTER_API drafter_serialize_options* drafter_init_serialize_options()

--- a/src/drafter.cc
+++ b/src/drafter.cc
@@ -82,7 +82,7 @@ DRAFTER_API drafter_error drafter_parse_blueprint(
     sc::ParseResult<sc::Blueprint> blueprint;
     sc::parse(source, scOptions, blueprint);
 
-    drafter::ConversionContext context(source);
+    drafter::ConversionContext context(source, parse_opts);
     auto result = WrapRefract(blueprint, context);
 
     if (out) {
@@ -181,7 +181,19 @@ DRAFTER_API void drafter_free_parse_options(drafter_parse_options* opts)
 DRAFTER_API void drafter_set_name_required(drafter_parse_options* opts)
 {
     assert(opts);
-    opts->requireBlueprintName = true;
+    opts->flags.set(drafter_parse_options::NAME_REQUIRED);
+}
+
+DRAFTER_API void set_omit_generated_values(drafter_parse_options* opts)
+{
+    assert(opts);
+    opts->flags.set(drafter_parse_options::OMIT_GENERATED_VALUES);
+}
+
+DRAFTER_API void set_omit_generated_schemas(drafter_parse_options* opts)
+{
+    assert(opts);
+    opts->flags.set(drafter_parse_options::OMIT_GENERATED_SCHEMAS);
 }
 
 DRAFTER_API drafter_serialize_options* drafter_init_serialize_options()
@@ -197,7 +209,7 @@ DRAFTER_API void drafter_free_serialize_options(drafter_serialize_options* opts)
 DRAFTER_API void drafter_set_sourcemaps_included(drafter_serialize_options* opts)
 {
     assert(opts);
-    opts->sourcemap = true;
+    opts->flags.set(drafter_serialize_options::SOURCEMAPS_INCLUDED);
 }
 
 DRAFTER_API void drafter_set_format(drafter_serialize_options* opts, drafter_format fmt)

--- a/src/drafter.cc
+++ b/src/drafter.cc
@@ -184,13 +184,13 @@ DRAFTER_API void drafter_set_name_required(drafter_parse_options* opts)
     opts->flags.set(drafter_parse_options::NAME_REQUIRED);
 }
 
-DRAFTER_API void set_skip_gen_bodies(drafter_parse_options* opts)
+DRAFTER_API void drafter_set_skip_gen_bodies(drafter_parse_options* opts)
 {
     assert(opts);
     opts->flags.set(drafter_parse_options::SKIP_GEN_BODIES);
 }
 
-DRAFTER_API void set_skip_gen_body_schemas(drafter_parse_options* opts)
+DRAFTER_API void drafter_set_skip_gen_body_schemas(drafter_parse_options* opts)
 {
     assert(opts);
     opts->flags.set(drafter_parse_options::SKIP_GEN_BODY_SCHEMAS);

--- a/src/drafter.h
+++ b/src/drafter.h
@@ -68,6 +68,18 @@ DRAFTER_API void drafter_free_parse_options(drafter_parse_options*);
  */
 DRAFTER_API void drafter_set_name_required(drafter_parse_options*);
 
+/* Access omit_generated_values option
+ *   @remark omit_generated_values: do not attempt generating payloads where
+ *     none are provided
+ */
+DRAFTER_API void set_omit_generated_values(drafter_parse_options*);
+
+/* Access omit_generated_schemas option
+ *   @remark omit_generated_schemas: do not attempt generating payload
+ *     schemas where none are provided
+ */
+DRAFTER_API void set_omit_generated_schemas(drafter_parse_options*);
+
 /* Serialisation options
  */
 typedef struct drafter_serialize_options drafter_serialize_options;

--- a/src/drafter.h
+++ b/src/drafter.h
@@ -71,12 +71,12 @@ DRAFTER_API void drafter_set_name_required(drafter_parse_options*);
 /* Set skip_gen_bodies option
  *   @remark skip_gen_bodies: skip generating message body payloads
  */
-DRAFTER_API void set_skip_gen_bodies(drafter_parse_options*);
+DRAFTER_API void drafter_set_skip_gen_bodies(drafter_parse_options*);
 
 /* Set skip_gen_body_schemas option
  *   @remark skip_gen_body_schemas: skip generating message body schema payloads
  */
-DRAFTER_API void set_skip_gen_body_schemas(drafter_parse_options*);
+DRAFTER_API void drafter_set_skip_gen_body_schemas(drafter_parse_options*);
 
 /* Serialisation options
  */

--- a/src/drafter.h
+++ b/src/drafter.h
@@ -68,17 +68,15 @@ DRAFTER_API void drafter_free_parse_options(drafter_parse_options*);
  */
 DRAFTER_API void drafter_set_name_required(drafter_parse_options*);
 
-/* Access omit_generated_values option
- *   @remark omit_generated_values: do not attempt generating payloads where
- *     none are provided
+/* Set skip_gen_bodies option
+ *   @remark skip_gen_bodies: skip generating message body payloads
  */
-DRAFTER_API void set_omit_generated_values(drafter_parse_options*);
+DRAFTER_API void set_skip_gen_bodies(drafter_parse_options*);
 
-/* Access omit_generated_schemas option
- *   @remark omit_generated_schemas: do not attempt generating payload
- *     schemas where none are provided
+/* Set skip_gen_body_schemas option
+ *   @remark skip_gen_body_schemas: skip generating message body schema payloads
  */
-DRAFTER_API void set_omit_generated_schemas(drafter_parse_options*);
+DRAFTER_API void set_skip_gen_body_schemas(drafter_parse_options*);
 
 /* Serialisation options
  */

--- a/src/options.cc
+++ b/src/options.cc
@@ -9,15 +9,25 @@
 
 bool drafter::is_name_required(const drafter_parse_options* opts) noexcept
 {
-    return opts && opts->requireBlueprintName;
+    return opts && opts->flags.test(drafter_parse_options::NAME_REQUIRED);
 }
 
 bool drafter::are_sourcemaps_included(const drafter_serialize_options* opts) noexcept
 {
-    return opts && opts->sourcemap;
+    return opts && opts->flags.test(drafter_serialize_options::SOURCEMAPS_INCLUDED);
 }
 
 drafter_format drafter::get_format(const drafter_serialize_options* opts) noexcept
 {
     return opts ? opts->format : DRAFTER_SERIALIZE_YAML;
+}
+
+bool drafter::is_omit_generated_values(const drafter_parse_options* opts) noexcept
+{
+    return opts && opts->flags.test(drafter_parse_options::OMIT_GENERATED_VALUES);
+}
+
+bool drafter::is_omit_generated_schemas(const drafter_parse_options* opts) noexcept
+{
+    return opts && opts->flags.test(drafter_parse_options::OMIT_GENERATED_SCHEMAS);
 }

--- a/src/options.cc
+++ b/src/options.cc
@@ -22,12 +22,12 @@ drafter_format drafter::get_format(const drafter_serialize_options* opts) noexce
     return opts ? opts->format : DRAFTER_SERIALIZE_YAML;
 }
 
-bool drafter::is_omit_generated_values(const drafter_parse_options* opts) noexcept
+bool drafter::is_skip_gen_bodies(const drafter_parse_options* opts) noexcept
 {
-    return opts && opts->flags.test(drafter_parse_options::OMIT_GENERATED_VALUES);
+    return opts && opts->flags.test(drafter_parse_options::SKIP_GEN_BODIES);
 }
 
-bool drafter::is_omit_generated_schemas(const drafter_parse_options* opts) noexcept
+bool drafter::is_skip_gen_body_schemas(const drafter_parse_options* opts) noexcept
 {
-    return opts && opts->flags.test(drafter_parse_options::OMIT_GENERATED_SCHEMAS);
+    return opts && opts->flags.test(drafter_parse_options::SKIP_GEN_BODY_SCHEMAS);
 }

--- a/src/options.h
+++ b/src/options.h
@@ -17,8 +17,8 @@ struct drafter_parse_options {
     using flags_type = std::bitset<3>;
 
     static constexpr std::size_t NAME_REQUIRED = 0;
-    static constexpr std::size_t OMIT_GENERATED_VALUES = 1;
-    static constexpr std::size_t OMIT_GENERATED_SCHEMAS = 2;
+    static constexpr std::size_t SKIP_GEN_BODIES = 1;
+    static constexpr std::size_t SKIP_GEN_BODY_SCHEMAS = 2;
 
     flags_type flags = 0;
 };
@@ -44,17 +44,15 @@ namespace drafter
      */
     bool are_sourcemaps_included(const drafter_serialize_options*) noexcept;
 
-    /* Access omit_generated_values option
-     *   @remark omit_generated_values: do not attempt generating payloads where
-     *     none are provided
+    /* Access skip_gen_bodies option
+     *   @remark skip_gen_bodies: skip generating message body payloads
      */
-    bool is_omit_generated_values(const drafter_parse_options*) noexcept;
+    bool is_skip_gen_bodies(const drafter_parse_options*) noexcept;
 
-    /* Access omit_generated_schemas option
-     *   @remark omit_generated_schemas: do not attempt generating payload
-     *     schemas where none are provided
+    /* Access skip_gen_body_schemas option
+     *   @remark skip_gen_body_schemas: skip generating message body schema payloads
      */
-    bool is_omit_generated_schemas(const drafter_parse_options*) noexcept;
+    bool is_skip_gen_body_schemas(const drafter_parse_options*) noexcept;
 
     /* Access format option
      *   @remark format: API Elements serialisation format (YAML|JSON)

--- a/src/options.h
+++ b/src/options.h
@@ -11,12 +11,24 @@
 
 #include "drafter.h"
 
+#include <bitset>
+
 struct drafter_parse_options {
-    bool requireBlueprintName = false;
+    using flags_type = std::bitset<3>;
+
+    static constexpr std::size_t NAME_REQUIRED = 0;
+    static constexpr std::size_t OMIT_GENERATED_VALUES = 1;
+    static constexpr std::size_t OMIT_GENERATED_SCHEMAS = 2;
+
+    flags_type flags = 0;
 };
 
 struct drafter_serialize_options {
-    bool sourcemap = false;
+    using flags_type = std::bitset<1>;
+
+    static constexpr std::size_t SOURCEMAPS_INCLUDED = 0;
+
+    flags_type flags = 0;
     drafter_format format = DRAFTER_SERIALIZE_YAML;
 };
 
@@ -31,6 +43,18 @@ namespace drafter
      *   @remark sourcemaps_included: source maps are not filtered from non-Annotations
      */
     bool are_sourcemaps_included(const drafter_serialize_options*) noexcept;
+
+    /* Access omit_generated_values option
+     *   @remark omit_generated_values: do not attempt generating payloads where
+     *     none are provided
+     */
+    bool is_omit_generated_values(const drafter_parse_options*) noexcept;
+
+    /* Access omit_generated_schemas option
+     *   @remark omit_generated_schemas: do not attempt generating payload
+     *     schemas where none are provided
+     */
+    bool is_omit_generated_schemas(const drafter_parse_options*) noexcept;
 
     /* Access format option
      *   @remark format: API Elements serialisation format (YAML|JSON)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,6 +76,7 @@ file(
 
 add_executable(drafter-ctest
     test-CAPI.c
+    ctesting.c
     )
 
 target_link_libraries(drafter-ctest

--- a/test/ctesting.c
+++ b/test/ctesting.c
@@ -3,16 +3,6 @@
 #include <string.h>
 #include <stdio.h>
 
-size_t strlen_until_nl(const char* str)
-{
-
-    size_t i = 0;
-    for (; str[i] != 0 && str[i] != '\n'; ++i)
-        ;
-
-    return i;
-}
-
 void drafter_ctest_fail(const char* expr, const char* file, size_t line)
 {
     fprintf(stderr, "Assertion `%s` failed at %s:%d\n", expr, file, line);

--- a/test/ctesting.c
+++ b/test/ctesting.c
@@ -1,0 +1,65 @@
+#include "ctesting.h"
+
+#include <string.h>
+#include <stdio.h>
+
+size_t strlen_until_nl(const char* str)
+{
+
+    size_t i = 0;
+    for (; str[i] != 0 && str[i] != '\n'; ++i)
+        ;
+
+    return i;
+}
+
+void drafter_ctest_fail(const char* expr, const char* file, size_t line)
+{
+    fprintf(stderr, "Assertion `%s` failed at %s:%d\n", expr, file, line);
+    abort();
+}
+
+void drafter_ctest_assert(int a, const char* expr, const char* file, size_t line)
+{
+    if (!a)
+        drafter_ctest_fail(expr, file, line);
+}
+
+void drafter_ctest_includes(const char* searched, const char* actual, const char* file, size_t line)
+{
+    const char* where = strstr(actual, searched);
+    if (!where) {
+        fprintf( //
+            stderr,
+            "Didn't find sub string\n"
+            "\x1b[32m%s\x1b[0m\n"
+            "in\n"
+            "\x1b[31m%s\x1b[0m\n",
+            searched,
+            actual);
+        drafter_ctest_fail("expected sub string not found", file, line);
+    }
+}
+
+void drafter_ctest_excludes(const char* searched, const char* actual, const char* file, size_t line)
+{
+    const char* where = strstr(actual, searched);
+    if (where) {
+        while (where != actual) {
+            if (where[0] == '\n') {
+                ++where;
+                break;
+            }
+            --where;
+        }
+        fprintf( //
+            stderr,
+            "Found prohibited sub string\n"
+            "\x1b[32m%s\x1b[0m\n"
+            "at\n"
+            "\x1b[31m%s\x1b[0m\n",
+            searched,
+            where);
+        drafter_ctest_fail("prohibited sub string found", file, line);
+    }
+}

--- a/test/ctesting.h
+++ b/test/ctesting.h
@@ -1,0 +1,18 @@
+#ifndef DRAFTER_CTESTING_H
+#define DRAFTER_CTESTING_H
+
+#include <stdlib.h>
+
+#define FAIL(expr) drafter_ctest_fail(#expr, __FILE__, __LINE__)
+void drafter_ctest_fail(const char* expr, const char* file, size_t line);
+
+#define REQUIRE(expr) drafter_ctest_assert(expr != 0, #expr, __FILE__, __LINE__)
+void drafter_ctest_assert(int a, const char* expr, const char* file, size_t line);
+
+#define REQUIRE_INCLUDES(searched, actual) drafter_ctest_includes(searched, actual, __FILE__, __LINE__)
+void drafter_ctest_includes(const char* expected, const char* actual, const char* file, size_t line);
+
+#define REQUIRE_EXCLUDES(searched, actual) drafter_ctest_excludes(searched, actual, __FILE__, __LINE__)
+void drafter_ctest_excludes(const char* expected, const char* actual, const char* file, size_t line);
+
+#endif

--- a/test/draftertest.cc
+++ b/test/draftertest.cc
@@ -117,7 +117,7 @@ bool draftertest::handleResultJSON(const std::string& fixturePath, test_options 
     int result = snowcrash::parse(source, snowcrash::ExportSourcemapOption, blueprint);
 
     std::ostringstream outStream;
-    drafter::ConversionContext context(source.c_str(), testOpts.test(TEST_OPTION_EXPAND_MSON));
+    drafter::ConversionContext context(source.c_str(), nullptr, testOpts.test(TEST_OPTION_EXPAND_MSON));
 
     if (auto parsed = WrapRefract(blueprint, context)) {
         auto soValue = refract::serialize::renderSo(*parsed, testOpts.test(TEST_OPTION_SOURCEMAPS));


### PR DESCRIPTION
Builds on tjanc/refactor-payloads-2 to implement skipping asset generation as laid out in https://github.com/apiaryio/api-elements.js/pull/281 .

In more detail, two options are added to `drafter_parse_options` and the drafter C API:
 - `skip_gen_bodies` [bool, default: false], when set, skips generating message body assets
 - `skip_gen_body_schemas` [bool, default: false], when set, skips generating message body schema assets

Simple tests were added. Some test logic was moved into a seperate compilation unit `test/ctesting.cc`.

### Not in scope of this PR
- wiring the new options into drafter CLI