### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Drafter Changelog
 
+## 5.0.0 (2020-04-20)
+
+### Enhancements
+
+* Drafter contains two new options for disabling messageBody and
+  messageBodySchema generation from MSON. See the APIs `skip_gen_bodies` and
+  `skip_gen_body_schemas` respectively.
+
 ## 5.0.0-rc.1 (2020-03-16)
 
 ### Breaking

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 project(Drafter VERSION 5.0.0 LANGUAGES CXX)
 
-set(DRAFTER_VERSION_IS_RELEASE 0)
-set(DRAFTER_PRE_RELEASE_VERSION rc.1)
+set(DRAFTER_VERSION_IS_RELEASE 1)
 
 configure_file(Version.h.in Version.h)
 include_directories(${PROJECT_BINARY_BIN})


### PR DESCRIPTION
### Enhancements

* Drafter contains two new options for disabling messageBody and messageBodySchema generation from MSON. See the APIs `skip_gen_bodies` and `skip_gen_body_schemas` respectively.