### PR TITLE
Remove empty source file

### DIFF
--- a/drafter.gyp
+++ b/drafter.gyp
@@ -291,7 +291,6 @@
         "packages/drafter/src/MsonTypeSectionToApie.h",
         "packages/drafter/src/MsonTypeSectionToApie.cc",
         "packages/drafter/src/MsonMemberToApie.h",
-        "packages/drafter/src/MsonMemberToApie.cc",
         "packages/drafter/src/MsonOneOfSectionToApie.h",
         "packages/drafter/src/MsonOneOfSectionToApie.cc",
         "packages/drafter/src/RefractDataStructure.h",

--- a/packages/drafter/CMakeLists.txt
+++ b/packages/drafter/CMakeLists.txt
@@ -10,7 +10,6 @@ include_directories(${PROJECT_BINARY_BIN})
 
 set(DRAFTER_SOURCES
     src/ConversionContext.cc
-    src/MsonMemberToApie.cc
     src/MsonOneOfSectionToApie.cc
     src/MsonTypeSectionToApie.cc
     src/NamedTypesRegistry.cc

--- a/packages/drafter/src/MsonMemberToApie.cc
+++ b/packages/drafter/src/MsonMemberToApie.cc
@@ -1,9 +1,0 @@
-//
-//  MsonMemberToApie.cc
-//  drafter
-//
-//  Created by Thomas Jandecka on 12/07/19.
-//  Copyright (c) 2019 Apiary Inc. All rights reserved.
-//
-
-#include "MsonMemberToApie.h"


### PR DESCRIPTION
The file `MsonMemberToApie.cc` is effectively empty, containing no symbols and which emits compilation warning.

Closes #740