### PR TITLE
Optimise JSON Schemas generated for fixed-type arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Drafter Changelog
 
+## TBD
+
+### Enhancements
+
+- JSON Schemas generated for `fixed-type` arrays with a single sub-type will
+  no longer be wrapped in an `anyOf` schema. Thus `array[Object]` as
+  `fixed-type` will now result in the following schema:
+
+  ```json
+  {
+    "type": "array",
+    "items": { "type": "object" }
+  }
+  ```
+
 ## 5.0.0 (2020-04-20)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
   }
   ```
 
+### Bug Fixes
+
+- JSON Schemas generated for `fixed-type` arrays with no types will no longer
+  produce an empty `anyOf` subschema.
+  [`anyOf`](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.2.1.2)
+  must be a non-empty array in JSON Schema.
+
 ## 5.0.0 (2020-04-20)
 
 ### Enhancements

--- a/packages/drafter/src/refract/JsonSchema.cc
+++ b/packages/drafter/src/refract/JsonSchema.cc
@@ -114,6 +114,12 @@ namespace
         return schema;
     }
 
+    so::Object& addMaxItems(so::Object& schema, size_t maxItems)
+    {
+        schema.data.emplace_back("maxItems", so::Number { maxItems });
+        return schema;
+    }
+
     so::Object& addProperties(so::Object& schema, so::Object value)
     {
         schema.data.emplace_back("properties", std::move(value));
@@ -432,8 +438,7 @@ namespace
             addType(schema, TYPE_NAME);
 
             if (e.empty()) {
-                so::Array items{};
-                addItems(schema, so::Object{ so::from_list{}, std::make_pair("anyOf", std::move(items)) });
+                addMaxItems(schema, 0);
             } else if (e.get().size() == 1) {
                 const auto& entry = *e.get().begin();
                 so::Object items = makeSchema(*entry, inheritOrPassFlags(options, *entry));

--- a/packages/drafter/test/fixtures/mson/fixed-type-array-primitive-nested.json
+++ b/packages/drafter/test/fixtures/mson/fixed-type-array-primitive-nested.json
@@ -177,7 +177,7 @@
                                   "content": "application/schema+json"
                                 }
                               },
-                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"s\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"anyOf\": [\n          {\n            \"type\": \"string\"\n          }\n        ]\n      }\n    }\n  }\n}"
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"s\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"type\": \"string\"\n      }\n    }\n  }\n}"
                             }
                           ]
                         }

--- a/packages/drafter/test/fixtures/schema/array-fixed-type-attributes.json
+++ b/packages/drafter/test/fixtures/schema/array-fixed-type-attributes.json
@@ -202,7 +202,7 @@
                                   "content": "application/schema+json"
                                 }
                               },
-                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"array\",\n  \"items\": {\n    \"anyOf\": [\n      {\n        \"type\": \"object\",\n        \"properties\": {\n          \"msg\": {\n            \"type\": \"string\"\n          },\n          \"id\": {\n            \"type\": \"number\"\n          }\n        },\n        \"required\": [\n          \"msg\"\n        ]\n      }\n    ]\n  }\n}"
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"array\",\n  \"items\": {\n    \"type\": \"object\",\n    \"properties\": {\n      \"msg\": {\n        \"type\": \"string\"\n      },\n      \"id\": {\n        \"type\": \"number\"\n      }\n    },\n    \"required\": [\n      \"msg\"\n    ]\n  }\n}"
                             }
                           ]
                         }

--- a/packages/drafter/test/fixtures/schema/array-fixed-type-object.json
+++ b/packages/drafter/test/fixtures/schema/array-fixed-type-object.json
@@ -255,7 +255,7 @@
                                   "content": "application/schema+json"
                                 }
                               },
-                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"number\"\n    },\n    \"name\": {\n      \"type\": \"string\"\n    },\n    \"medias\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"anyOf\": [\n          {\n            \"type\": \"object\",\n            \"properties\": {\n              \"mediaId\": {\n                \"type\": \"number\"\n              },\n              \"name\": {\n                \"type\": \"string\"\n              }\n            },\n            \"required\": [\n              \"mediaId\",\n              \"name\"\n            ]\n          }\n        ]\n      }\n    }\n  },\n  \"required\": [\n    \"name\"\n  ]\n}"
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"id\": {\n      \"type\": \"number\"\n    },\n    \"name\": {\n      \"type\": \"string\"\n    },\n    \"medias\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"mediaId\": {\n            \"type\": \"number\"\n          },\n          \"name\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"mediaId\",\n          \"name\"\n        ]\n      }\n    }\n  },\n  \"required\": [\n    \"name\"\n  ]\n}"
                             }
                           ]
                         }

--- a/packages/drafter/test/fixtures/schema/issue-493-multiple-same-required.json
+++ b/packages/drafter/test/fixtures/schema/issue-493-multiple-same-required.json
@@ -240,7 +240,7 @@
                                   "content": "application/schema+json"
                                 }
                               },
-                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"data\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"anyOf\": [\n          {\n            \"type\": \"object\",\n            \"properties\": {\n              \"field\": {\n                \"type\": \"string\"\n              }\n            },\n            \"required\": [\n              \"field\"\n            ]\n          }\n        ]\n      }\n    }\n  },\n  \"required\": [\n    \"data\"\n  ]\n}"
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"data\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"field\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"field\"\n        ]\n      }\n    }\n  },\n  \"required\": [\n    \"data\"\n  ]\n}"
                             }
                           ]
                         }

--- a/packages/drafter/test/fixtures/schema/variable-property-fixed-type.json
+++ b/packages/drafter/test/fixtures/schema/variable-property-fixed-type.json
@@ -206,7 +206,7 @@
                                   "content": "application/schema+json"
                                 }
                               },
-                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"object\",\n  \"patternProperties\": {\n    \"(?:)\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"anyOf\": [\n          {\n            \"type\": \"object\",\n            \"properties\": {\n              \"name\": {\n                \"type\": \"string\"\n              }\n            },\n            \"required\": [\n              \"name\"\n            ]\n          }\n        ]\n      }\n    }\n  }\n}"
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"object\",\n  \"patternProperties\": {\n    \"(?:)\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"name\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"name\"\n        ]\n      }\n    }\n  }\n}"
                             }
                           ]
                         }

--- a/packages/drafter/test/fixtures/schema/variable-property-fixed-type2.json
+++ b/packages/drafter/test/fixtures/schema/variable-property-fixed-type2.json
@@ -218,7 +218,7 @@
                                   "content": "application/schema+json"
                                 }
                               },
-                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"test\": {\n      \"type\": \"string\"\n    }\n  },\n  \"patternProperties\": {\n    \"(?:)\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"anyOf\": [\n          {\n            \"type\": \"object\",\n            \"properties\": {\n              \"name\": {\n                \"type\": \"string\"\n              }\n            },\n            \"required\": [\n              \"name\"\n            ]\n          }\n        ]\n      }\n    }\n  }\n}"
+                              "content": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"test\": {\n      \"type\": \"string\"\n    }\n  },\n  \"patternProperties\": {\n    \"(?:)\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"name\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"name\"\n        ]\n      }\n    }\n  }\n}"
                             }
                           ]
                         }

--- a/packages/drafter/test/refract/test-JsonSchema.cc
+++ b/packages/drafter/test/refract/test-JsonSchema.cc
@@ -302,7 +302,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
 
             THEN("the schema matches an empty array")
             {
-                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-07/schema#","type":"array","items":{"anyOf":[]}})");
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-07/schema#","type":"array","maxItems":0})");
             }
         }
     }

--- a/packages/drafter/test/refract/test-JsonSchema.cc
+++ b/packages/drafter/test/refract/test-JsonSchema.cc
@@ -349,7 +349,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
 
             THEN("the schema matches arrays of strings")
             {
-                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-07/schema#","type":"array","items":{"anyOf":[{"type":"string"}]}})");
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-07/schema#","type":"array","items":{"type":"string"}})");
             }
         }
     }
@@ -396,7 +396,7 @@ SCENARIO("JSON Schema serialization of ArrayElement", "[json-schema]")
 
             THEN("the schema matches arrays of strings")
             {
-                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-07/schema#","type":"array","items":{"anyOf":[{"type":"string"}]}})");
+                REQUIRE(to_string(result) == R"({"$schema":"http://json-schema.org/draft-07/schema#","type":"array","items":{"type":"string"}})");
             }
         }
     }


### PR DESCRIPTION
This changeset optimises the generation of JSON Schema of fixed-type array's with a single element inside them to be placed directly inside "items", instead of inside an "anyOf" inside "items". A user was asking about this behaviour in https://github.com/apiaryio/api-blueprint/issues/450.

In terms of JSON Schema validation these behave the same, the new behaviour produces a smaller, clearer JSON Schema.

While doing so, I noticed that Drafter would produce an invalid schema in the case where there is an empty fixed-type array. Drafter would emit a sub-schema such as `{"anyOf": []}` which breaks the clause in [JSON Schema 2019-09 Section 9.2.1.2](https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.2.1.2):

> This keyword's value MUST be a non-empty array.

Instead Drafter will now emit a schema with `maxItems` set to 0 to indicate the array must be empty. This matches the intended behaviour from Drafter test specification:

> Given: An empty ArrayElement with fixedType attribute true
> When: a JSON Schema is generated from it
> Then: the schema matches an empty array

These two changes are separated into different commits thus I recommend reviewing per-commit.

Closes https://github.com/apiaryio/api-blueprint/issues/450
Closes https://github.com/apiaryio/drafter/issues/694